### PR TITLE
fix: session expiration time

### DIFF
--- a/access.go
+++ b/access.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // Deprecated: Use WithCredentials Option
@@ -29,13 +30,15 @@ func (c *Client) CreateSession(ctx context.Context) error {
 	c.sessionMux.Lock()
 	defer c.sessionMux.Unlock()
 
-	if c.session != nil {
+	if c.session != nil && time.Now().Before(c.sessionExpiresAt) {
 		return ErrSessionExists
 	}
 
 	if _, err := c.Ticket(ctx, c.credentials); err != nil {
 		return err
 	}
+
+	c.sessionExpiresAt = time.Now().Add(time.Hour)
 
 	return nil
 }

--- a/proxmox.go
+++ b/proxmox.go
@@ -68,7 +68,8 @@ type Client struct {
 	session     *Session
 	log         LeveledLoggerInterface
 
-	sessionMux sync.Mutex
+	sessionExpiresAt time.Time
+	sessionMux       sync.Mutex
 }
 
 func NewClient(baseURL string, opts ...Option) *Client {


### PR DESCRIPTION
The Proxmox session token is valid for only 2 hours. We need to check the expiration time before sending an error.

https://forum.proxmox.com/threads/extend-api-token-lifetime.63320/

I've set to one `c.sessionExpiresAt = time.Now().Add(time.Hour)`. We may have an issue due to timezone changes.

Thanks.