### PR TITLE
adding noop error and ignoring task from addtag in cloudinit

### DIFF
--- a/proxmox.go
+++ b/proxmox.go
@@ -41,6 +41,12 @@ func IsNotFound(err error) bool {
 	return err == ErrNotFound
 }
 
+var ErrNoop = errors.New("nothing to do")
+
+func IsErrNoop(err error) bool {
+	return err == ErrNoop
+}
+
 func MakeTag(v string) string {
 	return fmt.Sprintf(TagFormat, v)
 }


### PR DESCRIPTION
regrets were have returning nil nil, adding a noop error type in case this happens again and decided to ultimately ignore the returned task in cloud init func since there wasn't much benefit to waiting for it to get done if we do actually call it

fixes #68 