### PR TITLE
Fix typos in Nodes endpoint response

### DIFF
--- a/sdn_vnets.go
+++ b/sdn_vnets.go
@@ -1,0 +1,64 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+)
+
+type Vnet struct {
+	client    *Client
+	Vnet      string
+	Zone      string
+	Alias     string
+	Tag       int
+	VlanAware bool
+}
+
+type VnetStatus struct {
+	client  *Client
+	Vnet    string
+	Pending bool
+	Running bool
+}
+
+type VnetOptions []*VnetOption
+type VnetOption struct {
+	Name  string
+	Value interface{}
+}
+
+func (c *Client) Vnets(ctx context.Context, pending bool, running bool) (vnets []VnetStatus, err error) {
+	return vnets, c.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets?pending=%s&running=%s", pending, running), &vnets)
+}
+
+func (c *Client) Vnet(ctx context.Context, name string) (vnet *VnetStatus, err error) {
+
+	if err = c.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s", name), &vnet); err != nil {
+		return nil, err
+	}
+
+	vnet.client = c
+
+	return
+}
+
+func (c *Client) NewVnet(ctx context.Context, vnet string, zone string, options ...VnetOption) (ret string, err error) {
+	data := make(map[string]interface{})
+	data["vnet"] = vnet
+	data["zone"] = zone
+
+	for _, option := range options {
+		data[option.Name] = option.Value
+	}
+
+	err = c.Post(ctx, "/cluster/sdn/vnets", data, &ret)
+	return ret, err
+}
+
+func (z *Vnet) Update(ctx context.Context, options ...VnetOption) error {
+	return z.client.Put(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s", z.Vnet), nil, nil)
+}
+
+func (z *Vnet) Delete(ctx context.Context) error {
+	return z.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s", z.Vnet), nil)
+}

--- a/sdn_zones.go
+++ b/sdn_zones.go
@@ -1,0 +1,55 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+)
+
+type Zone struct {
+	client *Client
+	Zone   string
+	Type   string
+}
+
+type ZoneStatus struct {
+	Zone    string
+	Pending bool
+	Running bool
+}
+
+type ZoneOptions []*ZoneOption
+type ZoneOption struct {
+	Name  string
+	Value interface{}
+}
+
+func (c *Client) Zones(ctx context.Context) (zones []ZoneStatus, err error) {
+	return zones, c.Get(ctx, "/cluster/sdn/zones", &zones)
+}
+
+func (c *Client) Zone(ctx context.Context, name string) (zone *Zone, err error) {
+
+	if err = c.Get(ctx, fmt.Sprintf("/cluster/sdn/zones/%s", name), &zone); err != nil {
+		return nil, err
+	}
+
+	zone.client = c
+
+	return
+}
+
+func (c *Client) NewZone(ctx context.Context, name string, options ...ZoneOption) (ret string, err error) {
+	data := make(map[string]interface{})
+	data["zone"] = name
+
+	for _, option := range options {
+		data[option.Name] = option.Value
+	}
+
+	err = c.Post(ctx, "/cluster/sdn/zones", data, &ret)
+	return ret, err
+}
+
+func (z *Zone) Delete(ctx context.Context) error {
+	return z.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/zones/%s", z.Zone), nil)
+}

