### PR TITLE
Switch AgentExecStatus.OutTruncated to IntOrBool

### DIFF
--- a/types.go
+++ b/types.go
@@ -1287,13 +1287,13 @@ type AgentOsInfo struct {
 }
 
 type AgentExecStatus struct {
-	Exited       int    `json:"exited"`
-	ErrData      string `json:"err-data"`
-	ErrTruncated bool   `json:"err-truncated"`
-	ExitCode     int    `json:"exitcode"`
-	OutData      string `json:"out-data"`
-	OutTruncated string `json:"out-truncated"`
-	Signal       bool   `json:"signal"`
+	Exited       int       `json:"exited"`
+	ErrData      string    `json:"err-data"`
+	ErrTruncated bool      `json:"err-truncated"`
+	ExitCode     int       `json:"exitcode"`
+	OutData      string    `json:"out-data"`
+	OutTruncated IntOrBool `json:"out-truncated"`
+	Signal       bool      `json:"signal"`
 }
 
 type FirewallSecurityGroup struct {


### PR DESCRIPTION
With one of the latest qemu-guest-agent package releases on debian, a call to the /nodes/[nodename]/qemu/[id]/agent/exec-status endpoint of proxmox now always returns the `out-truncated` field.

The field is not returned as a string but as a "boolean" encoded in an int.