### PR TITLE
feat: Query vm hostname

### DIFF
--- a/types.go
+++ b/types.go
@@ -1264,6 +1264,10 @@ type AgentNetworkIPAddress struct {
 	MacAddress    string `json:"mac-address"`
 }
 
+type AgentHostName struct {
+	HostName string `json:"host-name"`
+}
+
 type AgentNetworkIface struct {
 	Name            string                   `json:"name"`
 	HardwareAddress string                   `json:"hardware-address"`

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -467,6 +467,26 @@ func (v *VirtualMachine) MoveDisk(ctx context.Context, disk string, params *Virt
 	return NewTask(upid, v.client), nil
 }
 
+func (v *VirtualMachine) AgentGetHostName(ctx context.Context) (hostname *string, err error) {
+	node, err := v.client.Node(ctx, v.Node)
+	if err != nil {
+		return
+	}
+
+	results := map[string]*AgentHostName{}
+	hostname = nil
+	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-host-name", node.Name, v.VMID), &results)
+	if err != nil {
+		return
+	}
+	if result, ok := results["result"]; ok {
+		hostname = &result.HostName
+	} else {
+		err = fmt.Errorf("result is empty")
+	}
+	return
+}
+
 func (v *VirtualMachine) AgentGetNetworkIFaces(ctx context.Context) (iFaces []*AgentNetworkIface, err error) {
 	node, err := v.client.Node(ctx, v.Node)
 	if err != nil {

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -467,23 +467,23 @@ func (v *VirtualMachine) MoveDisk(ctx context.Context, disk string, params *Virt
 	return NewTask(upid, v.client), nil
 }
 
-func (v *VirtualMachine) AgentGetHostName(ctx context.Context) (hostname *string, err error) {
+func (v *VirtualMachine) AgentGetHostName(ctx context.Context) (hostname string, err error) {
 	node, err := v.client.Node(ctx, v.Node)
 	if err != nil {
 		return
 	}
 
 	results := map[string]*AgentHostName{}
-	hostname = nil
 	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-host-name", node.Name, v.VMID), &results)
 	if err != nil {
 		return
 	}
-	if result, ok := results["result"]; ok {
-		hostname = &result.HostName
-	} else {
+	result, ok := results["result"]
+	if !ok {
 		err = fmt.Errorf("result is empty")
+		return
 	}
+	hostname = result.HostName
 	return
 }
 


### PR DESCRIPTION
Add support for querying vm hostname via qemu-ga.

API Path at /nodes/{node}/qemu/{vmid}/agent/get-host-name