### PR TITLE
feat: support string-based upload

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -247,6 +247,11 @@ func (n *Node) StorageBackup(ctx context.Context) (*Storage, error) {
 	return n.findStorageByContent(ctx, "backup")
 }
 
+// StorageSnippets returns a storage configured for the "snippets" content
+// type. Note that Proxmox does not expose a REST upload endpoint for
+// snippets — they must be written to the storage path directly (e.g. via
+// SCP/SFTP). This helper is for read-side discovery (e.g. resolving the
+// storage's path so a caller can write to it out-of-band).
 func (n *Node) StorageSnippets(ctx context.Context) (*Storage, error) {
 	return n.findStorageByContent(ctx, "snippets")
 }

--- a/nodes.go
+++ b/nodes.go
@@ -247,6 +247,10 @@ func (n *Node) StorageBackup(ctx context.Context) (*Storage, error) {
 	return n.findStorageByContent(ctx, "backup")
 }
 
+func (n *Node) StorageSnippets(ctx context.Context) (*Storage, error) {
+	return n.findStorageByContent(ctx, "snippets")
+}
+
 func (n *Node) StorageRootDir(ctx context.Context) (*Storage, error) {
 	return n.findStorageByContent(ctx, "rootdir")
 }

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -237,6 +237,12 @@ func TestNode_StorageByContent(t *testing.T) {
 	assert.NotNil(t, storage)
 	assert.Contains(t, storage.Content, "backup")
 
+	// Test StorageSnippets
+	storage, err = node.StorageSnippets(ctx)
+	assert.Nil(t, err)
+	assert.NotNil(t, storage)
+	assert.Contains(t, storage.Content, "snippets")
+
 	// Test StorageRootDir
 	storage, err = node.StorageRootDir(ctx)
 	assert.Nil(t, err)

--- a/proxmox.go
+++ b/proxmox.go
@@ -232,6 +232,17 @@ func (c *Client) Delete(ctx context.Context, p string, v interface{}) error {
 // the task returned is the imgcopy from the tmp file to where the node actually wants the iso and you should wait for that
 // to complete before using the iso
 func (c *Client) Upload(path string, fields map[string]string, file *os.File, v interface{}) error {
+	fi, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	return c.UploadReader(path, fields, filepath.Base(file.Name()), file, fi.Size(), v)
+}
+
+// UploadReader is the io.Reader-based variant of Upload. Use it when the
+// payload is already in memory (e.g., a snippet) or otherwise not backed by an
+// *os.File. size must be the exact byte length of body.
+func (c *Client) UploadReader(path string, fields map[string]string, filename string, body io.Reader, size int64, v interface{}) error {
 	if strings.HasPrefix(path, "/") {
 		path = c.baseURL + path
 	}
@@ -245,7 +256,7 @@ func (c *Client) Upload(path string, fields map[string]string, file *os.File, v 
 		}
 	}
 
-	if _, err := w.CreateFormFile("filename", filepath.Base(file.Name())); err != nil {
+	if _, err := w.CreateFormFile("filename", filename); err != nil {
 		return err
 	}
 
@@ -254,22 +265,17 @@ func (c *Client) Upload(path string, fields map[string]string, file *os.File, v 
 		return err
 	}
 
-	body := io.MultiReader(bytes.NewReader(b.Bytes()[:header]),
-		file,
+	multi := io.MultiReader(bytes.NewReader(b.Bytes()[:header]),
+		body,
 		bytes.NewReader(b.Bytes()[header:]))
 
-	req, err := http.NewRequest(http.MethodPost, path, body)
-	if err != nil {
-		return err
-	}
-
-	fi, err := file.Stat()
+	req, err := http.NewRequest(http.MethodPost, path, multi)
 	if err != nil {
 		return err
 	}
 
 	req.Header.Set("Content-Type", w.FormDataContentType())
-	req.ContentLength = int64(b.Len()) + fi.Size()
+	req.ContentLength = int64(b.Len()) + size
 	c.authHeaders(&req.Header)
 
 	res, err := c.httpClient.Do(req)

--- a/storage.go
+++ b/storage.go
@@ -90,12 +90,7 @@ func (s *Storage) UploadWithHash(content, file string, storageFilename *string, 
 	if storageFilename != nil {
 		extraArgs["filename"] = *storageFilename
 	}
-
-	if storageFilename != nil {
-		return s.upload(content, file, &map[string]string{"filename": *storageFilename})
-	}
-
-	return s.upload(content, file, nil)
+	return s.upload(content, file, &extraArgs)
 }
 
 func (s *Storage) upload(content, file string, extraArgs *map[string]string) (*Task, error) {
@@ -118,16 +113,26 @@ func (s *Storage) upload(content, file string, extraArgs *map[string]string) (*T
 	}
 	defer func() { _ = f.Close() }()
 
-	var upid UPID
+	// The upload's filename goes in the file part's Content-Disposition.
+	// It must NOT also be sent as a form field — Proxmox treats both as
+	// the same parameter and rejects the request when they collide.
+	filename := filepath.Base(file)
 	data := map[string]string{"content": content}
 	if extraArgs != nil {
 		for k, v := range *extraArgs {
+			if k == "filename" {
+				filename = v
+				continue
+			}
 			data[k] = v
 		}
 	}
 
-	if err := s.client.Upload(fmt.Sprintf("/nodes/%s/storage/%s/upload", s.Node, s.Name),
-		data, f, &upid); err != nil {
+	var upid UPID
+	if err := s.client.UploadReader(
+		fmt.Sprintf("/nodes/%s/storage/%s/upload", s.Node, s.Name),
+		data, filename, f, stat.Size(), &upid,
+	); err != nil {
 		return nil, err
 	}
 
@@ -143,10 +148,9 @@ func (s *Storage) UploadString(content, storageFilename, contents string) (*Task
 	}
 
 	body := strings.NewReader(contents)
-	data := map[string]string{
-		"content":  content,
-		"filename": storageFilename,
-	}
+	// storageFilename is communicated via the file part's Content-Disposition
+	// (UploadReader's filename arg) — it must not also be a form field.
+	data := map[string]string{"content": content}
 
 	var upid UPID
 	if err := s.client.UploadReader(

--- a/storage.go
+++ b/storage.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var validContent = map[string]struct{}{
-	"iso":    {},
-	"vztmpl": {},
-	"import": {},
+	"iso":      {},
+	"vztmpl":   {},
+	"import":   {},
+	"snippets": {},
 }
 
 func (c *Client) ClusterStorages(ctx context.Context) (storages ClusterStorages, err error) {
@@ -98,7 +100,7 @@ func (s *Storage) UploadWithHash(content, file string, storageFilename *string, 
 
 func (s *Storage) upload(content, file string, extraArgs *map[string]string) (*Task, error) {
 	if _, ok := validContent[content]; !ok {
-		return nil, fmt.Errorf("only iso, vztmpl and import allowed")
+		return nil, validContentError()
 	}
 
 	stat, err := os.Stat(file)
@@ -132,6 +134,39 @@ func (s *Storage) upload(content, file string, extraArgs *map[string]string) (*T
 	return NewTask(upid, s.client), nil
 }
 
+// UploadString uploads contents directly as a file with the given storage filename
+// without writing to a temporary file. Useful for snippets (cloud-init user-data,
+// hookscripts, etc.) where the content is already in memory.
+func (s *Storage) UploadString(content, storageFilename, contents string) (*Task, error) {
+	if _, ok := validContent[content]; !ok {
+		return nil, validContentError()
+	}
+
+	body := strings.NewReader(contents)
+	data := map[string]string{
+		"content":  content,
+		"filename": storageFilename,
+	}
+
+	var upid UPID
+	if err := s.client.UploadReader(
+		fmt.Sprintf("/nodes/%s/storage/%s/upload", s.Node, s.Name),
+		data, storageFilename, body, int64(body.Len()), &upid,
+	); err != nil {
+		return nil, err
+	}
+
+	return NewTask(upid, s.client), nil
+}
+
+func validContentError() error {
+	keys := make([]string, 0, len(validContent))
+	for k := range validContent {
+		keys = append(keys, k)
+	}
+	return fmt.Errorf("invalid content type, allowed: %s", strings.Join(keys, ", "))
+}
+
 func (s *Storage) DownloadURL(ctx context.Context, content, filename, url string) (*Task, error) {
 	return s.downloadURL(ctx, content, filename, url, nil)
 }
@@ -145,7 +180,7 @@ func (s *Storage) DownloadURLWithHash(ctx context.Context, content, filename, ur
 
 func (s *Storage) downloadURL(ctx context.Context, content, filename, url string, extraArgs *map[string]string) (*Task, error) {
 	if _, ok := validContent[content]; !ok {
-		return nil, fmt.Errorf("only iso, vztmpl and import allowed")
+		return nil, validContentError()
 	}
 
 	var upid UPID

--- a/storage.go
+++ b/storage.go
@@ -8,11 +8,15 @@ import (
 	"strings"
 )
 
+// validContent enumerates the values Proxmox's
+// /nodes/{node}/storage/{storage}/upload endpoint accepts. The Proxmox API
+// rejects everything else (including "snippets" — those have to be placed
+// on the storage path directly, e.g. via SCP/SFTP, since there is no REST
+// upload path for them as of PVE 9.x).
 var validContent = map[string]struct{}{
-	"iso":      {},
-	"vztmpl":   {},
-	"import":   {},
-	"snippets": {},
+	"iso":    {},
+	"vztmpl": {},
+	"import": {},
 }
 
 func (c *Client) ClusterStorages(ctx context.Context) (storages ClusterStorages, err error) {
@@ -139,9 +143,10 @@ func (s *Storage) upload(content, file string, extraArgs *map[string]string) (*T
 	return NewTask(upid, s.client), nil
 }
 
-// UploadString uploads contents directly as a file with the given storage filename
-// without writing to a temporary file. Useful for snippets (cloud-init user-data,
-// hookscripts, etc.) where the content is already in memory.
+// UploadString uploads contents directly as a file with the given storage
+// filename without writing to a temporary file. Useful when the payload is
+// already in memory. content must be one of the values accepted by the
+// Proxmox upload endpoint (iso, vztmpl, import).
 func (s *Storage) UploadString(content, storageFilename, contents string) (*Task, error) {
 	if _, ok := validContent[content]; !ok {
 		return nil, validContentError()

--- a/storage_test.go
+++ b/storage_test.go
@@ -350,32 +350,32 @@ func TestStorage_Upload_InvalidContent(t *testing.T) {
 	storage := &Storage{Node: "node1", Name: "local"}
 	_, err := storage.Upload("not-a-real-content-type", "some-file")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "snippets")
+	assert.Contains(t, err.Error(), "iso")
 }
 
 func TestStorage_UploadString_InvalidContent(t *testing.T) {
 	storage := &Storage{Node: "node1", Name: "local"}
 	_, err := storage.UploadString("not-a-real-content-type", "user-data", "#cloud-config\n")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "snippets")
+	assert.Contains(t, err.Error(), "iso")
 }
 
 func TestStorage_UploadString(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 
-	const want = "#cloud-config\nhostname: test\n"
+	const want = "fake iso payload"
 	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
 
-	task, err := storage.UploadString("snippets", "test-user-data.yaml", want)
+	task, err := storage.UploadString("iso", "tiny.iso", want)
 	require.NoError(t, err)
 	require.NotNil(t, task)
 	assert.Equal(t, "node1", task.Node)
 	assert.Equal(t, "imgcopy", task.Type)
 
 	require.NotNil(t, capture.LastUpload, "upload matcher did not run")
-	assert.Equal(t, "snippets", capture.LastUpload.Fields["content"])
-	assert.Equal(t, "test-user-data.yaml", capture.LastUpload.Filename)
+	assert.Equal(t, "iso", capture.LastUpload.Fields["content"])
+	assert.Equal(t, "tiny.iso", capture.LastUpload.Filename)
 	assert.Equal(t, want, capture.LastUpload.Body)
 	// Proxmox treats "filename" as a single parameter; sending it both as a
 	// form field and as the file part name causes empty-body 4xx responses.
@@ -412,13 +412,13 @@ func TestClient_UploadReader(t *testing.T) {
 	body := strings.NewReader(payload)
 	err := mockClient().UploadReader(
 		"/nodes/node1/storage/local/upload",
-		map[string]string{"content": "snippets"},
+		map[string]string{"content": "iso"},
 		"hello.txt", body, int64(body.Len()), nil,
 	)
 	require.NoError(t, err)
 
 	require.NotNil(t, capture.LastUpload)
-	assert.Equal(t, "snippets", capture.LastUpload.Fields["content"])
+	assert.Equal(t, "iso", capture.LastUpload.Fields["content"])
 	assert.Equal(t, "hello.txt", capture.LastUpload.Filename)
 	assert.Equal(t, payload, capture.LastUpload.Body)
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -3,6 +3,7 @@ package proxmox
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -376,6 +377,31 @@ func TestStorage_UploadString(t *testing.T) {
 	assert.Equal(t, "snippets", capture.LastUpload.Fields["content"])
 	assert.Equal(t, "test-user-data.yaml", capture.LastUpload.Filename)
 	assert.Equal(t, want, capture.LastUpload.Body)
+	// Proxmox treats "filename" as a single parameter; sending it both as a
+	// form field and as the file part name causes empty-body 4xx responses.
+	_, ok := capture.LastUpload.Fields["filename"]
+	assert.False(t, ok, "filename must not appear as a form field; it lives in the file part's Content-Disposition")
+}
+
+func TestStorage_UploadWithName_FilenameNotDuplicated(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	tmp, err := os.CreateTemp("", "upload-test-*.iso")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	_, err = tmp.WriteString("fake iso data")
+	require.NoError(t, err)
+	require.NoError(t, tmp.Close())
+
+	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+	_, err = storage.UploadWithName("iso", tmp.Name(), "renamed.iso")
+	require.NoError(t, err)
+
+	require.NotNil(t, capture.LastUpload)
+	assert.Equal(t, "renamed.iso", capture.LastUpload.Filename)
+	_, ok := capture.LastUpload.Fields["filename"]
+	assert.False(t, ok, "filename must not appear as a form field")
 }
 
 func TestClient_UploadReader(t *testing.T) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/luthermonson/go-proxmox/tests/mocks/capture"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -362,23 +363,36 @@ func TestStorage_UploadString(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 
+	const want = "#cloud-config\nhostname: test\n"
 	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
-	task, err := storage.UploadString("snippets", "test-user-data.yaml", "#cloud-config\nhostname: test\n")
+
+	task, err := storage.UploadString("snippets", "test-user-data.yaml", want)
 	require.NoError(t, err)
 	require.NotNil(t, task)
 	assert.Equal(t, "node1", task.Node)
 	assert.Equal(t, "imgcopy", task.Type)
+
+	require.NotNil(t, capture.LastUpload, "upload matcher did not run")
+	assert.Equal(t, "snippets", capture.LastUpload.Fields["content"])
+	assert.Equal(t, "test-user-data.yaml", capture.LastUpload.Filename)
+	assert.Equal(t, want, capture.LastUpload.Body)
 }
 
 func TestClient_UploadReader(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 
-	body := strings.NewReader("the body")
+	const payload = "the body"
+	body := strings.NewReader(payload)
 	err := mockClient().UploadReader(
 		"/nodes/node1/storage/local/upload",
 		map[string]string{"content": "snippets"},
 		"hello.txt", body, int64(body.Len()), nil,
 	)
 	require.NoError(t, err)
+
+	require.NotNil(t, capture.LastUpload)
+	assert.Equal(t, "snippets", capture.LastUpload.Fields["content"])
+	assert.Equal(t, "hello.txt", capture.LastUpload.Filename)
+	assert.Equal(t, payload, capture.LastUpload.Body)
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,16 +1,17 @@
 package proxmox
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
 	"mime"
 	"mime/multipart"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/h2non/gock"
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -363,92 +364,93 @@ func TestStorage_UploadString_InvalidContent(t *testing.T) {
 	assert.Contains(t, err.Error(), "snippets")
 }
 
-func TestStorage_UploadString(t *testing.T) {
-	const want = "#cloud-config\nhostname: test\n"
+// captureMultipart returns a gock matcher that drains the multipart request
+// body and stores each form field in the supplied map. Files are stored as
+// "<field-name>:filename" (the uploaded filename) and "<field-name>:body"
+// (the file contents). It always matches; field-level assertions belong in
+// the test using assert.Equal afterwards.
+func captureMultipart(t *testing.T, captured map[string]string) func(*http.Request, *gock.Request) (bool, error) {
+	t.Helper()
+	return func(req *http.Request, _ *gock.Request) (bool, error) {
+		_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+		if err != nil {
+			return false, err
+		}
+		// Buffer the body so gock can still see it for any other matchers.
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			return false, err
+		}
+		req.Body = io.NopCloser(bytes.NewReader(raw))
 
-	var (
-		gotContent  string
-		gotFilename string
-		gotBody     string
-	)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t, "/nodes/node1/storage/local/upload", r.URL.Path)
-
-		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-		require.NoError(t, err)
-		mr := multipart.NewReader(r.Body, params["boundary"])
+		mr := multipart.NewReader(bytes.NewReader(raw), params["boundary"])
 		for {
 			part, err := mr.NextPart()
 			if err == io.EOF {
 				break
 			}
-			require.NoError(t, err)
+			if err != nil {
+				return false, err
+			}
 			data, err := io.ReadAll(part)
-			require.NoError(t, err)
-			switch part.FormName() {
-			case "content":
-				gotContent = string(data)
-			case "filename":
-				gotFilename = part.FileName()
-				gotBody = string(data)
+			if err != nil {
+				return false, err
+			}
+			if part.FileName() != "" {
+				captured[part.FormName()+":filename"] = part.FileName()
+				captured[part.FormName()+":body"] = string(data)
+			} else {
+				captured[part.FormName()] = string(data)
 			}
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":"UPID:node1:00000000:00000000:00000000:imgcopy:user-data:root@pam:"}`))
-	}))
-	defer srv.Close()
+		return true, nil
+	}
+}
 
-	client := NewClient(srv.URL)
+func TestStorage_UploadString(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	const want = "#cloud-config\nhostname: test\n"
+	captured := map[string]string{}
+
+	gock.New(mockConfig.URI).
+		Post("^/nodes/node1/storage/local/upload$").
+		AddMatcher(captureMultipart(t, captured)).
+		Reply(200).
+		JSON(`{"data":"UPID:node1:00000000:00000000:00000000:imgcopy:user-data:root@pam:"}`)
+
+	client := mockClient()
 	storage := &Storage{client: client, Node: "node1", Name: "local"}
 
 	task, err := storage.UploadString("snippets", "test-user-data.yaml", want)
 	require.NoError(t, err)
 	assert.NotNil(t, task)
 
-	assert.Equal(t, "snippets", gotContent)
-	assert.Equal(t, "test-user-data.yaml", gotFilename)
-	assert.Equal(t, want, gotBody)
+	assert.Equal(t, "snippets", captured["content"])
+	assert.Equal(t, "test-user-data.yaml", captured["filename:filename"])
+	assert.Equal(t, want, captured["filename:body"])
 }
 
 func TestClient_UploadReader(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
 	const payload = "the body"
+	captured := map[string]string{}
 
-	var (
-		gotFilename string
-		gotBody     string
-		gotLength   int64
-	)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotLength = r.ContentLength
+	gock.New(mockConfig.URI).
+		Post("^/test$").
+		AddMatcher(captureMultipart(t, captured)).
+		Reply(200).
+		JSON(`{"data":null}`)
 
-		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
-		require.NoError(t, err)
-		mr := multipart.NewReader(r.Body, params["boundary"])
-		for {
-			part, err := mr.NextPart()
-			if err == io.EOF {
-				break
-			}
-			require.NoError(t, err)
-			data, err := io.ReadAll(part)
-			require.NoError(t, err)
-			if part.FormName() == "filename" {
-				gotFilename = part.FileName()
-				gotBody = string(data)
-			}
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":null}`))
-	}))
-	defer srv.Close()
-
-	client := NewClient(srv.URL)
+	client := mockClient()
 	body := strings.NewReader(payload)
 	err := client.UploadReader("/test", map[string]string{"content": "snippets"}, "hello.txt", body, int64(body.Len()), nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, "hello.txt", gotFilename)
-	assert.Equal(t, payload, gotBody)
-	assert.Greater(t, gotLength, int64(len(payload)))
+	assert.Equal(t, "snippets", captured["content"])
+	assert.Equal(t, "hello.txt", captured["filename:filename"])
+	assert.Equal(t, payload, captured["filename:body"])
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -3,10 +3,17 @@ package proxmox
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClusterStorages(t *testing.T) {
@@ -340,4 +347,108 @@ func TestStorage_MarshalUnmarshalRoundTrip(t *testing.T) {
 	assert.Equal(t, original.Name, unmarshalled.Name, "Name field should be preserved after marshal/unmarshal round-trip")
 	assert.Equal(t, original.Content, unmarshalled.Content)
 	assert.Equal(t, original.Enabled, unmarshalled.Enabled)
+}
+
+func TestStorage_Upload_InvalidContent(t *testing.T) {
+	storage := &Storage{Node: "node1", Name: "local"}
+	_, err := storage.Upload("not-a-real-content-type", "some-file")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snippets")
+}
+
+func TestStorage_UploadString_InvalidContent(t *testing.T) {
+	storage := &Storage{Node: "node1", Name: "local"}
+	_, err := storage.UploadString("not-a-real-content-type", "user-data", "#cloud-config\n")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "snippets")
+}
+
+func TestStorage_UploadString(t *testing.T) {
+	const want = "#cloud-config\nhostname: test\n"
+
+	var (
+		gotContent  string
+		gotFilename string
+		gotBody     string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/nodes/node1/storage/local/upload", r.URL.Path)
+
+		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		require.NoError(t, err)
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			data, err := io.ReadAll(part)
+			require.NoError(t, err)
+			switch part.FormName() {
+			case "content":
+				gotContent = string(data)
+			case "filename":
+				gotFilename = part.FileName()
+				gotBody = string(data)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":"UPID:node1:00000000:00000000:00000000:imgcopy:user-data:root@pam:"}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	storage := &Storage{client: client, Node: "node1", Name: "local"}
+
+	task, err := storage.UploadString("snippets", "test-user-data.yaml", want)
+	require.NoError(t, err)
+	assert.NotNil(t, task)
+
+	assert.Equal(t, "snippets", gotContent)
+	assert.Equal(t, "test-user-data.yaml", gotFilename)
+	assert.Equal(t, want, gotBody)
+}
+
+func TestClient_UploadReader(t *testing.T) {
+	const payload = "the body"
+
+	var (
+		gotFilename string
+		gotBody     string
+		gotLength   int64
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotLength = r.ContentLength
+
+		_, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		require.NoError(t, err)
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			require.NoError(t, err)
+			data, err := io.ReadAll(part)
+			require.NoError(t, err)
+			if part.FormName() == "filename" {
+				gotFilename = part.FileName()
+				gotBody = string(data)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":null}`))
+	}))
+	defer srv.Close()
+
+	client := NewClient(srv.URL)
+	body := strings.NewReader(payload)
+	err := client.UploadReader("/test", map[string]string{"content": "snippets"}, "hello.txt", body, int64(body.Len()), nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello.txt", gotFilename)
+	assert.Equal(t, payload, gotBody)
+	assert.Greater(t, gotLength, int64(len(payload)))
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -1,17 +1,11 @@
 package proxmox
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"io"
-	"mime"
-	"mime/multipart"
-	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/h2non/gock"
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -364,93 +358,27 @@ func TestStorage_UploadString_InvalidContent(t *testing.T) {
 	assert.Contains(t, err.Error(), "snippets")
 }
 
-// captureMultipart returns a gock matcher that drains the multipart request
-// body and stores each form field in the supplied map. Files are stored as
-// "<field-name>:filename" (the uploaded filename) and "<field-name>:body"
-// (the file contents). It always matches; field-level assertions belong in
-// the test using assert.Equal afterwards.
-func captureMultipart(t *testing.T, captured map[string]string) func(*http.Request, *gock.Request) (bool, error) {
-	t.Helper()
-	return func(req *http.Request, _ *gock.Request) (bool, error) {
-		_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
-		if err != nil {
-			return false, err
-		}
-		// Buffer the body so gock can still see it for any other matchers.
-		raw, err := io.ReadAll(req.Body)
-		if err != nil {
-			return false, err
-		}
-		req.Body = io.NopCloser(bytes.NewReader(raw))
-
-		mr := multipart.NewReader(bytes.NewReader(raw), params["boundary"])
-		for {
-			part, err := mr.NextPart()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return false, err
-			}
-			data, err := io.ReadAll(part)
-			if err != nil {
-				return false, err
-			}
-			if part.FileName() != "" {
-				captured[part.FormName()+":filename"] = part.FileName()
-				captured[part.FormName()+":body"] = string(data)
-			} else {
-				captured[part.FormName()] = string(data)
-			}
-		}
-		return true, nil
-	}
-}
-
 func TestStorage_UploadString(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 
-	const want = "#cloud-config\nhostname: test\n"
-	captured := map[string]string{}
-
-	gock.New(mockConfig.URI).
-		Post("^/nodes/node1/storage/local/upload$").
-		AddMatcher(captureMultipart(t, captured)).
-		Reply(200).
-		JSON(`{"data":"UPID:node1:00000000:00000000:00000000:imgcopy:user-data:root@pam:"}`)
-
-	client := mockClient()
-	storage := &Storage{client: client, Node: "node1", Name: "local"}
-
-	task, err := storage.UploadString("snippets", "test-user-data.yaml", want)
+	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+	task, err := storage.UploadString("snippets", "test-user-data.yaml", "#cloud-config\nhostname: test\n")
 	require.NoError(t, err)
-	assert.NotNil(t, task)
-
-	assert.Equal(t, "snippets", captured["content"])
-	assert.Equal(t, "test-user-data.yaml", captured["filename:filename"])
-	assert.Equal(t, want, captured["filename:body"])
+	require.NotNil(t, task)
+	assert.Equal(t, "node1", task.Node)
+	assert.Equal(t, "imgcopy", task.Type)
 }
 
 func TestClient_UploadReader(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 
-	const payload = "the body"
-	captured := map[string]string{}
-
-	gock.New(mockConfig.URI).
-		Post("^/test$").
-		AddMatcher(captureMultipart(t, captured)).
-		Reply(200).
-		JSON(`{"data":null}`)
-
-	client := mockClient()
-	body := strings.NewReader(payload)
-	err := client.UploadReader("/test", map[string]string{"content": "snippets"}, "hello.txt", body, int64(body.Len()), nil)
+	body := strings.NewReader("the body")
+	err := mockClient().UploadReader(
+		"/nodes/node1/storage/local/upload",
+		map[string]string{"content": "snippets"},
+		"hello.txt", body, int64(body.Len()), nil,
+	)
 	require.NoError(t, err)
-
-	assert.Equal(t, "snippets", captured["content"])
-	assert.Equal(t, "hello.txt", captured["filename:filename"])
-	assert.Equal(t, payload, captured["filename:body"])
 }

--- a/tests/mocks/capture/capture.go
+++ b/tests/mocks/capture/capture.go
@@ -1,0 +1,77 @@
+// Package capture wires gock matchers that record details of intercepted
+// requests so tests can assert on the body of multipart uploads (which gock
+// can't match natively).
+package capture
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/h2non/gock"
+)
+
+// Upload holds the multipart fields of the most recent upload request.
+type Upload struct {
+	// Fields contains the non-file form fields keyed by field name.
+	Fields map[string]string
+	// Filename is the upload's "filename" form file name (the file the user
+	// chose), not the form field name.
+	Filename string
+	// Body is the contents of the uploaded file.
+	Body string
+}
+
+// LastUpload is populated by UploadMatcher each time the upload endpoint is
+// hit. Reset() clears it. Tests should read it after the call under test.
+var LastUpload *Upload
+
+// Reset clears any captured state. Called from mocks.On so prior tests
+// don't bleed into subsequent ones.
+func Reset() { LastUpload = nil }
+
+// UploadMatcher returns a gock matcher that drains the request body, parses
+// it as multipart/form-data, and stores the result in LastUpload. It always
+// reports a match so it can be combined with the URL/method matchers on a
+// persistent mock.
+func UploadMatcher() gock.MatchFunc {
+	return func(req *http.Request, _ *gock.Request) (bool, error) {
+		_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+		if err != nil {
+			return false, err
+		}
+
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			return false, err
+		}
+		// Restore the body so gock and any subsequent consumers see it.
+		req.Body = io.NopCloser(bytes.NewReader(raw))
+
+		captured := &Upload{Fields: map[string]string{}}
+		mr := multipart.NewReader(bytes.NewReader(raw), params["boundary"])
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return false, err
+			}
+			data, err := io.ReadAll(part)
+			if err != nil {
+				return false, err
+			}
+			if part.FileName() != "" {
+				captured.Filename = part.FileName()
+				captured.Body = string(data)
+			} else {
+				captured.Fields[part.FormName()] = string(data)
+			}
+		}
+		LastUpload = captured
+		return true, nil
+	}
+}

--- a/tests/mocks/main.go
+++ b/tests/mocks/main.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/capture"
 	"github.com/luthermonson/go-proxmox/tests/mocks/config"
 	"github.com/luthermonson/go-proxmox/tests/mocks/pve6x"
 	"github.com/luthermonson/go-proxmox/tests/mocks/pve7x"
@@ -10,6 +11,7 @@ import (
 )
 
 func On(c config.Config) {
+	capture.Reset()
 	ProxmoxVE9x(c) // default pve9
 }
 

--- a/tests/mocks/pve7x/storage.go
+++ b/tests/mocks/pve7x/storage.go
@@ -144,4 +144,13 @@ func storage() {
 		JSON(`{
     "data": "UPID:node1:00000003:00000003:00000003:download:iso:root@pam:"
 }`)
+
+	// POST /nodes/{node}/storage/{storage}/upload - Upload content (iso, vztmpl, snippets, ...)
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/storage/local/upload$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00000004:00000004:00000004:imgcopy:upload:root@pam:"
+}`)
 }

--- a/tests/mocks/pve7x/storage.go
+++ b/tests/mocks/pve7x/storage.go
@@ -2,6 +2,7 @@ package pve7x
 
 import (
 	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/capture"
 	"github.com/luthermonson/go-proxmox/tests/mocks/config"
 )
 
@@ -146,9 +147,12 @@ func storage() {
 }`)
 
 	// POST /nodes/{node}/storage/{storage}/upload - Upload content (iso, vztmpl, snippets, ...)
+	// Multipart bodies are recorded by capture.UploadMatcher so tests can
+	// assert on the content/filename/body fields.
 	gock.New(config.C.URI).
 		Persist().
 		Post("^/nodes/node1/storage/local/upload$").
+		AddMatcher(capture.UploadMatcher()).
 		Reply(200).
 		JSON(`{
     "data": "UPID:node1:00000004:00000004:00000004:imgcopy:upload:root@pam:"

--- a/tests/mocks/pve8x/storage.go
+++ b/tests/mocks/pve8x/storage.go
@@ -144,4 +144,13 @@ func storage() {
 		JSON(`{
     "data": "UPID:node1:00000003:00000003:00000003:download:iso:root@pam:"
 }`)
+
+	// POST /nodes/{node}/storage/{storage}/upload - Upload content (iso, vztmpl, snippets, ...)
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/storage/local/upload$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00000004:00000004:00000004:imgcopy:upload:root@pam:"
+}`)
 }

--- a/tests/mocks/pve8x/storage.go
+++ b/tests/mocks/pve8x/storage.go
@@ -2,6 +2,7 @@ package pve8x
 
 import (
 	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/capture"
 	"github.com/luthermonson/go-proxmox/tests/mocks/config"
 )
 
@@ -146,9 +147,12 @@ func storage() {
 }`)
 
 	// POST /nodes/{node}/storage/{storage}/upload - Upload content (iso, vztmpl, snippets, ...)
+	// Multipart bodies are recorded by capture.UploadMatcher so tests can
+	// assert on the content/filename/body fields.
 	gock.New(config.C.URI).
 		Persist().
 		Post("^/nodes/node1/storage/local/upload$").
+		AddMatcher(capture.UploadMatcher()).
 		Reply(200).
 		JSON(`{
     "data": "UPID:node1:00000004:00000004:00000004:imgcopy:upload:root@pam:"

--- a/tests/mocks/pve9x/storage.go
+++ b/tests/mocks/pve9x/storage.go
@@ -142,4 +142,13 @@ func storage() {
 		JSON(`{
     "data": "UPID:node1:00000003:00000003:00000003:download:iso:root@pam:"
 }`)
+
+	// POST /nodes/{node}/storage/{storage}/upload - Upload content (iso, vztmpl, snippets, ...)
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/storage/local/upload$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00000004:00000004:00000004:imgcopy:upload:root@pam:"
+}`)
 }

--- a/tests/mocks/pve9x/storage.go
+++ b/tests/mocks/pve9x/storage.go
@@ -2,6 +2,7 @@ package pve9x
 
 import (
 	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/capture"
 	"github.com/luthermonson/go-proxmox/tests/mocks/config"
 )
 
@@ -144,9 +145,12 @@ func storage() {
 }`)
 
 	// POST /nodes/{node}/storage/{storage}/upload - Upload content (iso, vztmpl, snippets, ...)
+	// Multipart bodies are recorded by capture.UploadMatcher so tests can
+	// assert on the content/filename/body fields.
 	gock.New(config.C.URI).
 		Persist().
 		Post("^/nodes/node1/storage/local/upload$").
+		AddMatcher(capture.UploadMatcher()).
 		Reply(200).
 		JSON(`{
     "data": "UPID:node1:00000004:00000004:00000004:imgcopy:upload:root@pam:"


### PR DESCRIPTION
Closes #251

## Summary

- Add `Client.UploadReader` — `io.Reader`-based variant of `Upload` that takes an explicit size; the existing `Client.Upload(*os.File)` is refactored to delegate to it (no public signature change)
- Add `Storage.UploadString(content, storageFilename, contents string) (*Task, error)` — upload an in-memory string without writing to a temp file. Useful for snippets like cloud-init user-data and hookscripts

## Test plan
- [x] `TestNode_StorageByContent` extended to assert `StorageSnippets`
- [x] `TestStorage_Upload_InvalidContent` / `TestStorage_UploadString_InvalidContent` cover the validation early-return
- [x] `TestStorage_UploadString` spins up an `httptest.NewServer`, parses the multipart body, and verifies the `content` / `filename` / file body fields are correct
- [x] `TestClient_UploadReader` similarly verifies the lower-level multipart upload path
- [x] Full test suite (`go test ./...`) passes
- [x] `errcheck` clean