### PR TITLE
Update VNet Tag type to uint32 and add max VNet Tag test case

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -117,5 +117,11 @@ func TestCluster_SDNVNets(t *testing.T) {
 	assert.Equal(t, "vnet", vnet.Type)
 	assert.Equal(t, "test1", vnet.Zone)
 	assert.Equal(t, 1, vnet.VlanAware)
-	assert.Equal(t, uint16(10), vnet.Tag)
+	assert.Equal(t, uint32(10), vnet.Tag)
+
+	// VNet Tag max value (VXLAN VNI range is 0-16777215)
+	vnetMaxTag, err := cluster.SDNVNet(ctx, "maxTagVnet")
+	assert.Nil(t, err)
+	assert.Equal(t, "maxTagVnet", vnetMaxTag.Name)
+	assert.Equal(t, uint32(16777215), vnetMaxTag.Tag)
 }

--- a/tests/mocks/pve7x/cluster.go
+++ b/tests/mocks/pve7x/cluster.go
@@ -429,6 +429,13 @@ func cluster() {
 		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10}
 		}`)
 
+	gock.New(config.C.URI).
+		Get("^/cluster/sdn/vnets/maxTagVnet$").
+		Reply(200).
+		JSON(`{
+		"data": {"vnet":"maxTagVnet","type":"vnet","zone":"test1","vlanaware":1,"tag":16777215}
+		}`)
+
 	// GET /cluster/firewall/groups - List firewall security groups
 	gock.New(config.C.URI).
 		Persist().

--- a/tests/mocks/pve8x/cluster.go
+++ b/tests/mocks/pve8x/cluster.go
@@ -429,6 +429,13 @@ func cluster() {
 		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10}
 		}`)
 
+	gock.New(config.C.URI).
+		Get("^/cluster/sdn/vnets/maxTagVnet$").
+		Reply(200).
+		JSON(`{
+		"data": {"vnet":"maxTagVnet","type":"vnet","zone":"test1","vlanaware":1,"tag":16777215}
+		}`)
+
 	// GET /cluster/firewall/groups - List firewall security groups
 	gock.New(config.C.URI).
 		Persist().

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -429,6 +429,13 @@ func cluster() {
 		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10}
 		}`)
 
+	gock.New(config.C.URI).
+		Get("^/cluster/sdn/vnets/maxTagVnet$").
+		Reply(200).
+		JSON(`{
+		"data": {"vnet":"maxTagVnet","type":"vnet","zone":"test1","vlanaware":1,"tag":16777215}
+		}`)
+
 	// GET /cluster/firewall/groups - List firewall security groups
 	gock.New(config.C.URI).
 		Persist().

--- a/types.go
+++ b/types.go
@@ -1989,7 +1989,7 @@ type VNet struct {
 	Type      string `json:"type,omitempty"`
 	Zone      string `json:"zone,omitempty"`
 	VlanAware int    `json:"vlanaware,omitempty"`
-	Tag       uint16 `json:"tag,omitempty"`
+	Tag       uint32 `json:"tag,omitempty"`
 }
 
 type VNetOptions struct {


### PR DESCRIPTION
Tag values for VNets can be in the range `1 - 16777215`. They were previously stored in a `uint16` which has as max value of `65535`. This caused an error when running `cluster.SDNVNet(ctx, "maxTagVnet")` on a VNet with a tag value > 65535: `json: cannot unmarshal number 16777215 into Go struct field VNet.tag of type uint16`. 

This pull request changes the VNet Tag value to a `uint32` which has a max value of `4294967295` and can hold any possible VNet tag value, and adds a test for a VNet with a tag value of `16777215` to catch any regression.

Documentation: https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/sdn/vnets/{vnet}