### PR TITLE
Fix warnings raised by Goland

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -41,7 +41,7 @@ type LeveledLogger struct {
 // Debugf logs a debug message using Printf conventions.
 func (l *LeveledLogger) Debugf(format string, v ...interface{}) {
 	if l.Level >= LevelDebug {
-		fmt.Fprintf(l.stdout(), "[DEBUG] "+format+"\n", v...)
+		_, _ = fmt.Fprintf(l.stdout(), "[DEBUG] "+format+"\n", v...)
 	}
 }
 
@@ -49,21 +49,21 @@ func (l *LeveledLogger) Debugf(format string, v ...interface{}) {
 func (l *LeveledLogger) Errorf(format string, v ...interface{}) {
 	// Infof logs a debug message using Printf conventions.
 	if l.Level >= LevelError {
-		fmt.Fprintf(l.stderr(), "[ERROR] "+format+"\n", v...)
+		_, _ = fmt.Fprintf(l.stderr(), "[ERROR] "+format+"\n", v...)
 	}
 }
 
 // Infof logs an informational message using Printf conventions.
 func (l *LeveledLogger) Infof(format string, v ...interface{}) {
 	if l.Level >= LevelInfo {
-		fmt.Fprintf(l.stdout(), "[INFO] "+format+"\n", v...)
+		_, _ = fmt.Fprintf(l.stdout(), "[INFO] "+format+"\n", v...)
 	}
 }
 
 // Warnf logs a warning message using Printf conventions.
 func (l *LeveledLogger) Warnf(format string, v ...interface{}) {
 	if l.Level >= LevelWarn {
-		fmt.Fprintf(l.stderr(), "[WARN] "+format+"\n", v...)
+		_, _ = fmt.Fprintf(l.stderr(), "[WARN] "+format+"\n", v...)
 	}
 }
 

--- a/mage/install/install.go
+++ b/mage/install/install.go
@@ -11,7 +11,7 @@ const (
 	GolangCILintVersion = "v1.50.1"
 )
 
-// install all dependencies
+// Dependencies install all dependencies
 func Dependencies() error {
 	fmt.Println("Installing Dependencies...")
 	mg.Deps(Golangcilint)
@@ -19,7 +19,7 @@ func Dependencies() error {
 	return nil
 }
 
-// install golangci-lint
+// Golangcilint install golangci-lint
 func Golangcilint() error {
 	fmt.Println("Installing GolangCI Lint...")
 	cmd := exec.Command("go", "install", "github.com/golangci/golangci-lint/cmd/golangci-lint@"+GolangCILintVersion)

--- a/mage/test/test.go
+++ b/mage/test/test.go
@@ -6,25 +6,25 @@ import (
 	"github.com/magefile/mage/sh"
 )
 
-// run all unit tests
+// Unit run all unit tests
 func Unit() error {
 	fmt.Println("Running Tests...")
 	return sh.RunV("go", "test")
 }
 
-// run a test build to confirm no compilation errors
+// Build run a test build to confirm no compilation errors
 func Build() error {
 	fmt.Println("Running Build...")
 	return sh.RunV("go", "build", "-tags", "test")
 }
 
-// run all unit tests and output coverage
+// Coverage run all unit tests and output coverage
 func Coverage() error {
 	fmt.Println("Running Tests with Coverage...")
 	return sh.RunV("go", "test", "-race", "-coverprofile=coverage.txt", "-covermode=atomic")
 }
 
-// run all integration tests against a pve node, see ./tests/integration
+// Integration run all integration tests against a pve node, see ./tests/integration
 func Integration() error {
 	fmt.Println("Running Integration Tests against a PVE Cluster...")
 	return sh.RunV("go", "test", "./tests/integration", "-tags", "nodes containers vms")

--- a/proxmox.go
+++ b/proxmox.go
@@ -26,25 +26,25 @@ const (
 var ErrNotAuthorized = errors.New("not authorized to access endpoint")
 
 func IsNotAuthorized(err error) bool {
-	return err == ErrNotAuthorized
+	return errors.Is(err, ErrNotAuthorized)
 }
 
 var ErrTimeout = errors.New("the operation has timed out")
 
 func IsTimeout(err error) bool {
-	return err == ErrTimeout
+	return errors.Is(err, ErrTimeout)
 }
 
 var ErrNotFound = errors.New("unable to find the item you are looking for")
 
 func IsNotFound(err error) bool {
-	return err == ErrNotFound
+	return errors.Is(err, ErrNotFound)
 }
 
 var ErrNoop = errors.New("nothing to do")
 
 func IsErrNoop(err error) bool {
-	return err == ErrNoop
+	return errors.Is(err, ErrNoop)
 }
 
 func MakeTag(v string) string {
@@ -94,7 +94,7 @@ func (c *Client) Req(method, path string, data []byte, v interface{}) error {
 	var body io.Reader
 	if data != nil {
 		if path != (c.baseURL + "/access/ticket") {
-			// dont show passwords in the logs
+			// don't show passwords in the logs
 			if len(data) < 2048 {
 				c.log.Debugf("DATA: %s", string(data))
 			} else {
@@ -257,7 +257,7 @@ func (c *Client) handleResponse(res *http.Response, v interface{}) error {
 
 	if res.Request != nil && res.Request.URL != nil {
 		if res.Request.URL.String() != (c.baseURL + "/access/ticket") {
-			// dont show tokens out of the logs
+			// don't show tokens out of the logs
 			c.log.Debugf("BODY: %s", string(body))
 		}
 	}
@@ -422,7 +422,7 @@ func (c *Client) VNCWebSocket(path string, vnc *VNC) (chan string, chan string, 
 					errs <- err
 				}
 			case msg := <-send:
-				c.log.Debugf("sending: %s", string(msg))
+				c.log.Debugf("sending: %s", msg)
 				m := []byte(msg)
 				send := append([]byte(fmt.Sprintf("0:%d:", len(m))), m...)
 				if err := conn.WriteMessage(websocket.BinaryMessage, send); err != nil {

--- a/storage.go
+++ b/storage.go
@@ -46,11 +46,14 @@ func (s *Storage) DownloadURL(content, filename, url string) (*Task, error) {
 	}
 
 	var upid UPID
-	s.client.Post(fmt.Sprintf("/nodes/%s/storage/%s/download-url", s.Node, s.Name), map[string]string{
+	err := s.client.Post(fmt.Sprintf("/nodes/%s/storage/%s/download-url", s.Node, s.Name), map[string]string{
 		"content":  content,
 		"filename": filename,
 		"url":      url,
 	}, &upid)
+	if err != nil {
+		return nil, err
+	}
 	return NewTask(upid, s.client), nil
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -142,7 +142,10 @@ func (t *Task) WaitFor(seconds int) error {
 
 func (t *Task) Wait(interval, max time.Duration) error {
 	// ping it quick to fill in all the details we need in case they're not there
-	t.Ping()
+	err := t.Ping()
+	if err != nil {
+		return err
+	}
 	t.client.log.Debugf("waiting for %s, checking every %fs for %fs", t.UPID, interval.Seconds(), max.Seconds())
 
 	timeout := time.After(max)
@@ -152,7 +155,7 @@ func (t *Task) Wait(interval, max time.Duration) error {
 			t.client.log.Debugf("timed out waiting for task %s for %fs", t.UPID, max.Seconds())
 			return ErrTimeout
 		default:
-			if err := t.Ping(); err != nil {
+			if err = t.Ping(); err != nil {
 				return err
 			}
 

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestNewTask(t *testing.T) {
-	upid := NewTask(UPID(""), &Client{})
+	upid := NewTask("", &Client{})
 	assert.Nil(t, upid)
 
 	task := NewTask(UPID("UPID:nodename:00388B23:02D69651:63C4F6AF:tasktype:100:root@pam:"), &Client{})

--- a/tests/integration/tasks_test.go
+++ b/tests/integration/tasks_test.go
@@ -58,7 +58,7 @@ func TestTask_JsonUnmarshalWithEndTime(t *testing.T) {
 
 // TestTask will start a download of a large iso, tail the logs and cancel it
 func TestTask(t *testing.T) {
-	// download ubuntu iso for long running task to test against
+	// download ubuntu iso for long-running task to test against
 	isoName := nameGenerator(12) + ".iso"
 	task, err := td.storage.DownloadURL("iso", isoName, ubuntuURL)
 	assert.Nil(t, err)

--- a/tests/integration/virtual_machines_test.go
+++ b/tests/integration/virtual_machines_test.go
@@ -117,7 +117,7 @@ func TestNode_NewVirtualMachine(t *testing.T) {
 	send <- "hostname"
 	time.Sleep(2 * time.Second)
 
-	// Reboot disabled for now doesnt work great w/o the guest agent installed so will uncomment when that's done
+	// Reboot disabled for now doesn't work great w/o the guest agent installed so will uncomment when that's done
 	//task, err = vm.Reboot()
 	//assert.NoError(t, err)
 	//assert.NoError(t, task.Wait(1*time.Second, 60*time.Second))

--- a/types.go
+++ b/types.go
@@ -267,7 +267,8 @@ type Time struct {
 	Localtime uint64
 }
 
-// VirtualMachineOptions
+// VirtualMachineOptions A key/value pair used to modify a virtual machine config
+// Refer to https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/config for a list of valid values
 type VirtualMachineOptions []*VirtualMachineOption
 type VirtualMachineOption struct {
 	Name  string
@@ -781,9 +782,9 @@ func (b *IntOrBool) MarshalJSON() ([]byte, error) {
 
 type NodeNetworks []*NodeNetwork
 type NodeNetwork struct {
-	client  *Client `json:"-"`
-	Node    string  `json:"-"`
-	NodeAPI *Node   `json:"-"`
+	client  *Client
+	Node    string `json:"-"`
+	NodeAPI *Node  `json:"-"`
 
 	Iface    string `json:"iface,omitempty"`
 	BondMode string `json:"bond_mode,omitempty"`

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -111,7 +111,7 @@ func (v *VirtualMachine) SplitTags() {
 }
 
 // CloudInit takes four yaml docs as a string and make an ISO, upload it to the data store as <vmid>-user-data.iso and will
-// mount it as a CDROM to be used with nocloud cloud-init. This is NOT how proxmox expects a user to do cloud-init
+// mount it as a CD-ROM to be used with nocloud cloud-init. This is NOT how proxmox expects a user to do cloud-init
 // which can be found here: https://pve.proxmox.com/wiki/Cloud-Init_Support#:~:text=and%20meta.-,Cloud%2DInit%20specific%20Options,-cicustom%3A%20%5Bmeta
 // If you want to use the proxmox implementation you'll need to use the cloudinit APIs https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/cloudinit
 func (v *VirtualMachine) CloudInit(device, userdata, metadata, vendordata, networkconfig string) error {
@@ -219,7 +219,7 @@ func makeCloudInitISO(filename, userdata, metadata, vendordata, networkconfig st
 
 // VNCWebSocket copy/paste when calling to get the channel names right
 // send, recv, errors, closer, errors := vm.VNCWebSocket(vnc)
-// for this to work you need to first setup a serial terminal on your vm https://pve.proxmox.com/wiki/Serial_Terminal
+// for this to work you need to first set up a serial terminal on your vm https://pve.proxmox.com/wiki/Serial_Terminal
 func (v *VirtualMachine) VNCWebSocket(vnc *VNC) (chan string, chan string, chan error, func() error, error) {
 	p := fmt.Sprintf("/nodes/%s/qemu/%d/vncwebsocket?port=%d&vncticket=%s",
 		v.Node, v.VMID, vnc.Port, url.QueryEscape(vnc.Ticket))

--- a/virtual_machine_config.go
+++ b/virtual_machine_config.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (vmc *VirtualMachineConfig) mergeIndexedDevices(prefix string) map[string]string {
-	deviceMap := make(map[string]string, 0)
+	deviceMap := make(map[string]string)
 	t := reflect.TypeOf(*vmc)
 	v := reflect.ValueOf(*vmc)
 	count := v.NumField()


### PR DESCRIPTION
This PR aims to solve part of the warnings raised by the Goland IDE. Leaving aside a few potentially more controversial ones (like unused unexported functions or deferring without handling errors).