### PR TITLE
fix: node permission

### DIFF
--- a/nodes_test.go
+++ b/nodes_test.go
@@ -40,5 +40,4 @@ func TestClient_Node(t *testing.T) {
 
 	node, err = client.Node(ctx, "doesntexist")
 	assert.NotNil(t, err)
-	assert.Nil(t, node)
 }


### PR DESCRIPTION
Getting the node status requires the `Sys.Audit` permission, which is quite extensive. 
Most calls only need the node name, so they should not fail if this permission is missing (same behavior as in Cluster()).

https://github.com/luthermonson/go-proxmox/blob/cd684d6404fcf4a83b68d04f2e465135d8faaf97/cluster.go#L10-L20

Thanks.