### PR TITLE
Adding firewall IPSet functionality 

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -253,12 +253,35 @@ func (c *Container) GetFirewallIPSet(ctx context.Context) (ipsets []*FirewallIPS
 	return ipsets, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset", c.Node, c.VMID), &ipsets)
 }
 
-func (c *Container) NewFirewallIPSet(ctx context.Context, ipset *FirewallIPSet) error {
+func (c *Container) NewFirewallIPSet(ctx context.Context, ipset *FirewallIPSetCreationOption) error {
 	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset", c.Node, c.VMID), ipset, nil)
 }
 
 func (c *Container) DeleteFirewallIPSet(ctx context.Context, name string, force bool) error {
 	return c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s", c.Node, c.VMID, name), map[string]interface{}{"force": force})
+}
+
+func (c *Container) GetFirewallIPSetEntries(ctx context.Context, name string) (entries []*FirewallIPSetEntry, err error) {
+	return entries, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s", c.Node, c.VMID, name), &entries)
+}
+
+func (c *Container) NewFirewallIPSetEntry(ctx context.Context, name string, entry *FirewallIPSetEntryCreationOption) error {
+	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s", c.Node, c.VMID, name), entry, nil)
+}
+
+func (c *Container) DeleteFirewallIPSetEntry(ctx context.Context, name string, cidr string, digest string) error {
+	return c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), map[string]interface{}{
+		"digest": digest,
+	})
+}
+
+func (c *Container) GetFirewallIPSetEntry(ctx context.Context, name string, cidr string) (entry *FirewallIPSetEntry, err error) {
+	err = c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), &entry)
+	return
+}
+
+func (c *Container) UpdateFirewallIPSetEntry(ctx context.Context, name string, cidr string, entry *FirewallIPSetEntryUpdateOption) error {
+	return c.client.Put(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), entry, nil)
 }
 
 func (c *Container) FirewallRules(ctx context.Context) (rules []*FirewallRule, err error) {

--- a/containers.go
+++ b/containers.go
@@ -254,6 +254,12 @@ func (c *Container) GetFirewallIPSet(ctx context.Context) (ipsets []*FirewallIPS
 }
 
 func (c *Container) NewFirewallIPSet(ctx context.Context, ipset *FirewallIPSetCreationOption) error {
+	if ipset == nil {
+		ipset = &FirewallIPSetCreationOption{}
+	}
+	if ipset.Name == "" {
+		return fmt.Errorf("ipset name is required")
+	}
 	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset", c.Node, c.VMID), ipset, nil)
 }
 
@@ -266,6 +272,12 @@ func (c *Container) GetFirewallIPSetEntries(ctx context.Context, name string) (e
 }
 
 func (c *Container) NewFirewallIPSetEntry(ctx context.Context, name string, entry *FirewallIPSetEntryCreationOption) error {
+	if entry == nil {
+		entry = &FirewallIPSetEntryCreationOption{}
+	}
+	if entry.CIDR == "" {
+		return fmt.Errorf("ipset entry cidr is required")
+	}
 	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s", c.Node, c.VMID, name), entry, nil)
 }
 

--- a/containers.go
+++ b/containers.go
@@ -253,13 +253,7 @@ func (c *Container) GetFirewallIPSet(ctx context.Context) (ipsets []*FirewallIPS
 	return ipsets, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset", c.Node, c.VMID), &ipsets)
 }
 
-func (c *Container) NewFirewallIPSet(ctx context.Context, ipset *FirewallIPSetCreationOption) error {
-	if ipset == nil {
-		ipset = &FirewallIPSetCreationOption{}
-	}
-	if ipset.Name == "" {
-		return fmt.Errorf("ipset name is required")
-	}
+func (c *Container) NewFirewallIPSet(ctx context.Context, ipset FirewallIPSetCreationOption) error {
 	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset", c.Node, c.VMID), ipset, nil)
 }
 
@@ -271,13 +265,7 @@ func (c *Container) GetFirewallIPSetEntries(ctx context.Context, name string) (e
 	return entries, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s", c.Node, c.VMID, name), &entries)
 }
 
-func (c *Container) NewFirewallIPSetEntry(ctx context.Context, name string, entry *FirewallIPSetEntryCreationOption) error {
-	if entry == nil {
-		entry = &FirewallIPSetEntryCreationOption{}
-	}
-	if entry.CIDR == "" {
-		return fmt.Errorf("ipset entry cidr is required")
-	}
+func (c *Container) NewFirewallIPSetEntry(ctx context.Context, name string, entry FirewallIPSetEntryCreationOption) error {
 	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/ipset/%s", c.Node, c.VMID, name), entry, nil)
 }
 

--- a/types.go
+++ b/types.go
@@ -1611,7 +1611,7 @@ type FirewallIPSet struct {
 }
 
 type FirewallIPSetCreationOption struct {
-	Name    string `json:"name,omitempty"`
+	Name    string `json:"name"`
 	Digest  string `json:"digest,omitempty"`
 	Comment string `json:"comment,omitempty"`
 	Rename  string `json:"rename,omitempty"`
@@ -1625,7 +1625,7 @@ type FirewallIPSetEntry struct {
 }
 
 type FirewallIPSetEntryCreationOption struct {
-	CIDR    string `json:"cidr,omitempty"`
+	CIDR    string `json:"cidr"`
 	Comment string `json:"comment,omitempty"`
 	NoMatch bool   `json:"nomatch,omitempty"`
 }

--- a/types.go
+++ b/types.go
@@ -1610,6 +1610,32 @@ type FirewallIPSet struct {
 	Comment string `json:"comment,omitempty"`
 }
 
+type FirewallIPSetCreationOption struct {
+	Name    string `json:"name,omitempty"`
+	Digest  string `json:"digest,omitempty"`
+	Comment string `json:"comment,omitempty"`
+	Rename  string `json:"rename,omitempty"`
+}
+
+type FirewallIPSetEntry struct {
+	CIDR    string `json:"cidr,omitempty"`
+	Digest  string `json:"digest,omitempty"`
+	Comment string `json:"comment,omitempty"`
+	NoMatch bool   `json:"nomatch,omitempty"`
+}
+
+type FirewallIPSetEntryCreationOption struct {
+	CIDR    string `json:"cidr,omitempty"`
+	Comment string `json:"comment,omitempty"`
+	NoMatch bool   `json:"nomatch,omitempty"`
+}
+
+type FirewallIPSetEntryUpdateOption struct {
+	Comment string `json:"comment,omitempty"`
+	Digest  string `json:"digest,omitempty"`
+	NoMatch bool   `json:"nomatch,omitempty"`
+}
+
 type (
 	VirtualMachineBackupMode               = string
 	VirtualMachineBackupCompress           = string

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -584,7 +584,7 @@ func (c *VirtualMachine) GetFirewallIPSet(ctx context.Context) (ipsets []*Firewa
 	return ipsets, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", c.Node, c.VMID), &ipsets)
 }
 
-func (c *VirtualMachine) NewFirewallIPSet(ctx context.Context, ipset *FirewallIPSetCreationOption) error {
+func (c *VirtualMachine) NewFirewallIPSet(ctx context.Context, ipset FirewallIPSetCreationOption) error {
 	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", c.Node, c.VMID), ipset, nil)
 }
 
@@ -596,7 +596,7 @@ func (c *VirtualMachine) GetFirewallIPSetEntries(ctx context.Context, name strin
 	return entries, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), &entries)
 }
 
-func (c *VirtualMachine) NewFirewallIPSetEntry(ctx context.Context, name string, entry *FirewallIPSetEntryCreationOption) error {
+func (c *VirtualMachine) NewFirewallIPSetEntry(ctx context.Context, name string, entry FirewallIPSetEntryCreationOption) error {
 	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), entry, nil)
 }
 

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -580,6 +580,41 @@ func (v *VirtualMachine) AgentSetUserPassword(ctx context.Context, password stri
 	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/set-user-password", v.Node, v.VMID), map[string]string{"password": password, "username": username}, nil)
 }
 
+func (c *VirtualMachine) GetFirewallIPSet(ctx context.Context) (ipsets []*FirewallIPSet, err error) {
+	return ipsets, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", c.Node, c.VMID), &ipsets)
+}
+
+func (c *VirtualMachine) NewFirewallIPSet(ctx context.Context, ipset *FirewallIPSetCreationOption) error {
+	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", c.Node, c.VMID), ipset, nil)
+}
+
+func (c *VirtualMachine) DeleteFirewallIPSet(ctx context.Context, name string, force bool) error {
+	return c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), map[string]interface{}{"force": force})
+}
+
+func (c *VirtualMachine) GetFirewallIPSetEntries(ctx context.Context, name string) (entries []*FirewallIPSetEntry, err error) {
+	return entries, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), &entries)
+}
+
+func (c *VirtualMachine) NewFirewallIPSetEntry(ctx context.Context, name string, entry *FirewallIPSetEntryCreationOption) error {
+	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), entry, nil)
+}
+
+func (c *VirtualMachine) DeleteFirewallIPSetEntry(ctx context.Context, name string, cidr string, digest string) error {
+	return c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), map[string]interface{}{
+		"digest": digest,
+	})
+}
+
+func (c *VirtualMachine) GetFirewallIPSetEntry(ctx context.Context, name string, cidr string) (entry *FirewallIPSetEntry, err error) {
+	err = c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), &entry)
+	return
+}
+
+func (c *VirtualMachine) UpdateFirewallIPSetEntry(ctx context.Context, name string, cidr string, entry *FirewallIPSetEntryUpdateOption) error {
+	return c.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), entry, nil)
+}
+
 func (v *VirtualMachine) FirewallOptionGet(ctx context.Context) (firewallOption *FirewallVirtualMachineOption, err error) {
 	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/options", v.Node, v.VMID), firewallOption)
 	return

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -580,39 +580,39 @@ func (v *VirtualMachine) AgentSetUserPassword(ctx context.Context, password stri
 	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/set-user-password", v.Node, v.VMID), map[string]string{"password": password, "username": username}, nil)
 }
 
-func (c *VirtualMachine) GetFirewallIPSet(ctx context.Context) (ipsets []*FirewallIPSet, err error) {
-	return ipsets, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", c.Node, c.VMID), &ipsets)
+func (v *VirtualMachine) GetFirewallIPSet(ctx context.Context) (ipsets []*FirewallIPSet, err error) {
+	return ipsets, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", v.Node, v.VMID), &ipsets)
 }
 
-func (c *VirtualMachine) NewFirewallIPSet(ctx context.Context, ipset FirewallIPSetCreationOption) error {
-	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", c.Node, c.VMID), ipset, nil)
+func (v *VirtualMachine) NewFirewallIPSet(ctx context.Context, ipset FirewallIPSetCreationOption) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", v.Node, v.VMID), ipset, nil)
 }
 
-func (c *VirtualMachine) DeleteFirewallIPSet(ctx context.Context, name string, force bool) error {
-	return c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), map[string]interface{}{"force": force})
+func (v *VirtualMachine) DeleteFirewallIPSet(ctx context.Context, name string, force bool) error {
+	return v.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", v.Node, v.VMID, name), map[string]interface{}{"force": force})
 }
 
-func (c *VirtualMachine) GetFirewallIPSetEntries(ctx context.Context, name string) (entries []*FirewallIPSetEntry, err error) {
-	return entries, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), &entries)
+func (v *VirtualMachine) GetFirewallIPSetEntries(ctx context.Context, name string) (entries []*FirewallIPSetEntry, err error) {
+	return entries, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", v.Node, v.VMID, name), &entries)
 }
 
