### PR TITLE
fix: cpuinfo cpu-model typo

### DIFF
--- a/types.go
+++ b/types.go
@@ -479,7 +479,7 @@ type RootFS struct {
 type CPUInfo struct {
 	UserHz  int `json:"user_hz"`
 	MHZ     StringOrInt
-	Mode    string
+	Model   string
 	Cores   int
 	Sockets int
 	Flags   string


### PR DESCRIPTION
Hello, thank you for your go-module!

I think there might be a small typo.

```json
{
    "data": {
        "cpuinfo": {
            "hvm": "1",
            "user_hz": 100,
            "flags": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good amd_lbr_v2 nopl nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba perfmon_v2 ibrs ibpb stibp ibrs_enhanced vmmcall fsgsbase bmi1 avx2 smep bmi2 erms invpcid cqm rdt_a avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk avx512_bf16 clzero irperf xsaveerptr rdpru wbnoinvd cppc arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic vgif x2avic v_spec_ctrl vnmi avx512vbmi umip pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid overflow_recov succor smca fsrm flush_l1d",
            "cpus": 16,
            "cores": 8,
            "sockets": 1,
            "mhz": "3315.951",
            "model": "AMD Ryzen 7 PRO 8700GE w/ Radeon 780M Graphics"
        },
```

Thanks again!

