### PR TITLE
Added VM actions

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -22,10 +22,22 @@ func (n *Node) Version() (version *Version, err error) {
 }
 
 func (n *Node) VirtualMachines() (vms VirtualMachines, err error) {
-	return vms, n.client.Get(fmt.Sprintf("/nodes/%s/qemu", n.Name), &vms)
+	if err := n.client.Get(fmt.Sprintf("/nodes/%s/qemu", n.Name), &vms); err != nil {
+		return nil, err
+	}
+
+	for _, v := range vms {
+		v.client = n.client
+		v.Node = n.Name
+	}
+
+	return vms, nil
 }
 
 func (n *Node) VirtualMachine(vmid int) (vm *VirtualMachine, err error) {
+	vm.client = n.client
+	vm.Node = n.Name
+
 	return vm, n.client.Get(fmt.Sprintf("/nodes/%s/qemu/%d/status/current", n.Name, vmid), &vm)
 }
 

--- a/types.go
+++ b/types.go
@@ -68,8 +68,10 @@ func (it *IsTemplate) UnmarshalJSON(b []byte) error {
 type VirtualMachines []*VirtualMachine
 type VirtualMachine struct {
 	Name      string
+	Node      string
 	NetIn     uint64
 	CPUs      int
+	client    *Client
 	DiskWrite uint64
 	Status    string
 	VMID      string
@@ -84,6 +86,11 @@ type VirtualMachine struct {
 	DiskRead  uint64
 	Template  IsTemplate // empty str if a vm, int 1 if a template
 	HA        HA         `json:",omitempty"`
+}
+
+type VirtualMachineStatuses []*VirtualMachineStatus
+type VirtualMachineStatus struct {
+	Data string `json:",omitempty"`
 }
 
 type HA struct {

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -1,1 +1,25 @@
+// +build vms
+
 package proxmox
+
+import "fmt"
+
+func (v *VirtualMachine) Start() (status string, err error) {
+	return status, v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%s/status/start", v.Node, v.VMID), nil, &status)
+}
+
+func (v *VirtualMachine) Stop() (status *VirtualMachineStatus, err error) {
+	return status, v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%s/status/stop", v.Node, v.VMID), nil, &status)
+}
+
+func (v *VirtualMachine) Suspend() (status *VirtualMachineStatus, err error) {
+	return status, v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%s/status/suspend", v.Node, v.VMID), nil, &status)
+}
+
+func (v *VirtualMachine) Reboot() (status *VirtualMachineStatus, err error) {
+	return status, v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%s/status/reboot", v.Node, v.VMID), nil, &status)
+}
+
+func (v *VirtualMachine) Resume() (status *VirtualMachineStatus, err error) {
+	return status, v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%s/status/resume", v.Node, v.VMID), nil, &status)
+}

--- a/virtual_machines_test.go
+++ b/virtual_machines_test.go
@@ -1,3 +1,128 @@
 // +build vms
 
 package proxmox
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var (
+	testVirtualMachineID   = 0
+)
+
+func TestVMStart(t *testing.T) {
+	if testVirtualMachineID == 0 || td.nodeName == "" {
+		t.Skip()
+	}
+	client := ClientFromLogins()
+	node, err := client.Node(td.nodeName)
+	require.NoError(t, err)
+
+	vm, err := node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+
+	if vm.Status != "stopped" {
+		_, err = vm.Stop()
+		require.NoError(t, err)
+		vm, err = node.VirtualMachine(testVirtualMachineID)
+		require.NoError(t, err)
+		require.Equal(t, "stopped", vm.Status)
+	}
+
+	_, err = vm.Start()
+	assert.NoError(t, err)
+
+	vm, err = node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+	assert.Equal(t, "running", vm.Status)
+}
+
+func TestVMStop(t *testing.T) {
+	if testVirtualMachineID == 0 || td.nodeName == "" {
+		t.Skip()
+	}
+	client := ClientFromLogins()
+	node, err := client.Node(td.nodeName)
+	require.NoError(t, err)
+
+	vm, err := node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+
+	if vm.Status != "running" {
+		_, err = vm.Start()
+		require.NoError(t, err)
+		vm, err = node.VirtualMachine(testVirtualMachineID)
+		require.NoError(t, err)
+		require.Equal(t, "running", vm.Status)
+	}
+
+	_, err = vm.Stop()
+	assert.NoError(t, err)
+
+	vm, err = node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+	assert.Equal(t, "stopped", vm.Status)
+}
+
+func TestVMReboot(t *testing.T) {
+	if testVirtualMachineID == 0 || td.nodeName == "" {
+		t.Skip()
+	}
+	client := ClientFromLogins()
+	node, err := client.Node(td.nodeName)
+	require.NoError(t, err)
+
+	vm, err := node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+
+	if vm.Status != "running" {
+		_, err = vm.Start()
+		require.NoError(t, err)
+		vm, err = node.VirtualMachine(testVirtualMachineID)
+		require.NoError(t, err)
+		require.Equal(t, "running", vm.Status)
+	}
+
+	_, err = vm.Reboot()
+	assert.NoError(t, err)
+
+	vm, err = node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+	assert.Equal(t, "running", vm.Status)
+}
+
+func TestVMSuspendAndResume(t *testing.T) {
+	if testVirtualMachineID == 0 || td.nodeName == "" {
+		t.Skip()
+	}
+	client := ClientFromLogins()
+	node, err := client.Node(td.nodeName)
+	require.NoError(t, err)
+
+	vm, err := node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+
+	if vm.Status != "running" {
+		_, err = vm.Start()
+		require.NoError(t, err)
+		vm, err = node.VirtualMachine(testVirtualMachineID)
+		require.NoError(t, err)
+		require.Equal(t, "running", vm.Status)
+	}
+
+	_, err = vm.Suspend()
+	assert.NoError(t, err)
+
+	vm, err = node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+	assert.Equal(t, "suspended", vm.Status)
+
+	_, err = vm.Resume()
+	assert.NoError(t, err)
+
+	vm, err = node.VirtualMachine(testVirtualMachineID)
+	require.NoError(t, err)
+	assert.Equal(t, "running", vm.Status)
+}


### PR DESCRIPTION
- Brought VM actions in line with start/stop/suspend/reboot/resume functionality for containers.
- Minimal integration tests (only works with an existing VM, temporary until VM creation/deletion is working).