--- a/sdn_zones.go
+++ b/sdn_zones.go
@@ -3,12 +3,37 @@ package proxmox
 import (
 	"context"
 	"fmt"
+	"strconv"
 )
 
 type Zone struct {
-	client *Client
-	Zone   string
-	Type   string
+	client                   *Client
+	Zone                     string `json:"zone"`
+	Type                     string `json:"type,omitempty"`
+	AdvertiseSubnets         bool   `json:"advertise-subnets,omitempty"`
+	Bridge                   string `json:"bridge,omitempty"`
+	BridgeDisableMacLearning bool   `json:"bridge-disable-mac-learning,omitempty"`
+	Controller               string `json:"controller,omitempty"`
+	Dhcp                     string `json:"dhcp,omitempty"`
+	DisableArpNdSuppression  bool   `json:"disable-arp-nd-suppression,omitempty"`
+	Dns                      string `json:"dns,omitempty"`
+	DnsZone                  string `json:"dnszone,omitempty"`
+	DpId                     int    `json:"dp-id,omitempty"`
+	Exitnodes                string `json:"exitnodes,omitempty"`
+	ExitnodesLocalRouting    bool   `json:"exitnodes-local-routing,omitempty"`
+	ExitnodesPrimary         string `json:"exitnodes-primary,omitempty"`
+	Ipam                     string `json:"ipam,omitempty"`
+	Mac                      string `json:"mac,omitempty"`
+	Mtu                      int    `json:"mtu,omitempty"`
+	Nodes                    string `json:"nodes,omitempty"`
+	Peers                    string `json:"peers,omitempty"`
+	Reversedns               string `json:"reversedns,omitempty"`
+	RtImport                 string `json:"rt-import,omitempty"`
+	Tag                      int    `json:"tag,omitempty"`
+	VlanProtocol             string `json:"vlan-protocol,omitempty"`
+	VrfVxlan                 int    `json:"vrf-vxlan,omitempty"`
+	VxlanPort                int    `json:"vxlan-port,omitempty"`
+	Digest                   string `json:"digest,omitempty"`
 }
 
 type ZoneStatus struct {
@@ -23,8 +48,38 @@ type ZoneOption struct {
 	Value interface{}
 }
 
-func (c *Client) Zones(ctx context.Context) (zones []ZoneStatus, err error) {
-	return zones, c.Get(ctx, "/cluster/sdn/zones", &zones)
+type ZoneConfig struct {
+	Zone                     string `json:"zone"`
+	Type                     string `json:"type,omitempty"`
+	AdvertiseSubnets         bool   `json:"advertise-subnets,omitempty"`
+	Bridge                   string `json:"bridge,omitempty"`
+	BridgeDisableMacLearning bool   `json:"bridge-disable-mac-learning,omitempty"`
+	Controller               string `json:"controller,omitempty"`
+	Dhcp                     string `json:"dhcp,omitempty"`
+	DisableArpNdSuppression  bool   `json:"disable-arp-nd-suppression,omitempty"`
+	Dns                      string `json:"dns,omitempty"`
+	DnsZone                  string `json:"dnszone,omitempty"`
+	DpId                     int    `json:"dp-id,omitempty"`
+	Exitnodes                string `json:"exitnodes,omitempty"`
+	ExitnodesLocalRouting    bool   `json:"exitnodes-local-routing,omitempty"`
+	ExitnodesPrimary         string `json:"exitnodes-primary,omitempty"`
+	Ipam                     string `json:"ipam,omitempty"`
+	Mac                      string `json:"mac,omitempty"`
+	Mtu                      int    `json:"mtu,omitempty"`
+	Nodes                    string `json:"nodes,omitempty"`
+	Peers                    string `json:"peers,omitempty"`
+	Reversedns               string `json:"reversedns,omitempty"`
+	RtImport                 string `json:"rt-import,omitempty"`
+	Tag                      int    `json:"tag,omitempty"`
+	VlanProtocol             string `json:"vlan-protocol,omitempty"`
+	VrfVxlan                 int    `json:"vrf-vxlan,omitempty"`
+	VxlanPort                int    `json:"vxlan-port,omitempty"`
+}
+
+func (c *Client) Zones(ctx context.Context, pending bool, running bool) (zones []ZoneStatus, err error) {
+	pendingStr := strconv.FormatBool(pending)
+	runningStr := strconv.FormatBool(running)
+	return zones, c.Get(ctx, fmt.Sprintf("/cluster/sdn/zones?pending=%v&running=%v", pendingStr, runningStr), &zones)
 }
 
 func (c *Client) Zone(ctx context.Context, name string) (zone *Zone, err error) {
@@ -38,16 +93,17 @@ func (c *Client) Zone(ctx context.Context, name string) (zone *Zone, err error) 
 	return
 }
 
-func (c *Client) NewZone(ctx context.Context, name string, options ...ZoneOption) (ret string, err error) {
-	data := make(map[string]interface{})
-	data["zone"] = name
+func (c *Client) NewZone(ctx context.Context, config ZoneConfig) (zone *Zone, err error) {
 
-	for _, option := range options {
-		data[option.Name] = option.Value
+	if err = c.Post(ctx, "/cluster/sdn/zones", config, nil); err != nil {
+		return nil, err
 	}
 
-	err = c.Post(ctx, "/cluster/sdn/zones", data, &ret)
-	return ret, err
+	return c.Zone(ctx, config.Zone)
+}
+
+func (z *Zone) Update(ctx context.Context, config ZoneConfig) error {
+	return z.client.Put(ctx, fmt.Sprintf("/cluster/sdn/zones/%s", z.Zone), config, nil)
 }
 
 func (z *Zone) Delete(ctx context.Context) error {

--- a/types.go
+++ b/types.go
@@ -201,6 +201,9 @@ type Node struct {
 	Ksm        Ksm
 	Uptime     uint64
 	Wait       float64
+
+	CurrentKernel CurrentKernel `json:"current-kernel"`
+	BootInfo      BootInfo      `json:"boot-info"`
 }
 
 type VirtualMachines []*VirtualMachine
@@ -248,8 +251,8 @@ type RootFS struct {
 
 type CPUInfo struct {
 	UserHz  int `json:"user_hz"`
-	MHZ     int
-	Mode    string
+	MHZ     string
+	Model   string
 	Cores   int
 	Sockets int
 	Flags   string
@@ -265,6 +268,18 @@ type Memory struct {
 
 type Ksm struct {
 	Shared int64
+}
+
+type CurrentKernel struct {
+	Release string
+	SysName string
+	Version string
+	Machine string
+}
+
+type BootInfo struct {
+	Mode       string
+	SecureBoot int
 }
 
 type Time struct {


### PR DESCRIPTION
Also add the CurrentKernel and BootInfo attributes.

Tested on Proxmox VE 8.2

Here is an example response from a test cluster I've recently started experimenting with to show the typos & new fields

```json
{
  "data": {
    "uptime": 457597,
    "cpu": 0.00487078384218172,
    "cpuinfo": {
      "model": "Intel(R) Core(TM) i5-9500T CPU @ 2.20GHz",
      "cpus": 6,
      "mhz": "3498.489",
      "flags": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx smx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb pti ssbd ibrs ibpb stibp tpr_shadow flexpriority ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 xsaves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp vnmi md_clear flush_l1d arch_capabilities",
      "sockets": 1,
      "hvm": "1",
      "cores": 6,
      "user_hz": 100
    },
    "swap": {
      "total": 8589930496,
      "used": 0,
      "free": 8589930496
    },
    "wait": 0.000354016870735012,
    "loadavg": [
      "0.01",
      "0.02",
      "0.00"
    ],
    "kversion": "Linux 6.8.12-1-pve #1 SMP PREEMPT_DYNAMIC PMX 6.8.12-1 (2024-08-05T16:17Z)",
    "pveversion": "pve-manager/8.2.4/faa83925c9641325",
    "current-kernel": {
      "release": "6.8.12-1-pve",
      "sysname": "Linux",
      "version": "#1 SMP PREEMPT_DYNAMIC PMX 6.8.12-1 (2024-08-05T16:17Z)",
      "machine": "x86_64"
    },
    "ksm": {
      "shared": 0
    },
    "memory": {
      "free": 14135144448,
      "total": 16572776448,
      "used": 2437632000
    },
    "boot-info": {
      "mode": "efi",
      "secureboot": 0
    },
    "idle": 0,
    "rootfs": {
      "free": 87486828544,
      "avail": 82316091392,
      "used": 13374898176,
      "total": 100861726720
    }
  }
}
