### PR TITLE
refactor pools to drop PoolAPI and add pool resource filters

### DIFF
--- a/pools_test.go
+++ b/pools_test.go
@@ -1,18 +1,20 @@
 package proxmox
 
 import (
+	"testing"
+
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
-func TestPoolList(t *testing.T) {
+func TestPools(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
 
-	_, err := client.Pools().List()
+	pools, err := client.Pools()
 	assert.Nil(t, err)
+	assert.Len(t, pools, 1)
 }
 
 func TestPoolGet(t *testing.T) {
@@ -20,13 +22,13 @@ func TestPoolGet(t *testing.T) {
 	defer mocks.Off()
 	client := mockClient()
 
-	pool, err := client.Pools().Get("test-pool")
+	pool, err := client.Pool("test-pool")
 	assert.Nil(t, err)
 	assert.NotNil(t, pool)
 	if pool != nil {
 		assert.Equal(t, "test-pool", pool.PoolID)
 		assert.Equal(t, "Test pool", pool.Comment)
-		assert.Len(t, pool.Members, 2)
+		assert.Len(t, pool.Members, 3)
 	}
 }
 
@@ -35,10 +37,7 @@ func TestPoolCreate(t *testing.T) {
 	defer mocks.Off()
 	client := mockClient()
 
-	err := client.Pools().Create(&PoolCreateOption{
-		PoolID:  "test-pool",
-		Comment: "Test pool",
-	})
+	err := client.NewPool("test-pool", "Test pool")
 	assert.Nil(t, err)
 }
 
@@ -47,7 +46,7 @@ func TestPoolUpdate(t *testing.T) {
 	defer mocks.Off()
 	client := mockClient()
 
-	pool, err := client.Pools().Get("test-pool")
+	pool, err := client.Pool("test-pool")
 
 	assert.Nil(t, err)
 	assert.NotNil(t, pool)
@@ -67,7 +66,7 @@ func TestPoolDelete(t *testing.T) {
 	defer mocks.Off()
 	client := mockClient()
 
-	pool, err := client.Pools().Get("test-pool")
+	pool, err := client.Pool("test-pool")
 
 	assert.Nil(t, err)
 	assert.NotNil(t, pool)

--- a/tests/mocks/pve7x/pools.go
+++ b/tests/mocks/pve7x/pools.go
@@ -62,7 +62,19 @@ func pool() {
         "vmid": 106,
         "maxdisk": 10737418240,
         "maxmem": 2147483648
-      }
+      },
+	  {
+		"node": "node1",
+		"maxdisk": 948340654080,
+		"type": "storage",
+		"id": "storage/node1/local",
+		"status": "available",
+		"storage": "local",
+		"content": "backup,vztmpl,iso",
+		"plugintype": "dir",
+		"disk": 10486939648,
+		"shared": 0
+	  }
     ]
   }
 }`)

--- a/types.go
+++ b/types.go
@@ -916,10 +916,6 @@ type Snapshot struct {
 	Snapstate   string
 }
 
-type PoolAPI struct {
-	client *Client
-}
-
 type Pools []*Pool
 type Pool struct {
 	client  *Client
@@ -928,18 +924,13 @@ type Pool struct {
 	Members []ClusterResource `json:"members,omitempty"`
 }
 
-type PoolCreateOption struct {
-	PoolID  string `json:"poolid"`
-	Comment string `json:"comment,omitempty"`
-}
-
 type PoolUpdateOption struct {
 	Comment string `json:"comment,omitempty"`
 	// Delete objects rather than adding them
 	Delete bool `json:"delete,omitempty"`
-	// Add or delete storage objects
+	// Comma separated lists of Storage names to add/delete to the pool
 	Storage string `json:"storage,omitempty"`
-	// Add or delete virtual machine objects
+	// Comma separated lists of Virtual Machine IDs to add/delete to the pool
 	VirtualMachines string `json:"vms,omitempty"`
 }
 


### PR DESCRIPTION
* removed PoolAPI in favor of top level `Pool(s)`
* added filter for cluster resources to Pool
* replaced `Create` with `NewPool` 