### PR TITLE
Skip disabled storage in Node.findStorageByContent

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -242,6 +242,10 @@ func (n *Node) findStorageByContent(ctx context.Context, content string) (storag
 	}
 
 	for _, storage := range storages {
+		if storage.Enabled == 0 {
+			continue
+		}
+
 		if strings.Contains(storage.Content, content) {
 			storage.Node = n.Name
 			storage.client = n.client


### PR DESCRIPTION
`Node.findStorageByContent` can return a disabled storage. This breaks ISO injection in cases where there are multiple ISO storages on the node, but some of them are disabled, with error `500 storage 'local' is disabled`.