### PR TITLE
fix: 🐛 fix UpdateACL function to take correct parameters

### DIFF
--- a/access.go
+++ b/access.go
@@ -30,8 +30,8 @@ func (c *Client) ACL(ctx context.Context) (acl ACLs, err error) {
 	return acl, c.Get(ctx, "/access/acl", &acl)
 }
 
-func (c *Client) UpdateACL(ctx context.Context, acl ACL) error {
-	return c.Put(ctx, "/access/acl", &acl, nil)
+func (c *Client) UpdateACL(ctx context.Context, aclOptions ACLOptions) error {
+	return c.Put(ctx, "/access/acl", &aclOptions, nil)
 }
 
 // Permissions get permissions for the current user for the client which passes no params, use Permission

--- a/types.go
+++ b/types.go
@@ -1486,21 +1486,21 @@ type Role struct {
 
 type ACLs []*ACL
 type ACL struct {
-	Path      string    `json:",omitempty"`
-	RoleID    string    `json:",omitempty"`
-	Type      string    `json:",omitempty"`
-	UGID      string    `json:",omitempty"`
-	Propagate IntOrBool `json:""`
+	Path      string    `json:"path,omitempty"`
+	RoleID    string    `json:"roleid,omitempty"`
+	Type      string    `json:"type,omitempty"`
+	UGID      string    `json:"ugid,omitempty"`
+	Propagate IntOrBool `json:"propagate,omitempty"`
 }
 
 type ACLOptions struct {
-	Path      string    `json:",omitempty"`
-	Roles     string    `json:",omitempty"`
-	Groups    string    `json:",omitempty"`
-	Users     string    `json:",omitempty"`
-	Tokens    string    `json:",omitempty"`
-	Propagate IntOrBool `json:",omitempty"`
-	Delete    IntOrBool `json:",omitempty"` // true to delete the ACL
+	Path      string    `json:"path,omitempty"`
+	Roles     string    `json:"roles,omitempty"` // comma separated list of roles
+	Groups    string    `json:"groups,omitempty"`
+	Users     string    `json:"users,omitempty"`
+	Tokens    string    `json:"tokens,omitempty"`
+	Propagate IntOrBool `json:"propagate"`        // Default is true, omitempty would never send false
+	Delete    IntOrBool `json:"delete,omitempty"` // true to delete the ACL
 }
 
 type StorageDownloadURLOptions struct {


### PR DESCRIPTION
The `ACL` struct is what the `/access/acl` endpoint returns to a GET request, however a PUT requires we send `ACLOptions`. This pull request modifies the `UpdateACL` function in access.go to send the `ACLOptions` where it previously tried to send the `ACL` struct which resulted in a 400 error.

GET  `/access/acl` API docs:

<img width="872" height="666" alt="image" src="https://github.com/user-attachments/assets/e44beaba-a059-4d6c-80d5-b4f87ba1f08b" />

`ACL` struct from types.go:

```
type ACL struct {
	Path      string    `json:"path,omitempty"`
	RoleID    string    `json:"roleid,omitempty"`
	Type      string    `json:"type,omitempty"`
	UGID      string    `json:"ugid,omitempty"`
	Propagate IntOrBool `json:"propagate,omitempty"`
}
```

PUT  `/access/acl` API docs:

<img width="997" height="805" alt="image" src="https://github.com/user-attachments/assets/853c4bc3-70a2-4456-8c64-ff584af5d75c" />

`ACLOptions` struct from types.go:

```
type ACLOptions struct {
	Path      string    `json:"path,omitempty"`
	Roles     string    `json:"roles,omitempty"` // comma separated list of roles
	Groups    string    `json:"groups,omitempty"`
	Users     string    `json:"users,omitempty"`
	Tokens    string    `json:"tokens,omitempty"`
	Propagate IntOrBool `json:"propagate"`        // Default is true, omitempty would never send false
	Delete    IntOrBool `json:"delete,omitempty"` // true to delete the ACL
}
```


fixes #180