### PR TITLE
Better handle the optionality of network-config and vendor-data

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -182,12 +182,18 @@ func makeCloudInitISO(filename, userdata, metadata, vendordata, networkconfig st
 		return nil, err
 	}
 
-	for filename, content := range map[string]string{
-		"user-data":      userdata,
-		"meta-data":      metadata,
-		"vendor-data":    vendordata,
-		"network-config": networkconfig,
-	} {
+	cifiles := map[string]string{
+		"user-data": userdata,
+		"meta-data": metadata,
+	}
+	if vendordata != "" {
+		cifiles["vendor-data"] = vendordata
+	}
+	if networkconfig != "" {
+		cifiles["network-config"] = networkconfig
+	}
+
+	for filename, content := range cifiles {
 		rw, err := fs.OpenFile("/"+filename, os.O_CREATE|os.O_RDWR)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
I realized I didn't handle properly the case where vendor-data and network-config were empty. An empty vendor-data config file will not be doing much, but though unlikely as it is an invalid configuration and should just be discarded, an empty network-config has potential for inhibiting the default network cloud-init behavior and replacing it with nothing. As I would rather not leave this up to cloud-init implementation details, not creating the files at all seems a safer course.