### PR TITLE
still return a cluster if no sys.audit access

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -11,7 +11,17 @@ func (c *Client) Cluster(ctx context.Context) (*Cluster, error) {
 	cluster := &Cluster{
 		client: c,
 	}
-	return cluster, c.Get(ctx, "/cluster/status", cluster)
+
+	// requires (/, Sys.Audit), do not error out if no access to still get the cluster
+	if err := cluster.Status(ctx); !IsNotAuthorized(err) {
+		return cluster, err
+	}
+
+	return cluster, nil
+}
+
+func (cl *Cluster) Status(ctx context.Context) error {
+	return cl.client.Get(ctx, "/cluster/status", cl)
 }
 
 func (cl *Cluster) NextID(ctx context.Context) (int, error) {


### PR DESCRIPTION
cluster status requires sys.audit and being a part of the cluster call it errors out without access. this lets the cluster still come back which you can list but can't get status details