### PR TITLE
fix: Return array for Getcontent method

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -107,7 +107,7 @@ func (s *Storage) downloadURL(ctx context.Context, content, filename, url string
 	return NewTask(upid, s.client), nil
 }
 
-func (s *Storage) GetContent(ctx context.Context) (content *StorageContent, err error) {
+func (s *Storage) GetContent(ctx context.Context) (content []*StorageContent, err error) {
 	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/storage/%s/content", s.Node, s.Name), &content)
 	return content, err
 }


### PR DESCRIPTION
This PR aims to fix the issue generated by #111. The return object should be an array according to the API docs.