### PR TITLE
Fix VM state functions

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -243,7 +243,7 @@ func (v *VirtualMachine) VNCWebSocket(vnc *VNC) (chan []byte, chan []byte, chan 
 }
 
 func (v *VirtualMachine) IsRunning() bool {
-	return v.Status == StatusVirtualMachineRunning
+	return v.Status == StatusVirtualMachineRunning && (v.QMPStatus == "" || v.QMPStatus == StatusVirtualMachineRunning)
 }
 
 func (v *VirtualMachine) Start(ctx context.Context) (task *Task, err error) {
@@ -256,7 +256,7 @@ func (v *VirtualMachine) Start(ctx context.Context) (task *Task, err error) {
 }
 
 func (v *VirtualMachine) IsStopped() bool {
-	return v.Status == StatusVirtualMachineStopped
+	return v.Status == StatusVirtualMachineStopped && (v.Lock != "suspended")
 }
 
 func (v *VirtualMachine) Reset(ctx context.Context) (task *Task, err error) {
@@ -287,7 +287,7 @@ func (v *VirtualMachine) Stop(ctx context.Context) (task *Task, err error) {
 }
 
 func (v *VirtualMachine) IsPaused() bool {
-	return v.Status == StatusVirtualMachinePaused
+	return v.Status == StatusVirtualMachineRunning && v.QMPStatus == StatusVirtualMachinePaused
 }
 
 func (v *VirtualMachine) Pause(ctx context.Context) (task *Task, err error) {

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -287,7 +287,7 @@ func (v *VirtualMachine) Stop(ctx context.Context) (task *Task, err error) {
 }
 
 func (v *VirtualMachine) IsPaused() bool {
-	return v.Status == StatusVirtualMachineRunning
+	return v.Status == StatusVirtualMachinePaused
 }
 
 func (v *VirtualMachine) Pause(ctx context.Context) (task *Task, err error) {

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -80,6 +80,44 @@ func TestVirtualMachineState(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	runningVM := VirtualMachine{
+		Status:    "running",
+		QMPStatus: "running",
+	}
+	assert.False(t, runningVM.IsStopped())
+	assert.False(t, runningVM.IsPaused())
+	assert.False(t, runningVM.IsHibernated())
+	assert.True(t, runningVM.IsRunning())
+	stoppedVM := VirtualMachine{
+		Status:    "stopped",
+		QMPStatus: "stopped",
+	}
+	assert.True(t, stoppedVM.IsStopped())
+	assert.False(t, stoppedVM.IsPaused())
+	assert.False(t, stoppedVM.IsHibernated())
+	assert.False(t, stoppedVM.IsRunning())
+	pausedVM := VirtualMachine{
+		Status:    "running",
+		QMPStatus: "paused",
+	}
+	assert.False(t, pausedVM.IsStopped())
+	assert.True(t, pausedVM.IsPaused())
+	assert.False(t, pausedVM.IsHibernated())
+	assert.False(t, pausedVM.IsRunning())
+	hibernatedVM := VirtualMachine{
+		Status:    "stopped",
+		QMPStatus: "stopped",
+		Lock:      "suspended",
+	}
+	assert.False(t, hibernatedVM.IsStopped())
+	assert.False(t, hibernatedVM.IsPaused())
+	assert.True(t, hibernatedVM.IsHibernated())
+	assert.False(t, hibernatedVM.IsRunning())
+}
+
+func TestVirtualMachineStateWithoutQMPStatus(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	runningVM := VirtualMachine{
 		Status: "running",
 	}
 	assert.False(t, runningVM.IsStopped())
@@ -93,18 +131,11 @@ func TestVirtualMachineState(t *testing.T) {
 	assert.False(t, stoppedVM.IsPaused())
 	assert.False(t, stoppedVM.IsHibernated())
 	assert.False(t, stoppedVM.IsRunning())
-	pausedVM := VirtualMachine{
-		Status: "paused",
-	}
-	assert.False(t, pausedVM.IsStopped())
-	assert.True(t, pausedVM.IsPaused())
-	assert.False(t, pausedVM.IsHibernated())
-	assert.False(t, pausedVM.IsRunning())
 	hibernatedVM := VirtualMachine{
 		Status: "stopped",
 		Lock:   "suspended",
 	}
-	assert.True(t, hibernatedVM.IsStopped())
+	assert.False(t, hibernatedVM.IsStopped())
 	assert.False(t, hibernatedVM.IsPaused())
 	assert.True(t, hibernatedVM.IsHibernated())
 	assert.False(t, hibernatedVM.IsRunning())

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -75,3 +75,37 @@ func TestVirtualMachineCloneWithoutNewID(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 100, newID)
 }
+
+func TestVirtualMachineState(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	runningVM := VirtualMachine{
+		Status: "running",
+	}
+	assert.False(t, runningVM.IsStopped())
+	assert.False(t, runningVM.IsPaused())
+	assert.False(t, runningVM.IsHibernated())
+	assert.True(t, runningVM.IsRunning())
+	stoppedVM := VirtualMachine{
+		Status: "stopped",
+	}
+	assert.True(t, stoppedVM.IsStopped())
+	assert.False(t, stoppedVM.IsPaused())
+	assert.False(t, stoppedVM.IsHibernated())
+	assert.False(t, stoppedVM.IsRunning())
+	pausedVM := VirtualMachine{
+		Status: "paused",
+	}
+	assert.False(t, pausedVM.IsStopped())
+	assert.True(t, pausedVM.IsPaused())
+	assert.False(t, pausedVM.IsHibernated())
+	assert.False(t, pausedVM.IsRunning())
+	hibernatedVM := VirtualMachine{
+		Status: "stopped",
+		Lock:   "suspended",
+	}
+	assert.True(t, hibernatedVM.IsStopped())
+	assert.False(t, hibernatedVM.IsPaused())
+	assert.True(t, hibernatedVM.IsHibernated())
+	assert.False(t, hibernatedVM.IsRunning())
+}


### PR DESCRIPTION
The fix for #139 (#166) breaks some VirtualMachine state functions.

I have tried to implement the functions in a way that works with and without a `VirtualMachine.QMPStatus`. Without a `QMPStatus`, we can't be sure of the paused state (because the `Status` of a paused VM is still `Running`).