### PR TITLE
Fix return value of `Clone` functions when `CloneOptions.NewID` is set

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -26,7 +26,7 @@ func (c *Container) Clone(ctx context.Context, params *ContainerCloneOptions) (n
 	if err := c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/clone", c.Node, c.VMID), params, &upid); err != nil {
 		return 0, nil, err
 	}
-	return newid, NewTask(upid, c.client), nil
+	return params.NewID, NewTask(upid, c.client), nil
 }
 
 func (c *Container) Delete(ctx context.Context) (task *Task, err error) {

--- a/containers.go
+++ b/containers.go
@@ -17,16 +17,18 @@ func (c *Container) Clone(ctx context.Context, params *ContainerCloneOptions) (n
 		if err != nil {
 			return newid, nil, err
 		}
-		newid, err := cluster.NextID(ctx)
+		newid, err = cluster.NextID(ctx)
 		if err != nil {
 			return newid, nil, err
 		}
 		params.NewID = newid
+	} else {
+		newid = params.NewID
 	}
 	if err := c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/clone", c.Node, c.VMID), params, &upid); err != nil {
 		return 0, nil, err
 	}
-	return params.NewID, NewTask(upid, c.client), nil
+	return newid, NewTask(upid, c.client), nil
 }
 
 func (c *Container) Delete(ctx context.Context) (task *Task, err error) {

--- a/containers_test.go
+++ b/containers_test.go
@@ -35,9 +35,25 @@ func TestContainerClone(t *testing.T) {
 	cloneOptions := ContainerCloneOptions{
 		NewID: 102,
 	}
-	_, _, err := container.Clone(ctx, &cloneOptions)
+	newid, _, err := container.Clone(ctx, &cloneOptions)
+	assert.Equal(t, cloneOptions.NewID, newid)
 	assert.Nil(t, err)
+}
 
+func TestContainerCloneWithoutNewID(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	container := Container{
+		client: client,
+		Node:   "node1",
+		VMID:   101,
+	}
+	cloneOptions := ContainerCloneOptions{}
+	newid, _, err := container.Clone(ctx, &cloneOptions)
+	assert.Equal(t, 100, newid)
+	assert.Nil(t, err)
 }
 
 func TestContainerDelete(t *testing.T) {

--- a/tests/mocks/pve7x/nodes.go
+++ b/tests/mocks/pve7x/nodes.go
@@ -1047,4 +1047,10 @@ func nodes() {
     "data": "UPID:node1:0031B740:0645340C:23E5BA99:vzrollback:101:root"
 }`)
 
+	gock.New(config.C.URI).
+		Post("^/nodes/node1/qemu/101/clone").
+		Reply(200).
+		JSON(`{
+    "data": null
+}`)
 }

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -167,7 +167,6 @@ func (v *VirtualMachine) CloudInit(ctx context.Context, device, userdata, metada
 		Name:  "boot",
 		Value: fmt.Sprintf("%s;%s", v.VirtualMachineConfig.Boot, device),
 	})
-
 	if err != nil {
 		return err
 	}
@@ -401,13 +400,15 @@ func (v *VirtualMachine) Clone(ctx context.Context, params *VirtualMachineCloneO
 			return newid, nil, err
 		}
 		params.NewID = newid
+	} else {
+		newid = params.NewID
 	}
 
 	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/clone", v.Node, v.VMID), params, &upid); err != nil {
 		return newid, nil, err
 	}
 
-	return params.NewID, NewTask(upid, v.client), nil
+	return newid, NewTask(upid, v.client), nil
 }
 
 func (v *VirtualMachine) ResizeDisk(ctx context.Context, disk, size string) (err error) {

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -407,7 +407,7 @@ func (v *VirtualMachine) Clone(ctx context.Context, params *VirtualMachineCloneO
 		return newid, nil, err
 	}
 
-	return newid, NewTask(upid, v.client), nil
+	return params.NewID, NewTask(upid, v.client), nil
 }
 
 func (v *VirtualMachine) ResizeDisk(ctx context.Context, disk, size string) (err error) {

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -39,3 +39,39 @@ func TestVirtualMachine_RRDData(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, rdddata, 70)
 }
+
+func TestVirtualMachineClone(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vmTemplate := VirtualMachine{
+		client:   client,
+		Node:     "node1",
+		Template: true,
+		VMID:     101,
+	}
+	cloneOptions := VirtualMachineCloneOptions{
+		NewID: 102,
+	}
+	newID, _, err := vmTemplate.Clone(ctx, &cloneOptions)
+	assert.Nil(t, err)
+	assert.Equal(t, cloneOptions.NewID, newID)
+}
+
+func TestVirtualMachineCloneWithoutNewID(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vmTemplate := VirtualMachine{
+		client:   client,
+		Node:     "node1",
+		Template: true,
+		VMID:     101,
+	}
+	cloneOptions := VirtualMachineCloneOptions{}
+	newID, _, err := vmTemplate.Clone(ctx, &cloneOptions)
+	assert.Nil(t, err)
+	assert.Equal(t, 100, newID)
+}


### PR DESCRIPTION
The `Clone` functions (`Container.Clone` and `VM.Clone`), when called with `CloneOptions.NewID` set, return 0 instead of the `NewID`.

I extended the tests. Updated `TestContainerClone` and new `TestVirtualMachineClone` tests fail without this fix.