### PR TITLE
feat: add alias field to VNet and VM Monitor Endpoint

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -116,6 +116,7 @@ func TestCluster_SDNVNets(t *testing.T) {
 	assert.Equal(t, "user1", vnet.Name)
 	assert.Equal(t, "vnet", vnet.Type)
 	assert.Equal(t, "test1", vnet.Zone)
+	assert.Equal(t, "myuser1's network", vnet.Alias)
 	assert.Equal(t, 1, vnet.VlanAware)
 	assert.Equal(t, uint32(10), vnet.Tag)
 

--- a/tests/mocks/pve7x/cluster.go
+++ b/tests/mocks/pve7x/cluster.go
@@ -414,7 +414,7 @@ func cluster() {
 		Reply(200).
 		JSON(`{
 		"data": [
-				{"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10},
+				{"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10,"alias":"myuser1's network"},
 				{"vnet":"user10","type":"vnet","zone":"test1","vlanaware":1,"tag":30},
 				{"vnet":"user11","type":"vnet","zone":"test1","vlanaware":1,"tag":31},
 				{"vnet":"user2","type":"vnet","zone":"test3","vlanaware":1,"tag":11},
@@ -426,7 +426,7 @@ func cluster() {
 		Get("^/cluster/sdn/vnets/user1$").
 		Reply(200).
 		JSON(`{
-		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10}
+		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10,"alias":"myuser1's network"}
 		}`)
 
 	gock.New(config.C.URI).

--- a/tests/mocks/pve8x/cluster.go
+++ b/tests/mocks/pve8x/cluster.go
@@ -414,7 +414,7 @@ func cluster() {
 		Reply(200).
 		JSON(`{
 		"data": [
-				{"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10},
+				{"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10,"alias":"myuser1's network"},
 				{"vnet":"user10","type":"vnet","zone":"test1","vlanaware":1,"tag":30},
 				{"vnet":"user11","type":"vnet","zone":"test1","vlanaware":1,"tag":31},
 				{"vnet":"user2","type":"vnet","zone":"test3","vlanaware":1,"tag":11},
@@ -426,7 +426,7 @@ func cluster() {
 		Get("^/cluster/sdn/vnets/user1$").
 		Reply(200).
 		JSON(`{
-		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10}
+		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10,"alias":"myuser1's network"}
 		}`)
 
 	gock.New(config.C.URI).

--- a/tests/mocks/pve8x/virtual_machines.go
+++ b/tests/mocks/pve8x/virtual_machines.go
@@ -638,6 +638,14 @@ func virtualMachines() {
     "data": null
 }`)
 
+	// POST /nodes/{node}/qemu/{vmid}/monitor - Access the Virtual Machine monitor
+	gock.New(config.C.URI).
+		Post("^/nodes/node1/qemu/101/monitor").
+		Reply(200).
+		JSON(`{
+    "data": "help text"
+}`)
+
 	// GET /nodes/{node}/qemu/{vmid}/config - Get VM config
 	gock.New(config.C.URI).
 		Persist().

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -414,7 +414,7 @@ func cluster() {
 		Reply(200).
 		JSON(`{
 		"data": [
-				{"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10},
+				{"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10,"alias":"myuser1's network"},
 				{"vnet":"user10","type":"vnet","zone":"test1","vlanaware":1,"tag":30},
 				{"vnet":"user11","type":"vnet","zone":"test1","vlanaware":1,"tag":31},
 				{"vnet":"user2","type":"vnet","zone":"test3","vlanaware":1,"tag":11},
@@ -426,7 +426,7 @@ func cluster() {
 		Get("^/cluster/sdn/vnets/user1$").
 		Reply(200).
 		JSON(`{
-		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10}
+		"data": {"vnet":"user1","type":"vnet","zone":"test1","vlanaware":1,"tag":10,"alias":"myuser1's network"}
 		}`)
 
 	gock.New(config.C.URI).

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -671,6 +671,14 @@ func virtualMachines() {
     "data": null
 }`)
 
+	// POST /nodes/{node}/qemu/{vmid}/monitor - Access the Virtual Machine monitor
+	gock.New(config.C.URI).
+		Post("^/nodes/node1/qemu/101/monitor").
+		Reply(200).
+		JSON(`{
+    "data": "help text"
+}`)
+
 	// GET /nodes/{node}/qemu/{vmid}/config - Get VM config
 	gock.New(config.C.URI).
 		Persist().

--- a/types.go
+++ b/types.go
@@ -2023,6 +2023,7 @@ type VNet struct {
 	Name      string `json:"vnet,omitempty"`
 	Type      string `json:"type,omitempty"`
 	Zone      string `json:"zone,omitempty"`
+	Alias     string `json:"alias,omitempty"`
 	VlanAware int    `json:"vlanaware,omitempty"`
 	Tag       uint32 `json:"tag,omitempty"`
 }

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -39,6 +39,8 @@ func (v *VirtualMachine) Ping(ctx context.Context) error {
 	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/status/current", v.Node, v.VMID), &v); err != nil {
 		return err
 	}
+	// New, empty config in case something was deleted
+	v.VirtualMachineConfig = &VirtualMachineConfig{}
 	return v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", v.Node, v.VMID), &v.VirtualMachineConfig)
 }
 

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -49,6 +49,13 @@ func (v *VirtualMachine) Config(ctx context.Context, options ...VirtualMachineOp
 	return NewTask(upid, v.client), err
 }
 
+func (v *VirtualMachine) Monitor(ctx context.Context, command string) (s string, err error) {
+	data := make(map[string]interface{})
+	data["command"] = command
+	err = v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/monitor", v.Node, v.VMID), data, &s)
+	return s, err
+}
+
 func (v *VirtualMachine) TermProxy(ctx context.Context) (term *Term, err error) {
 	return term, v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/termproxy", v.Node, v.VMID), nil, &term)
 }

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -36,7 +36,10 @@ func (v *VirtualMachine) New(c *Client, nodeName string, vmid int) {
 }
 
 func (v *VirtualMachine) Ping(ctx context.Context) error {
-	return v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/status/current", v.Node, v.VMID), &v)
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/status/current", v.Node, v.VMID), &v); err != nil {
+		return err
+	}
+	return v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", v.Node, v.VMID), &v.VirtualMachineConfig)
 }
 
 func (v *VirtualMachine) Config(ctx context.Context, options ...VirtualMachineOption) (*Task, error) {

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -692,6 +692,14 @@ func (v *VirtualMachine) SnapshotRollback(ctx context.Context, name string) (tas
 	return NewTask(upid, v.client), nil
 }
 
+func (v *VirtualMachine) DeleteSnapshot(ctx context.Context, snapshot string) (task *Task, err error) {
+	var upid UPID
+	if err := v.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s", v.Node, v.VMID, snapshot), &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, v.client), nil
+}
+
 // RRDData takes a timeframe enum and an optional consolidation function
 // usage: vm.RRDData(HOURLY) or vm.RRDData(HOURLY, AVERAGE)
 func (v *VirtualMachine) RRDData(ctx context.Context, timeframe Timeframe, consolidationFunction ...ConsolidationFunction) (rrddata []*RRDData, err error) {

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -59,6 +59,21 @@ func TestVirtualMachineClone(t *testing.T) {
 	assert.Equal(t, cloneOptions.NewID, newID)
 }
 
+func TestVirtualMachineMonitor(t *testing.T) {
+	mocks.On(mockConfig)
+	client := mockClient()
+	defer mocks.Off()
+	ctx := context.Background()
+	vmTemplate := VirtualMachine{
+		client: client,
+		VMID:   101,
+		Node:   "node1",
+	}
+	out, err := vmTemplate.Monitor(ctx, "help")
+	assert.Nil(t, err)
+	assert.Equal(t, "help text", out)
+}
+
 func TestVirtualMachineCloneWithoutNewID(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -369,6 +369,21 @@ func TestVirtualMachine_NewSnapshot(t *testing.T) {
 	assert.Equal(t, "100", task.ID)
 }
 
+func TestVirtualMachine_DeleteSnapshot(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		Node:   "node1",
+		VMID:   100,
+	}
+	task, err := vm.DeleteSnapshot(ctx, "snap2")
+	assert.Nil(t, err)
+	assert.NotEmpty(t, task)
+}
+
 func TestVirtualMachine_SnapshotRollback(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()


### PR DESCRIPTION
Hi

Thanks a lot for your library. It's super convenient for heavy API usage!

There are now 2 changes here. I'm currently implementing some heavy automation which used to be done with VMWare. Therefore we have a super specific feature set we need. `Alias` and the `Monitor` endpoint are the first two missing features I spotted. I might add a few more missing things in the next ~month, but not sure. However you prefer to review them, I can split them up into one PR per feature, add additional changes here and tell you once I'm truly finished, ...


I couldn't run the `mage test:integration` since some things in `tests/integration/proxmox_test.go` were commented out/changed and I'm not sure if my added code would actually be tested right now. But I'm incorporating the changes directly into our downstream project, so at least some "real world" testing on Proxmox VE 9.1 is done. Please tell me if you need some integration tests or anything else for the added features.

---

## Alias

I added the `alias` field to `VNet`, because we need to work around the 8char `Name` limit... :)

## Monitor

I've added the `monitor` endpoint for the Virtual Machines, since we need the possibility to send a `screendump FILENAME` command to create screenshots of the VMs.

## Update VirtualMachineConfig on `Ping()`

This is not really crucial, but I added a call to the `config` endpoint in the `Ping` after resetting the `vm.VirtualMachineConfig`. This is mostly used during Testing, i.e. we have a VM, do some changes to it, then we check the configuration of the VM. Getting a new object with `Node.VirtualMachine(ctx, vmname)` would also be feasible in case this change is not welcome.