-func (c *VirtualMachine) NewFirewallIPSetEntry(ctx context.Context, name string, entry FirewallIPSetEntryCreationOption) error {
-	return c.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", c.Node, c.VMID, name), entry, nil)
+func (v *VirtualMachine) NewFirewallIPSetEntry(ctx context.Context, name string, entry FirewallIPSetEntryCreationOption) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", v.Node, v.VMID, name), entry, nil)
 }
 
-func (c *VirtualMachine) DeleteFirewallIPSetEntry(ctx context.Context, name string, cidr string, digest string) error {
-	return c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), map[string]interface{}{
+func (v *VirtualMachine) DeleteFirewallIPSetEntry(ctx context.Context, name string, cidr string, digest string) error {
+	return v.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", v.Node, v.VMID, name, cidr), map[string]interface{}{
 		"digest": digest,
 	})
 }
 
-func (c *VirtualMachine) GetFirewallIPSetEntry(ctx context.Context, name string, cidr string) (entry *FirewallIPSetEntry, err error) {
-	err = c.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), &entry)
+func (v *VirtualMachine) GetFirewallIPSetEntry(ctx context.Context, name string, cidr string) (entry *FirewallIPSetEntry, err error) {
+	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", v.Node, v.VMID, name, cidr), &entry)
 	return
 }
 
-func (c *VirtualMachine) UpdateFirewallIPSetEntry(ctx context.Context, name string, cidr string, entry *FirewallIPSetEntryUpdateOption) error {
-	return c.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", c.Node, c.VMID, name, cidr), entry, nil)
+func (v *VirtualMachine) UpdateFirewallIPSetEntry(ctx context.Context, name string, cidr string, entry *FirewallIPSetEntryUpdateOption) error {
+	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", v.Node, v.VMID, name, cidr), entry, nil)
 }
 
 func (v *VirtualMachine) FirewallOptionGet(ctx context.Context) (firewallOption *FirewallVirtualMachineOption, err error) {


### PR DESCRIPTION
Introduce new methods to manage Firewall IPSet and IPSetEntries for both VirtualMachine and Container. Functions include creation, retrieval, updating, and deletion of IPSets and their entries. Added corresponding struct types for IPSet and IPSetEntry handling options.