### PR TITLE
Add function CheckID

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -33,15 +33,19 @@ func (cl *Cluster) NextID(ctx context.Context) (int, error) {
 	return strconv.Atoi(ret)
 }
 
-func (cl *Cluster) IsVMIDTaken(ctx context.Context, vmid int) (bool, error) {
+// CheckID checks if the given vmid is free.
+// CheckID calls the /cluster/nextid endpoint with the "vmid" parameter.
+// The API documentation describes the check as: "Pass a VMID to assert that its free (at time of check)."
+// Returns true if the vmid is free, false otherwise.
+func (cl *Cluster) CheckID(ctx context.Context, vmid int) (bool, error) {
 	var ret string
 	err := cl.client.Get(ctx, fmt.Sprintf("/cluster/nextid?vmid=%d", vmid), ret)
 	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("VM %d already exists", vmid)) {
-		return true, nil
+		return false, nil
 	} else if err != nil {
 		return false, err
 	}
-	return false, nil
+	return true, nil
 }
 
 // Resources retrieves a summary list of all resources in the cluster.

--- a/cluster.go
+++ b/cluster.go
@@ -2,6 +2,7 @@ package proxmox
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
 	"strings"
@@ -30,6 +31,17 @@ func (cl *Cluster) NextID(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	return strconv.Atoi(ret)
+}
+
+func (cl *Cluster) IsVMIDTaken(ctx context.Context, vmid int) (bool, error) {
+	var ret string
+	err := cl.client.Get(ctx, fmt.Sprintf("/cluster/nextid?vmid=%d", vmid), ret)
+	if err != nil && strings.Contains(err.Error(), fmt.Sprintf("VM %d already exists", vmid)) {
+		return true, nil
+	} else if err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 // Resources retrieves a summary list of all resources in the cluster.

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -37,7 +37,7 @@ func TestNextID(t *testing.T) {
 	assert.Equal(t, 100, nextid)
 }
 
-func TestIsVMIDTaken(t *testing.T) {
+func TestCheckID(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -45,12 +45,12 @@ func TestIsVMIDTaken(t *testing.T) {
 
 	cluster, err := client.Cluster(ctx)
 	assert.Nil(t, err)
-	idtaken, err := cluster.IsVMIDTaken(ctx, 100)
+	checkIDFree, err := cluster.CheckID(ctx, 100)
 	assert.Nil(t, err)
-	assert.Equal(t, false, idtaken)
-	idtaken, err = cluster.IsVMIDTaken(ctx, 200)
+	assert.Equal(t, true, checkIDFree)
+	checkIDTaken, err := cluster.CheckID(ctx, 200)
 	assert.Nil(t, err)
-	assert.Equal(t, true, idtaken)
+	assert.Equal(t, false, checkIDTaken)
 }
 
 func TestCluster_Resources(t *testing.T) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -37,6 +37,22 @@ func TestNextID(t *testing.T) {
 	assert.Equal(t, 100, nextid)
 }
 
+func TestIsVMIDTaken(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+	idtaken, err := cluster.IsVMIDTaken(ctx, 100)
+	assert.Nil(t, err)
+	assert.Equal(t, false, idtaken)
+	idtaken, err = cluster.IsVMIDTaken(ctx, 200)
+	assert.Nil(t, err)
+	assert.Equal(t, true, idtaken)
+}
+
 func TestCluster_Resources(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/tests/mocks/pve7x/cluster.go
+++ b/tests/mocks/pve7x/cluster.go
@@ -7,9 +7,21 @@ import (
 
 func cluster() {
 	gock.New(config.C.URI).
-		Get("/cluster/nextid").
+		Get("/cluster/nextid$").
 		Reply(200).
 		JSON(`{"data": "100"}`)
+
+	gock.New(config.C.URI).
+		Get("/cluster/nextid$").
+		MatchParam("vmid", "100").
+		Reply(200).
+		JSON(`{"data": "100"}`)
+
+	gock.New(config.C.URI).
+		Get("/cluster/nextid").
+		MatchParam("vmid", "200").
+		Reply(400).
+		JSON(`{"errors":{"vmid":"VM 200 already exists"},"data":null}`)
 
 	gock.New(config.C.URI).
 		Get("/cluster/status").


### PR DESCRIPTION
The Proxmox API endpoint `/cluster/nextid` takes an optional argument `vmid` to check if the given ID is free.
This argument is not implemented in the existing `NextID` function. In order not to break the existing API, I have added a new function `isVMIDTaken`.
This is especially useful if you want to check for a VMID without having `VM.Audit` privileges on the whole cluster.