### PR TITLE
Fix AgentExec when no pid returned

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -509,7 +509,12 @@ func (v *VirtualMachine) AgentExec(ctx context.Context, command []string, inputD
 			"input-data": inputData,
 		},
 		&tmpdata)
-	pid = int(tmpdata["pid"].(float64))
+
+	p := tmpdata["pid"]
+	if p == nil {
+		return 0, fmt.Errorf("no pid returned from agent exec command")
+	}
+	pid = int(p.(float64))
 	return
 }
 


### PR DESCRIPTION
That caused a panic:

Fix the AgentExec func to return error if no pid, has returned.

`oup="infrastructure.cluster.x-k8s.io" controllerKind="ProxmoxMachine" ProxmoxMachine="default/test-dev-control-plane-ptkhg" namespace="default" name="test-dev-control-plane-ptkhg" reconcileID="8013f2cd-4d25-4072-9c80-7d79af7191a4"
panic: interface conversion: interface {} is nil, not float64 [recovered]
        panic: interface conversion: interface {} is nil, not float64
`