### PR TITLE
add get and set client methods to virtual machines

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -587,3 +587,11 @@ func (v *VirtualMachine) SnapshotRollback(name string) (task *Task, err error) {
 
 	return NewTask(upid, v.client), nil
 }
+
+func (v *VirtualMachine) SetClient(client *Client) {
+	v.client = client
+}
+
+func (v *VirtualMachine) GetClient() *Client {
+	return v.client
+}


### PR DESCRIPTION
when calling Clone on a virtual machine, I get a panic because the vm's client is nil. I opened this PR to add basic GetClient() and SetClient() methods to VMs to fix this issue.

```go
        /Users/rosskirk/go/go1.19.3/src/runtime/panic.go:890 +0x267
github.com/luthermonson/go-proxmox.(*Client).Req(0x0, {0x32cd5f1, 0x4}, {0xc0006ea540, 0x14}, {0xc00018baa0, 0x5d, 0x60}, {0x2f15620, 0xc000597ee0})
        /Users/rosskirk/go/pkg/mod/github.com/luthermonson/go-proxmox@v0.0.0-alpha3/proxmox.go:83 +0xa5
github.com/luthermonson/go-proxmox.(*Client).Post(0x0, {0xc0006ea540, 0x14}, {0x2f156e0, 0xc000f1e240}, {0x2f15620, 0xc000597ee0})
        /Users/rosskirk/go/pkg/mod/github.com/luthermonson/go-proxmox@v0.0.0-alpha3/proxmox.go:152 +0x1b1
github.com/luthermonson/go-proxmox.(*VirtualMachine).Clone(0xc000bac098, 0xc000f1e240)
        /Users/rosskirk/go/pkg/mod/github.com/luthermonson/go-proxmox@v0.0.0-alpha3/virtual_machine.go:369 +0x432
```