### PR TITLE
feature: VM's network configuration info's

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zekiahmetbayar/go-proxmox
+module github.com/luthermonson/go-proxmox
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/luthermonson/go-proxmox
+module github.com/zekiahmetbayar/go-proxmox
 
-go 1.16
+go 1.18
 
 require (
 	github.com/buger/goterm v1.0.4
@@ -9,5 +9,12 @@ require (
 	github.com/jinzhu/copier v0.3.4
 	github.com/magefile/mage v1.12.1
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
+	gopkg.in/djherbis/times.v1 v1.2.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/nodes.go
+++ b/nodes.go
@@ -77,6 +77,11 @@ func (n *Node) VirtualMachine(vmid int) (*VirtualMachine, error) {
 		return nil, err
 	}
 
+	if err := n.client.Get(fmt.Sprintf("/nodes/%s/qemu/%d/agent/network-get-interfaces", n.Name, vmid), &vm.NetworkConfig); err != nil {
+		fmt.Println(err.Error())
+		return nil, err
+	}
+
 	//vm.VirtualMachineConfig = &vmconf
 
 	return vm, nil

--- a/types.go
+++ b/types.go
@@ -173,6 +173,33 @@ type NodeStatus struct {
 	Local  int    `json:",omitempty"`
 }
 
+type NetworkConfig struct {
+	Result []Res `json:"result"`
+}
+
+type Statistic struct {
+	TxErrs    int `json:"tx-errs"`
+	TxDropped int `json:"tx-dropped"`
+	RxBytes   int `json:"rx-bytes"`
+	RxPackets int `json:"rx-packets"`
+	RxErrs    int `json:"rx-errs"`
+	RxDropped int `json:"rx-dropped"`
+	TxBytes   int `json:"tx-bytes"`
+	TxPackets int `json:"tx-packets"`
+}
+
+type IPAddress struct {
+	Prefix        int    `json:"prefix"`
+	IPAddress     string `json:"ip-address"`
+	IPAddressType string `json:"ip-address-type"`
+}
+
+type Res struct {
+	Statistic       Statistic   `json:"statistics"`
+	IPAddresses     []IPAddress `json:"ip-addresses"`
+	HardwareAddress string      `json:"hardware-address"`
+	Name            string      `json:"name"`
+}
 type Node struct {
 	Name       string
 	client     *Client
@@ -194,27 +221,27 @@ type VirtualMachines []*VirtualMachine
 type VirtualMachine struct {
 	client               *Client
 	VirtualMachineConfig *VirtualMachineConfig
-
-	Name      string
-	Node      string
-	NetIn     uint64
-	CPUs      int
-	DiskWrite uint64
-	Status    string
-	Lock      string `json:",omitempty"`
-	VMID      StringOrUint64
-	PID       StringOrUint64
-	Netout    uint64
-	Disk      uint64
-	Uptime    uint64
-	Mem       uint64
-	CPU       float64
-	MaxMem    uint64
-	MaxDisk   uint64
-	DiskRead  uint64
-	QMPStatus string     `json:"qmpstatus,omitempty"`
-	Template  IsTemplate // empty str if a vm, int 1 if a template
-	HA        HA         `json:",omitempty"`
+	NetworkConfig        *NetworkConfig
+	Name                 string
+	Node                 string
+	NetIn                uint64
+	CPUs                 int
+	DiskWrite            uint64
+	Status               string
+	Lock                 string `json:",omitempty"`
+	VMID                 StringOrUint64
+	PID                  StringOrUint64
+	Netout               uint64
+	Disk                 uint64
+	Uptime               uint64
+	Mem                  uint64
+	CPU                  float64
+	MaxMem               uint64
+	MaxDisk              uint64
+	DiskRead             uint64
+	QMPStatus            string     `json:"qmpstatus,omitempty"`
+	Template             IsTemplate // empty str if a vm, int 1 if a template
+	HA                   HA         `json:",omitempty"`
 }
 
 type HA struct {


### PR DESCRIPTION
Added vm's network configuration info's

Sample JSON:

```
{
  "data": {
    "result": [
      {
        "statistics": {
          "rx-packets": 185,
          "tx-errs": 0,
          "tx-dropped": 0,
          "rx-bytes": 15957,
          "tx-packets": 185,
          "rx-errs": 0,
          "rx-dropped": 0,
          "tx-bytes": 15957
        },
        "ip-addresses": [
          {
            "prefix": 8,
            "ip-address-type": "ipv4",
            "ip-address": "127.0.0.1"
          },
          {
            "ip-address": "::1",
            "prefix": 128,
            "ip-address-type": "ipv6"
          }
        ],
        "name": "lo",
        "hardware-address": "00:00:00:00:00:00"
      },
      {
        "statistics": {
          "tx-packets": 4479,
          "tx-bytes": 241887,
          "rx-dropped": 2429,
          "rx-errs": 0,
          "rx-packets": 26597,
          "rx-bytes": 3296527,
          "tx-dropped": 0,
          "tx-errs": 0
        },
        "ip-addresses": [
          {
            "prefix": 99,
            "ip-address-type": "ipv4",
            "ip-address": "10.1.1.1"
          },
          {
            "ip-address-type": "ipv6",
            "prefix": 64,
            "ip-address": "eeee::cccc:bbbb:aaaa:xxxx"
          }
        ],
        "hardware-address": "11:11:11:sx:11:11",
        "name": "eth0"
      }
    ]
  }
}
```

