### PR TITLE
fix: do not compare optional QMP Status field when determining VM status

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -243,7 +243,7 @@ func (v *VirtualMachine) VNCWebSocket(vnc *VNC) (chan []byte, chan []byte, chan 
 }
 
 func (v *VirtualMachine) IsRunning() bool {
-	return v.Status == StatusVirtualMachineRunning && v.QMPStatus == StatusVirtualMachineRunning
+	return v.Status == StatusVirtualMachineRunning
 }
 
 func (v *VirtualMachine) Start(ctx context.Context) (task *Task, err error) {
@@ -256,7 +256,7 @@ func (v *VirtualMachine) Start(ctx context.Context) (task *Task, err error) {
 }
 
 func (v *VirtualMachine) IsStopped() bool {
-	return v.Status == StatusVirtualMachineStopped && v.QMPStatus == StatusVirtualMachineStopped
+	return v.Status == StatusVirtualMachineStopped
 }
 
 func (v *VirtualMachine) Reset(ctx context.Context) (task *Task, err error) {
@@ -287,7 +287,7 @@ func (v *VirtualMachine) Stop(ctx context.Context) (task *Task, err error) {
 }
 
 func (v *VirtualMachine) IsPaused() bool {
-	return v.Status == StatusVirtualMachineRunning && v.QMPStatus == StatusVirtualMachinePaused
+	return v.Status == StatusVirtualMachineRunning
 }
 
 func (v *VirtualMachine) Pause(ctx context.Context) (task *Task, err error) {
@@ -300,7 +300,7 @@ func (v *VirtualMachine) Pause(ctx context.Context) (task *Task, err error) {
 }
 
 func (v *VirtualMachine) IsHibernated() bool {
-	return v.Status == StatusVirtualMachineStopped && v.QMPStatus == StatusVirtualMachineStopped && v.Lock == "suspended"
+	return v.Status == StatusVirtualMachineStopped && v.Lock == "suspended"
 }
 
 func (v *VirtualMachine) Hibernate(ctx context.Context) (task *Task, err error) {


### PR DESCRIPTION
Drops the use of the QMP Status field when determining if a VM is running, stopped, paused or hibernated.