### PR TITLE
Extend VM config to cover most documented fields

### DIFF
--- a/types.go
+++ b/types.go
@@ -491,7 +491,6 @@ func (vmc *VirtualMachineConfig) MergeIDEs() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -512,7 +511,6 @@ func (vmc *VirtualMachineConfig) MergeSCSIs() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -534,7 +532,6 @@ func (vmc *VirtualMachineConfig) MergeSATAs() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -555,7 +552,6 @@ func (vmc *VirtualMachineConfig) MergeNets() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -577,7 +573,6 @@ func (vmc *VirtualMachineConfig) MergeVirtIOs() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -599,7 +594,6 @@ func (vmc *VirtualMachineConfig) MergeUnuseds() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -621,7 +615,6 @@ func (vmc *VirtualMachineConfig) MergeSerials() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -643,7 +636,6 @@ func (vmc *VirtualMachineConfig) MergeUSBs() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -665,7 +657,6 @@ func (vmc *VirtualMachineConfig) MergeHostPCIs() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -687,7 +678,6 @@ func (vmc *VirtualMachineConfig) MergeNumas() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -709,7 +699,6 @@ func (vmc *VirtualMachineConfig) MergeParallels() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}
@@ -731,7 +720,6 @@ func (vmc *VirtualMachineConfig) MergeIPConfigs() map[string]string {
 		for i := 0; i < count; i++ {
 			fn := t.Field(i).Name
 			fv := v.Field(i).String()
-			//fmt.Println(fn, fv)
 			if "" == fv {
 				continue
 			}

--- a/types.go
+++ b/types.go
@@ -465,7 +465,7 @@ type VirtualMachineConfig struct {
 	IPConfig9 string            `json:"ipconfig9,omitempty"`
 }
 
-func (vmc *VirtualMachineConfig) mergdeIndexedDevices(prefix string) map[string]string {
+func (vmc *VirtualMachineConfig) mergeIndexedDevices(prefix string) map[string]string {
 	deviceMap := make(map[string]string, 0)
 	t := reflect.TypeOf(*vmc)
 	v := reflect.ValueOf(*vmc)
@@ -492,84 +492,84 @@ func (vmc *VirtualMachineConfig) mergdeIndexedDevices(prefix string) map[string]
 
 func (vmc *VirtualMachineConfig) MergeIDEs() map[string]string {
 	if nil == vmc.IDEs {
-		vmc.IDEs = vmc.mergdeIndexedDevices("IDE")
+		vmc.IDEs = vmc.mergeIndexedDevices("IDE")
 	}
 	return vmc.IDEs
 }
 
 func (vmc *VirtualMachineConfig) MergeSCSIs() map[string]string {
 	if nil == vmc.SCSIs {
-		vmc.SCSIs = vmc.mergdeIndexedDevices("SCSI")
+		vmc.SCSIs = vmc.mergeIndexedDevices("SCSI")
 	}
 	return vmc.SCSIs
 }
 
 func (vmc *VirtualMachineConfig) MergeSATAs() map[string]string {
 	if nil == vmc.SATAs {
-		vmc.SATAs = vmc.mergdeIndexedDevices("SATA")
+		vmc.SATAs = vmc.mergeIndexedDevices("SATA")
 	}
 	return vmc.SATAs
 }
 
 func (vmc *VirtualMachineConfig) MergeNets() map[string]string {
 	if nil == vmc.Nets {
-		vmc.Nets = vmc.mergdeIndexedDevices("Net")
+		vmc.Nets = vmc.mergeIndexedDevices("Net")
 	}
 	return vmc.Nets
 }
 
 func (vmc *VirtualMachineConfig) MergeVirtIOs() map[string]string {
 	if nil == vmc.VirtIOs {
-		vmc.VirtIOs = vmc.mergdeIndexedDevices("VirtIO")
+		vmc.VirtIOs = vmc.mergeIndexedDevices("VirtIO")
 	}
 	return vmc.VirtIOs
 }
 
 func (vmc *VirtualMachineConfig) MergeUnuseds() map[string]string {
 	if nil == vmc.Unuseds {
-		vmc.Unuseds = vmc.mergdeIndexedDevices("Unused")
+		vmc.Unuseds = vmc.mergeIndexedDevices("Unused")
 	}
 	return vmc.Unuseds
 }
 
 func (vmc *VirtualMachineConfig) MergeSerials() map[string]string {
 	if nil == vmc.Serials {
-		vmc.Serials = vmc.mergdeIndexedDevices("Serial")
+		vmc.Serials = vmc.mergeIndexedDevices("Serial")
 	}
 	return vmc.Serials
 }
 
 func (vmc *VirtualMachineConfig) MergeUSBs() map[string]string {
 	if nil == vmc.USBs {
-		vmc.HostPCIs = vmc.mergdeIndexedDevices("USB")
+		vmc.HostPCIs = vmc.mergeIndexedDevices("USB")
 	}
 	return vmc.USBs
 }
 
 func (vmc *VirtualMachineConfig) MergeHostPCIs() map[string]string {
 	if nil == vmc.HostPCIs {
-		vmc.HostPCIs = vmc.mergdeIndexedDevices("HostPCI")
+		vmc.HostPCIs = vmc.mergeIndexedDevices("HostPCI")
 	}
 	return vmc.HostPCIs
 }
 
 func (vmc *VirtualMachineConfig) MergeNumas() map[string]string {
 	if nil == vmc.Numas {
-		vmc.HostPCIs = vmc.mergdeIndexedDevices("Numa")
+		vmc.HostPCIs = vmc.mergeIndexedDevices("Numa")
 	}
 	return vmc.Numas
 }
 
 func (vmc *VirtualMachineConfig) MergeParallels() map[string]string {
 	if nil == vmc.Parallels {
-		vmc.Parallels = vmc.mergdeIndexedDevices("Parallel")
+		vmc.Parallels = vmc.mergeIndexedDevices("Parallel")
 	}
 	return vmc.Parallels
 }
 
 func (vmc *VirtualMachineConfig) MergeIPConfigs() map[string]string {
 	if nil == vmc.IPConfigs {
-		vmc.IPConfigs = vmc.mergdeIndexedDevices("IPConfig")
+		vmc.IPConfigs = vmc.mergeIndexedDevices("IPConfig")
 	}
 	return vmc.IPConfigs
 }

--- a/types.go
+++ b/types.go
@@ -567,7 +567,7 @@ func (vmc *VirtualMachineConfig) MergeNets() map[string]string {
 	return vmc.Nets
 }
 
-func (vmc *VirtualMachineConfig) MergeVirtios() map[string]string {
+func (vmc *VirtualMachineConfig) MergeVirtIOs() map[string]string {
 	if nil == vmc.VirtIOs {
 		vmc.VirtIOs = map[string]string{}
 		t := reflect.TypeOf(*vmc)

--- a/types.go
+++ b/types.go
@@ -12,20 +12,19 @@ import (
 )
 
 var (
-	vmConfigRegexpIDE    *regexp.Regexp
-	vmConfigRegexpSCSI   *regexp.Regexp
-	vmConfigRegexpSATA   *regexp.Regexp
-	vmConfigRegexpNet    *regexp.Regexp
-	vmConfigRegexpUnused *regexp.Regexp
+	vmConfigRegexpIDE      = regexp.MustCompile("^IDE\\d+$")
+	vmConfigRegexpSCSI     = regexp.MustCompile("^SCSI\\d+$")
+	vmConfigRegexpSATA     = regexp.MustCompile("^SATA\\d+$")
+	vmConfigRegexpVirtIO   = regexp.MustCompile("^VirtIO\\d+$")
+	vmConfigRegexpUnused   = regexp.MustCompile("^Unused\\d+$")
+	vmConfigRegexpNet      = regexp.MustCompile("^Net\\d+$")
+	vmConfigRegexpSerial   = regexp.MustCompile("^Serial\\d+$")
+	vmConfigRegexpUSB      = regexp.MustCompile("^USB\\d+$")
+	vmConfigRegexpIPConfig = regexp.MustCompile("^IPConfig\\d+$")
+	vmConfigRegexpHostPCI  = regexp.MustCompile("^HostPCI\\d+$")
+	vmConfigRegexpParallel = regexp.MustCompile("^Parallel\\d+$")
+	vmConfigRegexpNuma     = regexp.MustCompile("^Numa\\d+$")
 )
-
-func init() {
-	vmConfigRegexpIDE, _ = regexp.Compile("^IDE[\\d]+$")
-	vmConfigRegexpSCSI, _ = regexp.Compile("^SCSI[\\d]+$")
-	vmConfigRegexpSATA, _ = regexp.Compile("^SATAIDE[\\d]+$")
-	vmConfigRegexpNet, _ = regexp.Compile("^Net[\\d]+$")
-	vmConfigRegexpUnused, _ = regexp.Compile("^Unused[\\d]+$")
-}
 
 type Credentials struct {
 	Username string `json:"username"`
@@ -261,78 +260,225 @@ type VirtualMachineOption struct {
 }
 
 type VirtualMachineConfig struct {
-	Cores   int
-	Numa    int
-	Memory  int
-	Sockets int
-	IDE2    string
-	OSType  string
-	SMBios1 string
-	SCSIHW  string
-	Net0    string
-	Digest  string
-	Meta    string
-	SCSI0   string
-	Boot    string
-	VMGenID string
-	Name    string
+	// PVE Metadata
+	Digest      string `json:"digest"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Meta        string `json:"meta,omitempty"`
+	VMGenID     string `json:"vmgenid,omitempty"`
+	Hookscript  string `json:"hookscript,omitempty"`
+	Hotplug     string `json:"hotplug,omitempty"`
+	Template    int    `json:"template,omitempty"`
+	Tags        string `json:"tags,omitempty"`
+	Protection  int    `json:"protection,omitempty"`
+	Lock        string `json:"lock,omitempty"`
 
-	IDEs map[string]string
-	IDE0 string
-	IDE1 string
-	IDE3 string
-	IDE4 string
-	IDE5 string
-	IDE6 string
-	IDE7 string
-	IDE8 string
-	IDE9 string
+	// Boot configuration
+	Boot   string `json:"boot,omitempty"`
+	OnBoot int    `json:"onboot,omitempty"`
 
-	SCSIs map[string]string
-	SCSI1 string
-	SCSI2 string
-	SCSI3 string
-	SCSI4 string
-	SCSI5 string
-	SCSI6 string
-	SCSI7 string
-	SCSI8 string
-	SCSI9 string
+	// Qemu general specs
+	OSType  string `json:"ostype,omitempty"`
+	Machine string `json:"machine,omitempty"`
+	Args    string `json:"args,omitempty"`
 
-	SATAs map[string]string
-	SATA0 string
-	SATA1 string
-	SATA2 string
-	SATA3 string
-	SATA4 string
-	SATA5 string
-	SATA6 string
-	SATA7 string
-	SATA8 string
-	SATA9 string
+	// Qemu firmware specs
+	Bios     string `json:"bios,omitempty"`
+	EFIDisk0 string `json:"efidisk0,omitempty"`
+	SMBios1  string `json:"smbios1,omitempty"`
+	Acpi     int    `json:"acpi,omitempty"`
 
-	Nets map[string]string
-	Net1 string
-	Net2 string
-	Net3 string
-	Net4 string
-	Net5 string
-	Net6 string
-	Net7 string
-	Net8 string
-	Net9 string
+	// Qemu CPU specs
+	Sockets  int    `json:"sockets,omitempty"`
+	Cores    int    `json:"cores,omitempty"`
+	CPU      string `json:"cpu,omitempty"`
+	CPULimit int    `json:"cpulimit,omitempty"`
+	CPUUnits int    `json:"cpuunits,omitempty"`
+	Vcpus    int    `json:"vcpus,omitempty"`
+	Affinity string `json:"affinity,omitempty"`
 
-	Unuseds map[string]string
-	Unused0 string
-	Unused1 string
-	Unused2 string
-	Unused3 string
-	Unused4 string
-	Unused5 string
-	Unused6 string
-	Unused7 string
-	Unused8 string
-	Unused9 string
+	// Qemu memory specs
+	Numa      int    `json:"numa,omitempty"`
+	Memory    int    `json:"memory,omitempty"`
+	Hugepages string `json:"hugepages,omitempty"`
+	Balloon   int    `json:"balloon,omitempty"`
+
+	// Other Qemu devices
+	VGA       string `json:"vga,omitempty"`
+	SCSIHW    string `json:"scsihw,omitempty"`
+	TPMState0 string `json:"tpmstate0,omitempty"`
+	Rng0      string `json:"rng0,omitempty"`
+	Audio0    string `json:"audio0,omitempty"`
+
+	// Disk devices
+	IDEs map[string]string `json:"-"`
+	IDE0 string            `json:"ide0,omitempty"`
+	IDE1 string            `json:"ide1,omitempty"`
+	IDE2 string            `json:"ide2,omitempty"`
+	IDE3 string            `json:"ide3,omitempty"`
+
+	SCSIs  map[string]string `json:"-"`
+	SCSI0  string            `json:"scsi0,omitempty"`
+	SCSI1  string            `json:"scsi1,omitempty"`
+	SCSI2  string            `json:"scsi2,omitempty"`
+	SCSI3  string            `json:"scsi3,omitempty"`
+	SCSI4  string            `json:"scsi4,omitempty"`
+	SCSI5  string            `json:"scsi5,omitempty"`
+	SCSI6  string            `json:"scsi6,omitempty"`
+	SCSI7  string            `json:"scsi7,omitempty"`
+	SCSI8  string            `json:"scsi8,omitempty"`
+	SCSI9  string            `json:"scsi9,omitempty"`
+	SCSI10 string            `json:"scsi10,omitempty"`
+	SCSI11 string            `json:"scsi11,omitempty"`
+	SCSI12 string            `json:"scsi12,omitempty"`
+	SCSI13 string            `json:"scsi13,omitempty"`
+	SCSI14 string            `json:"scsi14,omitempty"`
+	SCSI15 string            `json:"scsi15,omitempty"`
+	SCSI16 string            `json:"scsi16,omitempty"`
+	SCSI17 string            `json:"scsi17,omitempty"`
+	SCSI18 string            `json:"scsi18,omitempty"`
+	SCSI19 string            `json:"scsi19,omitempty"`
+	SCSI20 string            `json:"scsi20,omitempty"`
+	SCSI21 string            `json:"scsi21,omitempty"`
+	SCSI22 string            `json:"scsi22,omitempty"`
+	SCSI23 string            `json:"scsi23,omitempty"`
+	SCSI24 string            `json:"scsi24,omitempty"`
+	SCSI25 string            `json:"scsi25,omitempty"`
+	SCSI26 string            `json:"scsi26,omitempty"`
+	SCSI27 string            `json:"scsi27,omitempty"`
+	SCSI28 string            `json:"scsi28,omitempty"`
+	SCSI29 string            `json:"scsi29,omitempty"`
+	SCSI30 string            `json:"scsi30,omitempty"`
+
+	SATAs map[string]string `json:"-"`
+	SATA0 string            `json:"sata0,omitempty"`
+	SATA1 string            `json:"sata1,omitempty"`
+	SATA2 string            `json:"sata2,omitempty"`
+	SATA3 string            `json:"sata3,omitempty"`
+	SATA4 string            `json:"sata4,omitempty"`
+	SATA5 string            `json:"sata5,omitempty"`
+
+	VirtIOs  map[string]string `json:"-"`
+	VirtIO0  string            `json:"virtio0,omitempty"`
+	VirtIO1  string            `json:"virtio1,omitempty"`
+	VirtIO2  string            `json:"virtio2,omitempty"`
+	VirtIO3  string            `json:"virtio3,omitempty"`
+	VirtIO4  string            `json:"virtio4,omitempty"`
+	VirtIO5  string            `json:"virtio5,omitempty"`
+	VirtIO6  string            `json:"virtio6,omitempty"`
+	VirtIO7  string            `json:"virtio7,omitempty"`
+	VirtIO8  string            `json:"virtio8,omitempty"`
+	VirtIO9  string            `json:"virtio9,omitempty"`
+	VirtIO10 string            `json:"virtio10,omitempty"`
+	VirtIO11 string            `json:"virtio11,omitempty"`
+	VirtIO12 string            `json:"virtio12,omitempty"`
+	VirtIO13 string            `json:"virtio13,omitempty"`
+	VirtIO14 string            `json:"virtio14,omitempty"`
+	VirtIO15 string            `json:"virtio15,omitempty"`
+
+	Unuseds map[string]string `json:"-"`
+	Unused0 string            `json:"unused0,omitempty"`
+	Unused1 string            `json:"unused1,omitempty"`
+	Unused2 string            `json:"unused2,omitempty"`
+	Unused3 string            `json:"unused3,omitempty"`
+	Unused4 string            `json:"unused4,omitempty"`
+	Unused5 string            `json:"unused5,omitempty"`
+	Unused6 string            `json:"unused6,omitempty"`
+	Unused7 string            `json:"unused7,omitempty"`
+	Unused8 string            `json:"unused8,omitempty"`
+	Unused9 string            `json:"unused9,omitempty"`
+
+	// Network devices
+	Nets map[string]string `json:"-"`
+	Net0 string            `json:"net0,omitempty"`
+	Net1 string            `json:"net1,omitempty"`
+	Net2 string            `json:"net2,omitempty"`
+	Net3 string            `json:"net3,omitempty"`
+	Net4 string            `json:"net4,omitempty"`
+	Net5 string            `json:"net5,omitempty"`
+	Net6 string            `json:"net6,omitempty"`
+	Net7 string            `json:"net7,omitempty"`
+	Net8 string            `json:"net8,omitempty"`
+	Net9 string            `json:"net9,omitempty"`
+
+	// NUMA topology
+	Numas map[string]string `json:"-"`
+	Numa0 string            `json:"numa0,omitempty"`
+	Numa1 string            `json:"numa1,omitempty"`
+	Numa2 string            `json:"numa2,omitempty"`
+	Numa3 string            `json:"numa3,omitempty"`
+	Numa4 string            `json:"numa4,omitempty"`
+	Numa5 string            `json:"numa5,omitempty"`
+	Numa6 string            `json:"numa6,omitempty"`
+	Numa7 string            `json:"numa7,omitempty"`
+	Numa8 string            `json:"numa8,omitempty"`
+	Numa9 string            `json:"numa9,omitempty"`
+
+	// Host PCI devices
+	HostPCIs map[string]string `json:"-"`
+	HostPCI0 string            `json:"hostpci0,omitempty"`
+	HostPCI1 string            `json:"hostpci1,omitempty"`
+	HostPCI2 string            `json:"hostpci2,omitempty"`
+	HostPCI3 string            `json:"hostpci3,omitempty"`
+	HostPCI4 string            `json:"hostpci4,omitempty"`
+	HostPCI5 string            `json:"hostpci5,omitempty"`
+	HostPCI6 string            `json:"hostpci6,omitempty"`
+	HostPCI7 string            `json:"hostpci7,omitempty"`
+	HostPCI8 string            `json:"hostpci8,omitempty"`
+	HostPCI9 string            `json:"hostpci9,omitempty"`
+
+	// Serial devices
+	Serials map[string]string `json:"-"`
+	Serial0 string            `json:"serial0,omitempty"`
+	Serial1 string            `json:"serial1,omitempty"`
+	Serial2 string            `json:"serial2,omitempty"`
+	Serial3 string            `json:"serial3,omitempty"`
+
+	// USB devices
+	USBs  map[string]string `json:"-"`
+	USB0  string            `json:"usb0,omitempty"`
+	USB1  string            `json:"usb1,omitempty"`
+	USB2  string            `json:"usb2,omitempty"`
+	USB3  string            `json:"usb3,omitempty"`
+	USB4  string            `json:"usb4,omitempty"`
+	USB5  string            `json:"usb5,omitempty"`
+	USB6  string            `json:"usb6,omitempty"`
+	USB7  string            `json:"usb7,omitempty"`
+	USB8  string            `json:"usb8,omitempty"`
+	USB9  string            `json:"usb9,omitempty"`
+	USB10 string            `json:"usb10,omitempty"`
+	USB11 string            `json:"usb11,omitempty"`
+	USB12 string            `json:"usb12,omitempty"`
+	USB13 string            `json:"usb13,omitempty"`
+	USB14 string            `json:"usb14,omitempty"`
+
+	// Parallel devices
+	Parallels map[string]string `json:"-"`
+	Parallel0 string            `json:"parallel0,omitempty"`
+	Parallel1 string            `json:"parallel1,omitempty"`
+	Parallel2 string            `json:"parallel2,omitempty"`
+
+	// Cloud-init
+	CIType       string `json:"citype,omitempty"`
+	CIUser       string `json:"ciuser,omitempty"`
+	CIPassword   string `json:"cipassword,omitempty"`
+	Nameserver   string `json:"nameserver,omitempty"`
+	Searchdomain string `json:"searchdomain,omitempty"`
+	SSHKeys      string `json:"sshkeys,omitempty"`
+	CICustom     string `json:"cicustom,omitempty"`
+
+	// Cloud-init interfaces
+	IPConfigs map[string]string `json:"-"`
+	IPConfig0 string            `json:"ipconfig0,omitempty"`
+	IPConfig1 string            `json:"ipconfig1,omitempty"`
+	IPConfig2 string            `json:"ipconfig2,omitempty"`
+	IPConfig3 string            `json:"ipconfig3,omitempty"`
+	IPConfig4 string            `json:"ipconfig4,omitempty"`
+	IPConfig5 string            `json:"ipconfig5,omitempty"`
+	IPConfig6 string            `json:"ipconfig6,omitempty"`
+	IPConfig7 string            `json:"ipconfig7,omitempty"`
+	IPConfig8 string            `json:"ipconfig8,omitempty"`
+	IPConfig9 string            `json:"ipconfig9,omitempty"`
 }
 
 func (vmc *VirtualMachineConfig) MergeIDEs() map[string]string {
@@ -420,6 +566,29 @@ func (vmc *VirtualMachineConfig) MergeNets() map[string]string {
 	}
 	return vmc.Nets
 }
+
+func (vmc *VirtualMachineConfig) MergeVirtios() map[string]string {
+	if nil == vmc.VirtIOs {
+		vmc.VirtIOs = map[string]string{}
+		t := reflect.TypeOf(*vmc)
+		v := reflect.ValueOf(*vmc)
+		count := v.NumField()
+
+		for i := 0; i < count; i++ {
+			fn := t.Field(i).Name
+			fv := v.Field(i).String()
+			//fmt.Println(fn, fv)
+			if "" == fv {
+				continue
+			}
+			if vmConfigRegexpVirtIO.MatchString(fn) {
+				vmc.VirtIOs[strings.ToLower(fn)] = fv
+			}
+		}
+	}
+	return vmc.VirtIOs
+}
+
 func (vmc *VirtualMachineConfig) MergeUnuseds() map[string]string {
 	if nil == vmc.Unuseds {
 		vmc.Unuseds = map[string]string{}
@@ -440,6 +609,138 @@ func (vmc *VirtualMachineConfig) MergeUnuseds() map[string]string {
 		}
 	}
 	return vmc.Unuseds
+}
+
+func (vmc *VirtualMachineConfig) MergeSerials() map[string]string {
+	if nil == vmc.Serials {
+		vmc.Serials = map[string]string{}
+		t := reflect.TypeOf(*vmc)
+		v := reflect.ValueOf(*vmc)
+		count := v.NumField()
+
+		for i := 0; i < count; i++ {
+			fn := t.Field(i).Name
+			fv := v.Field(i).String()
+			//fmt.Println(fn, fv)
+			if "" == fv {
+				continue
+			}
+			if vmConfigRegexpSerial.MatchString(fn) {
+				vmc.Serials[strings.ToLower(fn)] = fv
+			}
+		}
+	}
+	return vmc.Serials
+}
+
+func (vmc *VirtualMachineConfig) MergeUSBs() map[string]string {
+	if nil == vmc.USBs {
+		vmc.HostPCIs = map[string]string{}
+		t := reflect.TypeOf(*vmc)
+		v := reflect.ValueOf(*vmc)
+		count := v.NumField()
+
+		for i := 0; i < count; i++ {
+			fn := t.Field(i).Name
+			fv := v.Field(i).String()
+			//fmt.Println(fn, fv)
+			if "" == fv {
+				continue
+			}
+			if vmConfigRegexpUSB.MatchString(fn) {
+				vmc.USBs[strings.ToLower(fn)] = fv
+			}
+		}
+	}
+	return vmc.USBs
+}
+
+func (vmc *VirtualMachineConfig) MergeHostPCIs() map[string]string {
+	if nil == vmc.HostPCIs {
+		vmc.HostPCIs = map[string]string{}
+		t := reflect.TypeOf(*vmc)
+		v := reflect.ValueOf(*vmc)
+		count := v.NumField()
+
+		for i := 0; i < count; i++ {
+			fn := t.Field(i).Name
+			fv := v.Field(i).String()
+			//fmt.Println(fn, fv)
+			if "" == fv {
+				continue
+			}
+			if vmConfigRegexpHostPCI.MatchString(fn) {
+				vmc.HostPCIs[strings.ToLower(fn)] = fv
+			}
+		}
+	}
+	return vmc.HostPCIs
+}
+
+func (vmc *VirtualMachineConfig) MergeNumas() map[string]string {
+	if nil == vmc.Numas {
+		vmc.HostPCIs = map[string]string{}
+		t := reflect.TypeOf(*vmc)
+		v := reflect.ValueOf(*vmc)
+		count := v.NumField()
+
+		for i := 0; i < count; i++ {
+			fn := t.Field(i).Name
+			fv := v.Field(i).String()
+			//fmt.Println(fn, fv)
+			if "" == fv {
+				continue
+			}
+			if vmConfigRegexpNuma.MatchString(fn) {
+				vmc.Numas[strings.ToLower(fn)] = fv
+			}
+		}
+	}
+	return vmc.Numas
+}
+
+func (vmc *VirtualMachineConfig) MergeParallels() map[string]string {
+	if nil == vmc.Parallels {
+		vmc.Parallels = map[string]string{}
+		t := reflect.TypeOf(*vmc)
+		v := reflect.ValueOf(*vmc)
+		count := v.NumField()
+
+		for i := 0; i < count; i++ {
+			fn := t.Field(i).Name
+			fv := v.Field(i).String()
+			//fmt.Println(fn, fv)
+			if "" == fv {
+				continue
+			}
+			if vmConfigRegexpParallel.MatchString(fn) {
+				vmc.Parallels[strings.ToLower(fn)] = fv
+			}
+		}
+	}
+	return vmc.Parallels
+}
+
+func (vmc *VirtualMachineConfig) MergeIPConfigs() map[string]string {
+	if nil == vmc.IPConfigs {
+		vmc.IPConfigs = map[string]string{}
+		t := reflect.TypeOf(*vmc)
+		v := reflect.ValueOf(*vmc)
+		count := v.NumField()
+
+		for i := 0; i < count; i++ {
+			fn := t.Field(i).Name
+			fv := v.Field(i).String()
+			//fmt.Println(fn, fv)
+			if "" == fv {
+				continue
+			}
+			if vmConfigRegexpIPConfig.MatchString(fn) {
+				vmc.IPConfigs[strings.ToLower(fn)] = fv
+			}
+		}
+	}
+	return vmc.IPConfigs
 }
 
 type UPID string


### PR DESCRIPTION
I was missing a few fields for my own use, and figured it would be nice to extend this `VirtualMachineConfig` a bit further since I may need the rest later on anyway. Now I know this is a lot of fields, but even parallel ports have their use sometimes (though I hope I'll never have to go down this path myself).

I actually cut a few superfluous ones on the way. The endpoint spec seems to indicates IDE devices are limited to 4 and SATA to 6. SCSI on the other hand goes as far as 30. I let lists with unspecified limits at 10 as this seemed a reasonable default

The diff is a bit of a mess since I figured a struct as large as this warranted some reorganization rather than an endless unsorted list. I also added JSON tags everywhere and replaced the regexp compilations to do away with the init().