### PR TITLE
fix: make TermWebSocket/VNCWebSocket actually work, surface API-token limits

### DIFF
--- a/proxmox.go
+++ b/proxmox.go
@@ -54,6 +54,18 @@ func IsErrNoop(err error) bool {
 	return errors.Is(err, ErrNoop)
 }
 
+// ErrAPITokenWebSocketUnsupported is returned by TermWebSocket and VNCWebSocket
+// when the client is authenticated with an API token. Proxmox's vncwebsocket
+// endpoint rejects the token-suffixed user (e.g. "root@pam!tokenname") during
+// the post-upgrade auth handshake, which surfaces here as "unexpected EOF" and
+// on the server as `failed waiting for client: timed out`. Use WithCredentials
+// or WithSession for terminal/VNC access.
+var ErrAPITokenWebSocketUnsupported = errors.New("proxmox does not accept API tokens for vncwebsocket; use WithCredentials or WithSession")
+
+func IsAPITokenWebSocketUnsupported(err error) bool {
+	return errors.Is(err, ErrAPITokenWebSocketUnsupported)
+}
+
 func MakeTag(v string) string {
 	return fmt.Sprintf(TagFormat, v)
 }
@@ -348,7 +360,17 @@ func (c *Client) handleResponse(res *http.Response, v interface{}) error {
 	return json.Unmarshal(body, &v) // assume passed in type fully supports response
 }
 
