### PR TITLE
semi working termproxy/vncwebsocket endpoints

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -2,24 +2,36 @@ package proxmox
 
 import (
 	"fmt"
+	"net/url"
 )
 
 func (c *Container) Start() (status string, err error) {
-	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%s/status/start", c.Node, c.VMID), nil, &status)
+	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%d/status/start", c.Node, c.VMID), nil, &status)
 }
 
 func (c *Container) Stop() (status *ContainerStatus, err error) {
-	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%s/status/stop", c.Node, c.VMID), nil, &status)
+	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%d/status/stop", c.Node, c.VMID), nil, &status)
 }
 
 func (c *Container) Suspend() (status *ContainerStatus, err error) {
-	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%s/status/suspend", c.Node, c.VMID), nil, &status)
+	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%d/status/suspend", c.Node, c.VMID), nil, &status)
 }
 
 func (c *Container) Reboot() (status *ContainerStatus, err error) {
-	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%s/status/reboot", c.Node, c.VMID), nil, &status)
+	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%d/status/reboot", c.Node, c.VMID), nil, &status)
 }
 
 func (c *Container) Resume() (status *ContainerStatus, err error) {
-	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%s/status/resume", c.Node, c.VMID), nil, &status)
+	return status, c.client.Post(fmt.Sprintf("/nodes/%s/lxc/%d/status/resume", c.Node, c.VMID), nil, &status)
+}
+
+func (c *Container) TermProxy() (vnc *VNC, err error) {
+	return vnc, c.client.Post(fmt.Sprintf("/nodes/%s/lxk/%d/termproxy", c.Node, c.VMID), nil, &vnc)
+}
+
+func (c *Container) VNCWebSocket(vnc *VNC) (chan string, chan string, chan error, func() error, error) {
+	p := fmt.Sprintf("/nodes/%s/lxc/%d/vncwebsocket?port=%d&vncticket=%s",
+		c.Node, c.VMID, vnc.Port, url.QueryEscape(vnc.Ticket))
+
+	return c.client.VNCWebSocket(p, vnc)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/luthermonson/go-proxmox
 go 1.16
 
 require (
+	github.com/buger/goterm v1.0.4
 	github.com/diskfs/go-diskfs v1.2.0
+	github.com/gorilla/websocket v1.4.2
 	github.com/jinzhu/copier v0.3.4
 	github.com/magefile/mage v1.12.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 4d63.com/gochecknoinits v0.0.0-20200108094044-eb73b47b9fc4/go.mod h1:4o1i5aXtIF5tJFt3UD1knCVmWOXg7fLYdHVu6jeNcnM=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/buger/goterm v1.0.4 h1:Z9YvGmOih81P0FbVtEYTFF6YsSgxSUKEhf/f9bTMXbY=
+github.com/buger/goterm v1.0.4/go.mod h1:HiFWV3xnkolgrBV3mY8m0X0Pumt4zg4QhbdOzQtB8tE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -8,6 +10,8 @@ github.com/diskfs/go-diskfs v1.2.0/go.mod h1:ZTeTbzixuyfnZW5y5qKMtjV2o+GLLHo1KfM
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gordonklaus/ineffassign v0.0.0-20190601041439-ed7b1b5ee0f8/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jgautheron/goconst v0.0.0-20170703170152-9740945f5dcb/go.mod h1:82TxjOpWQiPmywlbIaB2ZkqJoSYJdLGPgAJDvM3PbKc=
 github.com/jinzhu/copier v0.3.4 h1:mfU6jI9PtCeUjkjQ322dlff9ELjGDu975C2p/nrubVI=
 github.com/jinzhu/copier v0.3.4/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
@@ -48,6 +52,9 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20200102200121-6de373a2766c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=

--- a/magefile.go
+++ b/magefile.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	envConfig = map[string]struct{}{
+		"PROXMOX_URL":              {},
 		"PROXMOX_USERNAME":         {},
 		"PROXMOX_PASSWORD":         {},
 		"PROXMOX_OTP":              {},

--- a/proxmox.go
+++ b/proxmox.go
@@ -2,6 +2,7 @@ package proxmox
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
+
+	"github.com/buger/goterm"
+	"github.com/gorilla/websocket"
 )
 
 const (
@@ -186,6 +191,150 @@ func (c *Client) Upload(path string, fields map[string]string, file *os.File, v 
 	defer res.Body.Close()
 
 	return c.handleResponse(res, &v)
+}
+
+func (c *Client) VNCWebSocket(path string, vnc *VNC) (chan string, chan string, chan error, func() error, error) {
+	if strings.HasPrefix(path, "/") {
+		path = strings.Replace(c.baseURL, "https://", "wss://", 1) + path
+	}
+
+	c.log.Debugf("connecting to websocket: %s", path)
+	dialer := &websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: 15 * time.Second,
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+	}
+
+	conn, _, err := dialer.Dial(path, http.Header{
+		"Cookie": []string{"PVEAuthCookie=" + c.session.Ticket},
+	})
+
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	// start the session by sending user@realm:ticket
+	if err := conn.WriteMessage(websocket.BinaryMessage, []byte(vnc.User+":"+vnc.Ticket+"\n")); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	// it sends back the same thing you just sent so catch it drop it
+	_, msg, err := conn.ReadMessage()
+	if err != nil || string(msg) != "OK" {
+		if err := conn.Close(); err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("error closing websocket: %s", err.Error())
+		}
+		return nil, nil, nil, nil, fmt.Errorf("unable to establish websocket: %s", err.Error())
+	}
+
+	type size struct {
+		height int
+		width  int
+	}
+	// start the session by sending user@realm:ticket
+	tsize := size{
+		height: goterm.Height(),
+		width:  goterm.Width(),
+	}
+
+	c.log.Debugf("sending terminal size: %d x %d", tsize.height, tsize.width)
+	if err := conn.WriteMessage(websocket.BinaryMessage, []byte(fmt.Sprintf("1:%d:%d:", tsize.height, tsize.width))); err != nil {
+		return nil, nil, nil, nil, err
+	}
+
+	send := make(chan string)
+	recv := make(chan string)
+	errors := make(chan error)
+	done := make(chan struct{})
+	ticker := time.NewTicker(30 * time.Second)
+	resize := make(chan size)
+
+	go func(tsize size) {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				resized := size{
+					height: goterm.Height(),
+					width:  goterm.Width(),
+				}
+				if tsize.height != resized.height ||
+					tsize.width != resized.width {
+					tsize = resized
+					resize <- resized
+				}
+			}
+		}
+	}(tsize)
+
+	closer := func() error {
+		close(done)
+		time.Sleep(1 * time.Second)
+		close(send)
+		close(recv)
+		close(errors)
+		ticker.Stop()
+
+		return conn.Close()
+	}
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_, msg, err := conn.ReadMessage()
+				if err != nil {
+					if strings.Contains(err.Error(), "use of closed network connection") {
+						return
+					}
+					if !websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+						return
+					}
+					errors <- err
+				}
+				recv <- string(msg)
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				if err := conn.WriteMessage(websocket.CloseMessage, []byte{}); err != nil {
+					errors <- err
+				}
+				return
+			case <-ticker.C:
+				c.log.Debugf("sending wss keep alive")
+				if err := conn.WriteMessage(websocket.BinaryMessage, []byte("2")); err != nil {
+					errors <- err
+				}
+			case resized := <-resize:
+				c.log.Debugf("resizing terminal window: %d x %d", resized.height, resized.width)
+				if err := conn.WriteMessage(websocket.BinaryMessage, []byte(fmt.Sprintf("1:%d:%d:", resized.height, resized.width))); err != nil {
+					errors <- err
+				}
+			case msg := <-send:
+				c.log.Debugf("sending: %s", string(msg))
+				m := []byte(msg)
+				send := append([]byte(fmt.Sprintf("0:%d:", len(m))), m...)
+				if err := conn.WriteMessage(websocket.BinaryMessage, send); err != nil {
+					errors <- err
+				}
+				if err := conn.WriteMessage(websocket.BinaryMessage, []byte("0:1:\n")); err != nil {
+					errors <- err
+				}
+			}
+		}
+	}()
+
+	return send, recv, errors, closer, nil
 }
 
 func (c *Client) Put(p string, d interface{}, v interface{}) error {

--- a/types.go
+++ b/types.go
@@ -31,6 +31,14 @@ type Version struct {
 	Version string `json:"version"`
 }
 
+type VNC struct {
+	Cert   string
+	Port   StringOrInt
+	Ticket string
+	UPID   string
+	User   string
+}
+
 type Cluster struct {
 	client  *Client
 	Version int
@@ -328,7 +336,7 @@ type Container struct {
 	client  *Client
 	CPUs    int
 	Status  string
-	VMID    string
+	VMID    StringOrUint64
 	Uptime  uint64
 	MaxMem  uint64
 	MaxDisk uint64
@@ -412,6 +420,18 @@ func (it *IsTemplate) UnmarshalJSON(b []byte) error {
 		*it = false
 	}
 
+	return nil
+}
+
+type StringOrInt int
+
+func (d *StringOrInt) UnmarshalJSON(b []byte) error {
+	str := strings.Replace(string(b), "\"", "", -1)
+	parsed, err := strconv.ParseUint(str, 0, 64)
+	if err != nil {
+		return err
+	}
+	*d = StringOrInt(parsed)
 	return nil
 }
 


### PR DESCRIPTION
this recreates the functionality in the xterm.js vnc web socket connection used by proxmox to talk to the host/qemu/lxc. This was mostly tested using the host but should be functional in containers out of the box and will be tested more with containers when i actually get to working on them.

the web socket has some prereqs you will need to see #25 for setup info and figure out how to get your guest vms to properly use the socket0 serial for tty output.