### PR TITLE
Add listing of network interfaces by type

### DIFF
--- a/nodes_network.go
+++ b/nodes_network.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 )
 
 func (n *Node) NewNetwork(ctx context.Context, network *NodeNetwork) (task *Task, err error) {
@@ -35,14 +36,18 @@ func (n *Node) Network(ctx context.Context, iface string) (network *NodeNetwork,
 }
 
 func (n *Node) Networks(ctx context.Context, ifaceType ...string) (networks NodeNetworks, err error) {
-	filterParam := ""
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/network", n.Name)}
+	params := url.Values{}
+
 	if len(ifaceType) > 1 {
 		return nil, errors.New("only one interface type filter is allowed")
 	} else if len(ifaceType) == 1 {
-		filterParam = fmt.Sprintf("?type=%s", ifaceType[0])
+		params.Add("type", ifaceType[0])
 	}
 
-	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/network%s", n.Name, filterParam), &networks)
+	u.RawQuery = params.Encode()
+
+	err = n.client.Get(ctx, u.String(), &networks)
 	if err != nil {
 		return nil, err
 	}

--- a/nodes_network.go
+++ b/nodes_network.go
@@ -48,6 +48,21 @@ func (n *Node) Networks(ctx context.Context) (networks NodeNetworks, err error) 
 	return
 }
 
+func (n *Node) NetworksOfType(ctx context.Context, ifaceType string) (networks NodeNetworks, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/network?type=%s", n.Name, ifaceType), &networks)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range networks {
+		v.client = n.client
+		v.Node = n.Name
+		v.NodeAPI = n
+	}
+
+	return
+}
+
 func (n *Node) NetworkReload(ctx context.Context) (*Task, error) {
 	var upid UPID
 	err := n.client.Put(ctx, fmt.Sprintf("/nodes/%s/network", n.Name), nil, &upid)

--- a/nodes_network_test.go
+++ b/nodes_network_test.go
@@ -67,3 +67,18 @@ func TestNetworksPve8(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, networks, 5)
 }
+
+func TestNetworksPve8NetworksOfType(t *testing.T) {
+	mocks.ProxmoxVE8x(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	node := Node{
+		client: client,
+		Name:   "node1",
+	}
+
+	networks, err := node.NetworksOfType(ctx, "any_bridge")
+	assert.Nil(t, err)
+	assert.Len(t, networks, 1)
+}

--- a/nodes_network_test.go
+++ b/nodes_network_test.go
@@ -78,7 +78,10 @@ func TestNetworksPve8NetworksOfType(t *testing.T) {
 		Name:   "node1",
 	}
 
-	networks, err := node.NetworksOfType(ctx, "any_bridge")
+	networks, err := node.Networks(ctx, "any_bridge")
 	assert.Nil(t, err)
 	assert.Len(t, networks, 1)
+
+	_, err = node.Networks(ctx, "any_bridge", "second_argument")
+	assert.NotNil(t, err)
 }

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -23,7 +23,7 @@ func nodes() {
                 "inet"
             ],
             "bridge_vids": "2-4094",
-            "active": 1,
+            "active": "1",
             "bridge_stp": "off",
             "bridge_vlan_aware": 1,
             "type": "bridge",

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -8,6 +8,34 @@ import (
 func nodes() {
 	gock.New(config.C.URI).
 		Persist().
+		Get("^/nodes/node1/network").
+		ParamPresent("type").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "iface": "vmbr1",
+            "bridge_fd": "0",
+            "autostart": 1,
+            "bridge_ports": "eno1.2 vmbr2.10",
+            "priority": 31,
+            "families": [
+                "inet"
+            ],
+            "bridge_vids": "2-4094",
+            "active": 1,
+            "bridge_stp": "off",
+            "bridge_vlan_aware": 1,
+            "type": "bridge",
+            "comments": "some comment\n",
+            "method6": "manual",
+            "method": "manual"
+        }
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
 		Get("^/nodes/node1/network$").
 		Reply(200).
 		JSON(`{

--- a/types.go
+++ b/types.go
@@ -1247,14 +1247,14 @@ type NodeNetwork struct {
 	OVSPorts   string `json:"ovs_ports,omitempty"`
 	OVSTags    string `json:"ovs_tag,omitempty"`
 
-	Slaves   string `json:"slaves,omitempty"`
-	Address  string `json:"address,omitempty"`
-	Address6 string `json:"address6,omitempty"`
-	Type     string `json:"type,omitempty"`
-	Active   int    `json:"active,omitempty"`
-	Method   string `json:"method,omitempty"`
-	Method6  string `json:"method6,omitempty"`
-	Priority int    `json:"priority,omitempty"`
+	Slaves   string      `json:"slaves,omitempty"`
+	Address  string      `json:"address,omitempty"`
+	Address6 string      `json:"address6,omitempty"`
+	Type     string      `json:"type,omitempty"`
+	Active   StringOrInt `json:"active,omitempty"`
+	Method   string      `json:"method,omitempty"`
+	Method6  string      `json:"method6,omitempty"`
+	Priority int         `json:"priority,omitempty"`
 }
 
 type AgentNetworkIPAddress struct {


### PR DESCRIPTION
See #200 for reasoning.

This PR adds a new function `NetworksOfType` to enable listing of networks by a specific type. Requesting a specific type can return more results than just requesting all networks, so this allows you to query all types of networks.

One caveat is that in `NodeNetwork`, I needed to change the `Active` field from `int` to `StringOrInt` since for some reason some of Proxmox's responses when specifying type are set to strings rather than ints. This may be a breaking change, although StringOrInt is an int under the hood so in most cases it should work as-is. Open to suggestions here.