### PR TITLE
Add import content type

### DIFF
--- a/types.go
+++ b/types.go
@@ -1099,6 +1099,9 @@ type ISO struct{ Content }
 type VzTmpls []*VzTmpl
 type VzTmpl struct{ Content }
 
+type Imports []*Import
+type Import struct{ Content }
+
 type Backups []*Backup
 type Backup struct{ Content }
 


### PR DESCRIPTION
Proxmox VE 9.0 adds a new storage content type called "import". This PR adds support for uploading & referencing these files.

Files of type import (.raw & .qcow2 extensions) can be used with the [`import-from=` syntax](https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_9.0:~:text=import%2Dfrom) when adding new VM disks.