### PR TITLE
Add function that Unmount Cloud ISO if not needed

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -645,18 +645,20 @@ func (v *VirtualMachine) ConvertToTemplate(ctx context.Context) (task *Task, err
 }
 
 func (v *VirtualMachine) UnmountCloudInitISO(ctx context.Context, device string) error {
-	if v.HasTag(MakeTag(TagCloudInit)) {
-		if ok, err := v.deleteCloudInitISO(ctx); err != nil || !ok {
-			return err
-		}
-		task, err := v.Config(ctx, VirtualMachineOption{
-			Name:  device,
-			Value: "none,media=cdrom",
-		})
-		if err != nil {
-			return err
-		}
-		return task.WaitFor(ctx, 5)
+	if !v.HasTag(MakeTag(TagCloudInit)) {
+		return nil
+	}
+
+	_, err := v.Config(ctx, VirtualMachineOption{
+		Name:  device,
+		Value: "none,media=cdrom",
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err = v.deleteCloudInitISO(ctx); err != nil {
+		return err
 	}
 	return nil
 }

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -643,3 +643,20 @@ func (v *VirtualMachine) ConvertToTemplate(ctx context.Context) (task *Task, err
 	}
 	return NewTask(upid, v.client), nil
 }
+
+func (v *VirtualMachine) UnmountCloudInitISO(ctx context.Context, device string) error {
+	if v.HasTag(MakeTag(TagCloudInit)) {
+		if ok, err := v.deleteCloudInitISO(ctx); err != nil || !ok {
+			return err
+		}
+		task, err := v.Config(ctx, VirtualMachineOption{
+			Name:  device,
+			Value: "none,media=cdrom",
+		})
+		if err != nil {
+			return err
+		}
+		return task.WaitFor(ctx, 5)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR:

- Adds a function `UnmountCloudInitISO` to unattach and delete the cloudinit iso.


Closes #127