### PR TITLE
Add support for LXC clone

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -12,7 +12,7 @@ func (c *Container) Clone(ctx context.Context, params *ContainerCloneOptions) (n
 	if params == nil {
 		params = &ContainerCloneOptions{}
 	}
-	if params.NewID == 0 {
+	if params.NewID <= 0 {
 		cluster, err := c.client.Cluster(ctx)
 		if err != nil {
 			return newid, nil, err
@@ -24,7 +24,7 @@ func (c *Container) Clone(ctx context.Context, params *ContainerCloneOptions) (n
 		params.NewID = newid
 	}
 	if err := c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/clone", c.Node, c.VMID), params, &upid); err != nil {
-		return newid, nil, err
+		return 0, nil, err
 	}
 	return newid, NewTask(upid, c.client), nil
 }

--- a/types.go
+++ b/types.go
@@ -647,6 +647,18 @@ type Container struct {
 	MaxSwap uint64
 }
 
+type ContainerCloneOptions struct {
+	NewID       int    `json:"newid"`
+	BWLimit     uint64 `json:"bwlimit,omitempty"`
+	Description string `json:"description,omitempty"`
+	Full        uint8  `json:"full,omitempty"`
+	Hostname    string `json:"hostname,omitempty"`
+	Pool        string `json:"pool,omitempty"`
+	SnapName    string `json:"snapname,omitempty"`
+	Storage     string `json:"storage,omitempty"`
+	Target      string `json:"target,omitempty"`
+}
+
 type ContainerStatuses []*ContainerStatus
 type ContainerStatus struct {
 	Data string `json:",omitempty"`


### PR DESCRIPTION
Hi, 

I'm currently working on a Kubernetes operator for Proxmox and am impressed by the "go-proxmox" project. I realized that cloning an LXC is not implemented by the client so my PR tries to have an implementation of LXC cloning.

Here is the relevant API documentation on [Proxmox](https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/clone): 