### PR TITLE
feat: Add CIUpgrade field on VirtualMachineConfig

### DIFF
--- a/types.go
+++ b/types.go
@@ -520,6 +520,7 @@ type VirtualMachineConfig struct {
 	Searchdomain string `json:"searchdomain,omitempty"`
 	SSHKeys      string `json:"sshkeys,omitempty"`
 	CICustom     string `json:"cicustom,omitempty"`
+	CIUpgrade    int    `json:"ciupgrade,omitempty"`
 
 	// Cloud-init interfaces
 	IPConfigs map[string]string `json:"-"`


### PR DESCRIPTION
This PR tries to add a CIUpgrade field to VirtualMachineConfig struct.

Here is the relevant API doc:

https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/config

The field can be found as "ciupgrade" and also here is an example output from Proxmox cluster.

`{"boot":"order=scsi0","cipassword":"**********","ciupgrade":1,"ciuser":"ubuntu","cores":2,"digest":"b1d4d4d59a8bb982a9b173c3f5741207b0869a79","ide2":"local-lvm:vm-105-cloudinit,media=cdrom","memory":"2048","meta":"creation-qemu=8.1.5,ctime=1724765699","name":"virtualmachinetemplate-sample","nameserver":"10.0.0.1 10.0.0.2","net0":"virtio=BC:24:11:A7:27:31,bridge=vmbr0","scsi0":"local-lvm:base-105-disk-0,size=2252M","scsihw":"virtio-scsi-pci","searchdomain":"alperen.cloud","smbios1":"uuid=36e481f6-430b-4baf-b238-19dd0d891703","sockets":1,"template":1,"vmgenid":"13631d1d-eb61-45ec-a285-e63003b509eb"}`