### PR TITLE
Fix live migrations

### DIFF
--- a/types.go
+++ b/types.go
@@ -535,6 +535,17 @@ type VirtualMachineConfig struct {
 	IPConfig9 string            `json:"ipconfig9,omitempty"`
 }
 
+type VirtualMachineMigrateOptions struct {
+	Target           string    `json:"target"`
+	BWLimit          uint64    `json:"bwlimit,omitempty"`
+	Force            IntOrBool `json:"force,omitempty"`
+	MigrationNetwork string    `json:"migration_network,omitempty"`
+	MigrationType    string    `json:"migration_type,omitempty"`
+	Online           IntOrBool `json:"online,omitempty"`
+	TargetStorage    string    `json:"targetstorage,omitempty"`
+	WithLocalDisks   IntOrBool `json:"with-local-disks,omitempty"`
+}
+
 type VirtualMachineCloneOptions struct {
 	NewID       int    `json:"newid"`
 	BWLimit     uint64 `json:"bwlimit,omitempty"`

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -361,7 +361,9 @@ func (v *VirtualMachine) deleteCloudInitISO(ctx context.Context) (ok bool, err e
 func (v *VirtualMachine) Migrate(ctx context.Context, target, targetstorage string) (task *Task, err error) {
 	var upid UPID
 	params := map[string]string{
-		"target": target,
+		"target":           target,
+		"online":           "1",
+		"with-local-disks": "1",
 	}
 	if targetstorage != "" {
 		params["targetstorage"] = targetstorage

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -358,17 +358,17 @@ func (v *VirtualMachine) deleteCloudInitISO(ctx context.Context) (ok bool, err e
 	return true, nil
 }
 
-func (v *VirtualMachine) Migrate(ctx context.Context, target, targetstorage string) (task *Task, err error) {
+func (v *VirtualMachine) Migrate(
+	ctx context.Context,
+	params *VirtualMachineMigrateOptions,
+) (task *Task, err error) {
 	var upid UPID
-	params := map[string]string{
-		"target":           target,
-		"online":           "1",
-		"with-local-disks": "1",
+
+	if params == nil {
+		params = &VirtualMachineMigrateOptions{}
 	}
-	if targetstorage != "" {
-		params["targetstorage"] = targetstorage
-	}
-	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/migrate", v.Node, v.VMID), params, &upid); err != nil {
+
+	if err = v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/migrate", v.Node, v.VMID), params, &upid); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Add missing flags to allow live migration, with local disks.

Those flags are not supposed to do anything with offline VM and shouldn't change the current behavior too much, except if someone relied on migration failing.