### PR TITLE
fix(access): 🐛 add useroptions type and fix user update function

### DIFF
--- a/access.go
+++ b/access.go
@@ -165,8 +165,8 @@ func (c *Client) NewUser(ctx context.Context, user *NewUser) (err error) {
 	return c.Post(ctx, "/access/users", user, nil)
 }
 
-func (u *User) Update(ctx context.Context) error {
-	return u.client.Put(ctx, fmt.Sprintf("/access/users/%s", u.UserID), u, nil)
+func (u *User) Update(ctx context.Context, options UserOptions) error {
+	return u.client.Put(ctx, fmt.Sprintf("/access/users/%s", u.UserID), &options, nil)
 }
 
 func (u *User) Delete(ctx context.Context) error {

--- a/types.go
+++ b/types.go
@@ -1468,6 +1468,18 @@ type User struct {
 	TOTPLocked     IntOrBool        `json:"totp-locked,omitempty"`
 }
 
+type UserOptions struct {
+	Append    IntOrBool `json:"append,omitempty"`
+	Comment   string    `json:"comment,omitempty"`
+	Email     string    `json:"email,omitempty"`
+	Enable    IntOrBool `json:"enable"`
+	Expire    int       `json:"expire,omitempty"`
+	Firstname string    `json:"firstname,omitempty"`
+	Groups    []string  `json:"groups,omitempty"`
+	Keys      string    `json:"keys,omitempty"`
+	Lastname  string    `json:"lastname,omitempty"`
+}
+
 type Tokens []*Token
 type Token struct {
 	TokenID string    `json:"tokenid,omitempty"`


### PR DESCRIPTION
The user update function PUTs data that is different from the user object returned from the GET to /access/users/{userid}. Thus a UserOptions struct was created and used in the user Update function. You only need to send the fields you wish to be updated. See https://pve.proxmox.com/pve-docs/api-viewer/#/access/users/{userid} for the API documentation.

Fixes #215 