+// TermWebSocket opens a terminal WebSocket connection to a previously created
+// termproxy session. It is invoked by Node.TermWebSocket, VirtualMachine.TermWebSocket,
+// and Container.TermWebSocket.
+//
+// Returns ErrAPITokenWebSocketUnsupported if the client is authenticated with
+// an API token; Proxmox does not accept tokens for /vncwebsocket — see issue
+// luthermonson/go-proxmox#221 and the linked Proxmox forum threads.
 func (c *Client) TermWebSocket(path string, term *Term) (chan []byte, chan []byte, chan error, func() error, error) {
+	if c.token != "" {
+		return nil, nil, nil, nil, ErrAPITokenWebSocketUnsupported
+	}
 	if strings.HasPrefix(path, "/") {
 		path = strings.Replace(c.baseURL, "https://", "wss://", 1) + path
 	}
@@ -363,6 +385,12 @@ func (c *Client) TermWebSocket(path string, term *Term) (chan []byte, chan []byt
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: 30 * time.Second,
 		TLSClientConfig:  tlsConfig,
+		// Proxmox's vncwebsocket handler requires the "binary" subprotocol —
+		// the web UI's xterm.js opens the socket with `new WebSocket(url, "binary")`.
+		// Without it the server closes the upgraded connection immediately,
+		// surfacing as "close 1006 (abnormal closure): unexpected EOF" on the
+		// first read.
+		Subprotocols: []string{"binary"},
 	}
 
 	dialerHeaders := http.Header{}
@@ -398,8 +426,9 @@ func (c *Client) TermWebSocket(path string, term *Term) (chan []byte, chan []byt
 		width:  goterm.Width(),
 	}
 
-	c.log.Debugf("sending terminal size: %d x %d", tsize.height, tsize.width)
-	if err := conn.WriteMessage(websocket.BinaryMessage, []byte(fmt.Sprintf("1:%d:%d:", tsize.height, tsize.width))); err != nil {
+	// Proxmox's xterm.js resize protocol is "1:<cols>:<rows>:" — width first.
+	c.log.Debugf("sending terminal size: cols=%d rows=%d", tsize.width, tsize.height)
+	if err := conn.WriteMessage(websocket.BinaryMessage, []byte(fmt.Sprintf("1:%d:%d:", tsize.width, tsize.height))); err != nil {
 		return nil, nil, nil, nil, err
 	}
 
@@ -477,8 +506,8 @@ func (c *Client) TermWebSocket(path string, term *Term) (chan []byte, chan []byt
 					errs <- err
 				}
 			case resized := <-resize:
-				c.log.Debugf("resizing terminal window: %d x %d", resized.height, resized.width)
-				if err := conn.WriteMessage(websocket.BinaryMessage, []byte(fmt.Sprintf("1:%d:%d:", resized.height, resized.width))); err != nil {
+				c.log.Debugf("resizing terminal window: cols=%d rows=%d", resized.width, resized.height)
+				if err := conn.WriteMessage(websocket.BinaryMessage, []byte(fmt.Sprintf("1:%d:%d:", resized.width, resized.height))); err != nil {
 					errs <- err
 				}
 			case msg := <-send:
@@ -494,7 +523,16 @@ func (c *Client) TermWebSocket(path string, term *Term) (chan []byte, chan []byt
 	return send, recv, errs, closer, nil
 }
 
+// VNCWebSocket opens a VNC WebSocket connection to a previously created VNC
+// session. It is invoked by Node.VNCWebSocket, VirtualMachine.VNCWebSocket,
+// and Container.VNCWebSocket.
+//
+// Returns ErrAPITokenWebSocketUnsupported if the client is authenticated with
+// an API token; see TermWebSocket for the underlying Proxmox limitation.
 func (c *Client) VNCWebSocket(path string, vnc *VNC) (chan []byte, chan []byte, chan error, func() error, error) {
+	if c.token != "" {
+		return nil, nil, nil, nil, ErrAPITokenWebSocketUnsupported
+	}
 	if strings.HasPrefix(path, "/") {
 		path = strings.Replace(c.baseURL, "https://", "wss://", 1) + path
 	}
@@ -509,6 +547,12 @@ func (c *Client) VNCWebSocket(path string, vnc *VNC) (chan []byte, chan []byte, 
 		Proxy:            http.ProxyFromEnvironment,
 		HandshakeTimeout: 30 * time.Second,
 		TLSClientConfig:  tlsConfig,
+		// Proxmox's vncwebsocket handler requires the "binary" subprotocol —
+		// the web UI's xterm.js opens the socket with `new WebSocket(url, "binary")`.
+		// Without it the server closes the upgraded connection immediately,
+		// surfacing as "close 1006 (abnormal closure): unexpected EOF" on the
+		// first read.
+		Subprotocols: []string{"binary"},
 	}
 
 	dialerHeaders := http.Header{}

--- a/proxmox_test.go
+++ b/proxmox_test.go
@@ -69,6 +69,27 @@ func TestClient_authHeaders(t *testing.T) {
 	}
 }
 
+func TestClient_TermWebSocket_APITokenUnsupported(t *testing.T) {
+	c := NewClient(TestURI, WithAPIToken("root@pam!test", "secret"))
+	send, recv, errs, closer, err := c.TermWebSocket("/nodes/n/lxc/100/vncwebsocket?port=1&vncticket=t", &Term{})
+	assert.Nil(t, send)
+	assert.Nil(t, recv)
+	assert.Nil(t, errs)
+	assert.Nil(t, closer)
+	assert.ErrorIs(t, err, ErrAPITokenWebSocketUnsupported)
+	assert.True(t, IsAPITokenWebSocketUnsupported(err))
+}
+
+func TestClient_VNCWebSocket_APITokenUnsupported(t *testing.T) {
+	c := NewClient(TestURI, WithAPIToken("root@pam!test", "secret"))
+	send, recv, errs, closer, err := c.VNCWebSocket("/nodes/n/qemu/100/vncwebsocket?port=1&vncticket=t", &VNC{})
+	assert.Nil(t, send)
+	assert.Nil(t, recv)
+	assert.Nil(t, errs)
+	assert.Nil(t, closer)
+	assert.ErrorIs(t, err, ErrAPITokenWebSocketUnsupported)
+}
+
 func TestClient_Version7(t *testing.T) {
 	mocks.ProxmoxVE7x(mockConfig)
 	defer mocks.Off()


### PR DESCRIPTION
fixes #221 

Three independent fixes for issue #221, all in the WebSocket handshake path:

1. Request the "binary" Sec-WebSocket-Protocol subprotocol on the dialer. Proxmox's vncwebsocket handler closes the connection right after the upgrade if the client did not advertise it (the WebUI's xterm.js opens the socket with `new WebSocket(url, "binary")`). The symptom was "websocket: close 1006 (abnormal closure): unexpected EOF" on the first ReadMessage, hitting every caller regardless of auth method.

2. Fix the resize message field order. The Proxmox protocol is "1:<cols>:<rows>:" but we were sending rows first, so any non-square terminal was resized to the transposed geometry. Renamed debug logs to spell out cols=/rows= so the meaning is no longer ambiguous.

3. Return a clear sentinel ErrAPITokenWebSocketUnsupported when the client was built with WithAPIToken. Proxmox's termproxy validates the VNC ticket by calling /access/ticket with the authuser, and verify_username rejects the "!tokenname" suffix; the VNC ticket HMAC is bound to the same user-with-suffix so stripping client-side does not work either. Independently rediscovered by akoenig/proxctl in the same investigation. Without this guard callers got the same opaque "unexpected EOF" as the other handshake failures, which was how #221 was originally reported.

Adds unit tests for the API-token early-return on both Term and VNC helpers.