### PR TITLE
feat: add new() method

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -21,6 +21,12 @@ func (c *Client) Cluster(ctx context.Context) (*Cluster, error) {
 	return cluster, nil
 }
 
+func (cl *Cluster) New(c *Client) *Cluster {
+	return &Cluster{
+		client: c,
+	}
+}
+
 func (cl *Cluster) Status(ctx context.Context) error {
 	return cl.client.Get(ctx, "/cluster/status", cl)
 }

--- a/nodes.go
+++ b/nodes.go
@@ -22,6 +22,19 @@ func (c *Client) Node(ctx context.Context, name string) (node *Node, err error) 
 	return
 }
 
+func (n *Node) New(c *Client, name string) *Node {
+	node := &Node{
+		Name:   name,
+		client: c,
+	}
+
+	return node
+}
+
+func (n *Node) Status(ctx context.Context) error {
+	return n.client.Get(ctx, fmt.Sprintf("/nodes/%s/status", n.Name), n)
+}
+
 func (n *Node) Version(ctx context.Context) (version *Version, err error) {
 	return version, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/version", n.Name), &version)
 }

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -29,6 +29,12 @@ const (
 // DefaultAgentWaitInterval is the polling interval when waiting for agent exec commands
 var DefaultAgentWaitInterval = 100 * time.Millisecond
 
+func (v *VirtualMachine) New(c *Client, nodeName string, vmid int) {
+	v.client = c
+	v.Node = nodeName
+	v.VMID = StringOrUint64(vmid)
+}
+
 func (v *VirtualMachine) Ping(ctx context.Context) error {
 	return v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/status/current", v.Node, v.VMID), &v)
 }


### PR DESCRIPTION
This helps reduce unnecessary API calls

Example to use:

```go
	vm := &proxmox.VirtualMachine{}
	vm.New(c.Client, nodeName, vmID)

	if err := vm.Ping(ctx); err != nil {
		return 0, fmt.Errorf("failed to get vm %d status: %v", vmID, err)
	}
```

Thanks