### PR TITLE
Rewrite Clone and MoveDisk qemu calls to support all endpoint parameters

### DIFF
--- a/types.go
+++ b/types.go
@@ -442,6 +442,31 @@ func (vmc *VirtualMachineConfig) MergeUnuseds() map[string]string {
 	return vmc.Unuseds
 }
 
+type VirtualMachineCloneOptions struct {
+	NewID       int    `json:"newid"`
+	BwLimit     uint64 `json:"bwlimit,omitempty"`
+	Description string `json:"description,omitempty"`
+	Format      string `json:"format,omitempty"`
+	Full        uint8  `json:"full,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Pool        string `json:"pool,omitempty"`
+	SnapName    string `json:"snapname,omitempty"`
+	Storage     string `json:"storage,omitempty"`
+	Target      string `json:"target,omitempty"`
+}
+
+type VirtualMachineMoveDiskOptions struct {
+	Disk         string `json:"disk"`
+	BwLimit      uint64 `json:"bwlimit,omitempty"`
+	Delete       uint8  `json:"delete,omitempty"`
+	Digest       string `json:"digest,omitempty"`
+	Format       string `json:"format,omitempty"`
+	Storage      string `json:"storage,omitempty"`
+	TargetDigest string `json:"target-digest,omitempty"`
+	TargetDisk   string `json:"target-disk,omitempty"`
+	TargetVMID   int    `json:"target-vmid,omitempty"`
+}
+
 type UPID string
 
 type Tasks []*Tasks

--- a/types.go
+++ b/types.go
@@ -444,7 +444,7 @@ func (vmc *VirtualMachineConfig) MergeUnuseds() map[string]string {
 
 type VirtualMachineCloneOptions struct {
 	NewID       int    `json:"newid"`
-	BwLimit     uint64 `json:"bwlimit,omitempty"`
+	BWLimit     uint64 `json:"bwlimit,omitempty"`
 	Description string `json:"description,omitempty"`
 	Format      string `json:"format,omitempty"`
 	Full        uint8  `json:"full,omitempty"`
@@ -457,7 +457,7 @@ type VirtualMachineCloneOptions struct {
 
 type VirtualMachineMoveDiskOptions struct {
 	Disk         string `json:"disk"`
-	BwLimit      uint64 `json:"bwlimit,omitempty"`
+	BWLimit      uint64 `json:"bwlimit,omitempty"`
 	Delete       uint8  `json:"delete,omitempty"`
 	Digest       string `json:"digest,omitempty"`
 	Format       string `json:"format,omitempty"`

--- a/virtual_machines.go
+++ b/virtual_machines.go
@@ -3,7 +3,6 @@ package proxmox
 import (
 	"fmt"
 	"net/url"
-	"strconv"
 )
 
 const (
@@ -152,23 +151,27 @@ func (v *VirtualMachine) Migrate(target, targetstorage string) (task *Task, err 
 	return NewTask(upid, v.client), nil
 }
 
-func (v *VirtualMachine) Clone(name, target string) (newid int, task *Task, err error) {
+func (v *VirtualMachine) Clone(params *VirtualMachineCloneOptions) (newid int, task *Task, err error) {
 	var upid UPID
-	cluster, err := v.client.Cluster()
-	if err != nil {
-		return newid, nil, err
+
+	if params == nil {
+		params = &VirtualMachineCloneOptions{}
 	}
 
-	newid, err = cluster.NextID()
-	if err != nil {
-		return newid, nil, err
+	if params.NewID == 0 {
+		cluster, err := v.client.Cluster()
+		if err != nil {
+			return newid, nil, err
+		}
+
+		newid, err = cluster.NextID()
+		if err != nil {
+			return newid, nil, err
+		}
+		params.NewID = newid
 	}
 
-	if err := v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%d/clone", v.Node, v.VMID), map[string]string{
-		"newid":  strconv.Itoa(newid),
-		"name":   name,
-		"target": target,
-	}, &upid); err != nil {
+	if err := v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%d/clone", v.Node, v.VMID), params, &upid); err != nil {
 		return newid, nil, err
 	}
 
@@ -204,13 +207,18 @@ func (v *VirtualMachine) UnlinkDisk(diskID string, force bool) (task *Task, err 
 	return NewTask(upid, v.client), nil
 }
 
-func (v *VirtualMachine) MoveDisk(disk, storage string) (task *Task, err error) {
+func (v *VirtualMachine) MoveDisk(disk string, params *VirtualMachineMoveDiskOptions) (task *Task, err error) {
 	var upid UPID
 
-	err = v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%d/move_disk", v.Node, v.VMID), map[string]string{
-		"disk":    disk,
-		"storage": storage,
-	}, &upid)
+	if params == nil {
+		params = &VirtualMachineMoveDiskOptions{}
+	}
+
+	if disk != "" {
+		params.Disk = disk
+	}
+
+	err = v.client.Post(fmt.Sprintf("/nodes/%s/qemu/%d/move_disk", v.Node, v.VMID), params, &upid)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
I tried implementing the full range of parameters supported by those calls while I was at it.

For `Clone`, I kept newid exclusively in the Options structure in the end, since an implicit call to NextID as the default behavior makes sense and simplifies client usage in most cases.

For `MoveDisk`, I'm a bit torn on what to do with `disk` since it is mandatory but is also part of the JSON payload so I need it in the Options struct anyway. The current implementation now has two way to pass this information, either through the arg, or through the Options struct if the `disk` arg is empty. I could also systematically overwrite the struct value with the arg even when empty, or drop the arg altogether, which would make the struct mandatory in practice.