### PR TITLE
add /nodes/{node}/report getter

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -26,7 +26,7 @@ func (n *Node) Version(ctx context.Context) (version *Version, err error) {
 	return version, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/version", n.Name), &version)
 }
 
-func (n *Node) Report(ctx context.Context) (report *Report, err error) {
+func (n *Node) Report(ctx context.Context) (report string, err error) {
 	return report, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/report", n.Name), &report)
 }
 

--- a/types.go
+++ b/types.go
@@ -50,10 +50,6 @@ type Version struct {
 	Version string `json:"version"`
 }
 
-type Report struct {
-	Data string `json:"data"`
-}
-
 type Term struct {
 	Port   StringOrInt
 	Ticket string


### PR DESCRIPTION
Hello,

This PR adds a new Report method to the Node struct, allowing retrieval of a node’s report via the /nodes/{name}/report endpoint.
A new Report type has also been introduced to represent the response structure.