### PR TITLE
fix: capture all indexed device entries in VirtualMachineConfig/ContainerConfig (#211)

### DIFF
--- a/containers_test.go
+++ b/containers_test.go
@@ -36,6 +36,37 @@ func TestContainerConfig_UnmarshalJSON_BeyondTen(t *testing.T) {
 	assert.Equal(t, "name=eth0,bridge=vmbr0", cfg.Nets["net0"])
 }
 
+// TestNode_ContainerConfig_HighIndices is the integration-shaped regression
+// test for issue #211 on the LXC side: routes mp42/mp255, dev15, net20,
+// unused100 through node.Container(ctx, 102) and the gock mock.
+func TestNode_ContainerConfig_HighIndices(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	ct, err := node.Container(ctx, 102)
+	assert.Nil(t, err)
+	assert.NotNil(t, ct)
+	assert.NotNil(t, ct.ContainerConfig)
+
+	cfg := ct.ContainerConfig
+
+	assert.Equal(t, "/srv/data,mp=/data", cfg.Mps["mp0"])
+	assert.Equal(t, "/srv/forty-two,mp=/forty-two", cfg.Mps["mp42"])
+	assert.Equal(t, "/srv/last,mp=/last", cfg.Mps["mp255"])
+	assert.Equal(t, "name=eth0,bridge=vmbr0", cfg.Nets["net0"])
+	assert.Equal(t, "name=eth20,bridge=vmbr20", cfg.Nets["net20"])
+	assert.Equal(t, "/dev/sdb15", cfg.Devs["dev15"])
+	assert.Equal(t, "local-lvm:subvol-102-unused-100", cfg.Unuseds["unused100"])
+
+	// Net0 keeps the explicit-field mirror for back-compat.
+	assert.Equal(t, "name=eth0,bridge=vmbr0", cfg.Net0)
+}
+
 func TestContainer(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/containers_test.go
+++ b/containers_test.go
@@ -2,11 +2,39 @@ package proxmox
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestContainerConfig_UnmarshalJSON_BeyondTen exercises issue #211 for LXC:
+// mp0..mp255 and dev0..dev255 in particular routinely exceed 9 in real setups.
+func TestContainerConfig_UnmarshalJSON_BeyondTen(t *testing.T) {
+	body := []byte(`{
+		"mp0": "/srv/data,mp=/data",
+		"mp42": "/srv/forty-two,mp=/forty-two",
+		"mp255": "/srv/last,mp=/last",
+		"net0": "name=eth0,bridge=vmbr0",
+		"net20": "name=eth20,bridge=vmbr20",
+		"dev15": "/dev/sdb15",
+		"unused100": "local-lvm:subvol-100-unused-100"
+	}`)
+
+	var cfg ContainerConfig
+	assert.NoError(t, json.Unmarshal(body, &cfg))
+
+	assert.Equal(t, "/srv/forty-two,mp=/forty-two", cfg.Mps["mp42"])
+	assert.Equal(t, "/srv/last,mp=/last", cfg.Mps["mp255"])
+	assert.Equal(t, "name=eth20,bridge=vmbr20", cfg.Nets["net20"])
+	assert.Equal(t, "/dev/sdb15", cfg.Devs["dev15"])
+	assert.Equal(t, "local-lvm:subvol-100-unused-100", cfg.Unuseds["unused100"])
+
+	// Net0 keeps the explicit-field mirror for back-compat.
+	assert.Equal(t, "name=eth0,bridge=vmbr0", cfg.Net0)
+	assert.Equal(t, "name=eth0,bridge=vmbr0", cfg.Nets["net0"])
+}
 
 func TestContainer(t *testing.T) {
 	mocks.On(mockConfig)

--- a/tests/mocks/pve9x/containers.go
+++ b/tests/mocks/pve9x/containers.go
@@ -48,6 +48,52 @@ func containers() {
     ]
 }`)
 
+	// GET /nodes/node1/lxc/102/status/current — minimal payload to support
+	// the high-index regression test for issue #211.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/lxc/102/status/current$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "vmid": 102,
+        "status": "running",
+        "name": "ct-wide",
+        "cpus": 2,
+        "maxmem": 2147483648,
+        "maxdisk": 17179869184,
+        "maxswap": 536870912,
+        "uptime": 100
+    }
+}`)
+
+	// GET /nodes/node1/lxc/102/config — high-index entries (mp42, mp255, dev15,
+	// net20, unused100) so node.Container(ctx, 102) verifies the maps capture
+	// indices >9 for LXC too.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/lxc/102/config$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "arch": "amd64",
+        "cores": 2,
+        "hostname": "ct-wide",
+        "memory": 2048,
+        "ostype": "ubuntu",
+        "rootfs": "local-lvm:vm-102-disk-0,size=8G",
+        "swap": 512,
+        "digest": "wideabcdef1234567890",
+        "net0": "name=eth0,bridge=vmbr0",
+        "net20": "name=eth20,bridge=vmbr20",
+        "mp0": "/srv/data,mp=/data",
+        "mp42": "/srv/forty-two,mp=/forty-two",
+        "mp255": "/srv/last,mp=/last",
+        "dev15": "/dev/sdb15",
+        "unused100": "local-lvm:subvol-102-unused-100"
+    }
+}`)
+
 	// GET /nodes/{node}/lxc/{vmid}/status/current - Get container current status
 	gock.New(config.C.URI).
 		Get("^/nodes/node1/lxc/101/status/current$").

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -39,6 +39,57 @@ func virtualMachines() {
     }
 }`)
 
+	// GET /nodes/{node}/qemu/102/config — high-index device entries plus
+	// prefix-collision fields (scsihw, bare numa). Issue #211 regression coverage:
+	// proves the UnmarshalJSON router routes net15..net31, scsi30, unused255,
+	// hostpci15, ipconfig20 into the maps and does NOT route scsihw or numa.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/102/config$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "digest": "abc123def456beyondten",
+        "name": "wide",
+        "vmid": 102,
+        "cores": 4,
+        "memory": 4096,
+        "ostype": "l26",
+        "scsihw": "virtio-scsi-pci",
+        "numa": 1,
+        "scsi0": "local-lvm:vm-102-disk-0,size=32G",
+        "scsi30": "local-lvm:vm-102-disk-30,size=32G",
+        "net0": "virtio=00:00:00:00:00:00,bridge=vmbr0",
+        "net15": "virtio=00:00:00:00:00:15,bridge=vmbr15",
+        "net31": "virtio=00:00:00:00:00:31,bridge=vmbr31",
+        "unused15": "local-lvm:vm-102-unused-15",
+        "unused255": "local-lvm:vm-102-unused-255",
+        "hostpci15": "0000:0f:00.0",
+        "numa0": "cpus=0-1,memory=2048",
+        "ipconfig20": "ip=10.0.0.20/24,gw=10.0.0.1"
+    }
+}`)
+
+	// GET /nodes/node1/qemu/102/status/current — minimal status payload so
+	// node.VirtualMachine(ctx, 102) succeeds before fetching /config.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/102/status/current$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "vmid": 102,
+        "name": "wide",
+        "status": "running",
+        "uptime": 1234,
+        "cpus": 4,
+        "maxmem": 4294967296,
+        "mem": 0,
+        "maxdisk": 34359738368,
+        "disk": 0
+    }
+}`)
+
 	// GET /nodes/{node}/qemu/{vmid}/status/current - VM status
 	gock.New(config.C.URI).
 		Get("^/nodes/node1/qemu/101/status/current$").

--- a/types.go
+++ b/types.go
@@ -772,6 +772,33 @@ type VirtualMachineConfig struct {
 	IPConfig9 string            `json:"ipconfig9,omitempty"`
 }
 
+// indexedDeviceMaps lists the JSON-key prefixes that get routed into a
+// per-prefix helper map on VirtualMachineConfig. Proxmox accepts more indices
+// for each device type than the explicit IDE0..VirtIO15 fields cover (e.g.
+// net0..net31, scsi0..scsi30, unused0..unused255), so the maps are the
+// authoritative source of truth and the explicit fields stay as a
+// compatibility mirror for indices 0..9. Plan: mark the explicit fields
+// // Deprecated in v0.7.x and drop them in a later release.
+//
+// Order does not matter; lookups are by exact prefix followed by a pure-digit
+// suffix, which means "scsihw" and the bare "numa" scalar do not collide.
+func (vmc *VirtualMachineConfig) indexedDeviceMaps() map[string]*map[string]string {
+	return map[string]*map[string]string{
+		"ide":      &vmc.IDEs,
+		"scsi":     &vmc.SCSIs,
+		"sata":     &vmc.SATAs,
+		"virtio":   &vmc.VirtIOs,
+		"unused":   &vmc.Unuseds,
+		"net":      &vmc.Nets,
+		"numa":     &vmc.Numas,
+		"hostpci":  &vmc.HostPCIs,
+		"serial":   &vmc.Serials,
+		"usb":      &vmc.USBs,
+		"parallel": &vmc.Parallels,
+		"ipconfig": &vmc.IPConfigs,
+	}
+}
+
 func (vmc *VirtualMachineConfig) UnmarshalJSON(data []byte) error {
 	type tmpVirtualMachineConfig VirtualMachineConfig
 
@@ -790,21 +817,56 @@ func (vmc *VirtualMachineConfig) UnmarshalJSON(data []byte) error {
 	// Split the tags on TagSeparator and populate TagsSlice
 	vmc.TagsSlice = strings.Split(vmc.Tags, TagSeperator)
 
-	// Populate the indexed fields into helper maps
-	vmc.MergeIDEs()
-	vmc.MergeSCSIs()
-	vmc.MergeSATAs()
-	vmc.MergeVirtIOs()
-	vmc.MergeUnuseds()
-	vmc.MergeNets()
-	vmc.MergeNumas()
-	vmc.MergeHostPCIs()
-	vmc.MergeSerials()
-	vmc.MergeUSBs()
-	vmc.MergeParallels()
-	vmc.MergeIPConfigs()
+	// Walk the raw JSON object once and route every "<prefix><digits>" key
+	// into its target map. This captures indices Proxmox returns beyond the
+	// explicit struct fields (e.g. net10..net31, scsi10..scsi30).
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	routes := vmc.indexedDeviceMaps()
+	for k, v := range raw {
+		prefix, ok := indexedDeviceKey(k)
+		if !ok {
+			continue
+		}
+		target, ok := routes[prefix]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			// non-string indexed value — skip rather than fail the whole config
+			continue
+		}
+		if *target == nil {
+			*target = make(map[string]string)
+		}
+		(*target)[k] = s
+	}
 
 	return nil
+}
+
+// indexedDeviceKey returns ("net", true) for "net10" and ("", false) for keys
+// like "scsihw" or "numa" that share a prefix but lack a pure-digit suffix.
+func indexedDeviceKey(k string) (prefix string, ok bool) {
+	for i := 0; i < len(k); i++ {
+		c := k[i]
+		if c >= '0' && c <= '9' {
+			if i == 0 {
+				return "", false
+			}
+			// rest of the string must be all digits
+			for j := i + 1; j < len(k); j++ {
+				if k[j] < '0' || k[j] > '9' {
+					return "", false
+				}
+			}
+			return k[:i], true
+		}
+	}
+	return "", false
 }
 
 type VirtualMachineMigrateOptions struct {
@@ -1037,6 +1099,17 @@ type ContainerConfig struct {
 	Unused9      string            `json:"unused9,omitempty"`
 }
 
+// indexedDeviceMaps mirrors VirtualMachineConfig.indexedDeviceMaps for the
+// container side: dev0..dev255, mp0..mp255, net0..net31, unused0..unused255.
+func (cc *ContainerConfig) indexedDeviceMaps() map[string]*map[string]string {
+	return map[string]*map[string]string{
+		"dev":    &cc.Devs,
+		"mp":     &cc.Mps,
+		"net":    &cc.Nets,
+		"unused": &cc.Unuseds,
+	}
+}
+
 func (cc *ContainerConfig) UnmarshalJSON(data []byte) error {
 	type tmpContainerConfig ContainerConfig
 
@@ -1054,11 +1127,31 @@ func (cc *ContainerConfig) UnmarshalJSON(data []byte) error {
 	// Split the tags on TagSeparator and populate TagsSlice
 	cc.TagsSlice = strings.Split(cc.Tags, TagSeperator)
 
-	// Populate the indexed fields into helper maps
-	cc.MergeDevs()
-	cc.MergeMps()
-	cc.MergeNets()
-	cc.MergeUnuseds()
+	// Walk the raw JSON object once and route every "<prefix><digits>" key
+	// into its target map; covers indices beyond the explicit Net0..Net9 etc.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	routes := cc.indexedDeviceMaps()
+	for k, v := range raw {
+		prefix, ok := indexedDeviceKey(k)
+		if !ok {
+			continue
+		}
+		target, ok := routes[prefix]
+		if !ok {
+			continue
+		}
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			continue
+		}
+		if *target == nil {
+			*target = make(map[string]string)
+		}
+		(*target)[k] = s
+	}
 
 	return nil
 }

--- a/virtual_machine_config_test.go
+++ b/virtual_machine_config_test.go
@@ -310,6 +310,51 @@ func TestIndexedDeviceKey(t *testing.T) {
 	}
 }
 
+// TestNode_VirtualMachineConfig_HighIndices is the integration-shaped regression
+// test for issue #211: it goes through node.VirtualMachine(ctx, 102), which hits
+// the gock mock returning net15..net31, scsi30, unused255, hostpci15, ipconfig20,
+// plus prefix-collision keys (scsihw, bare numa).
+func TestNode_VirtualMachineConfig_HighIndices(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	vm, err := node.VirtualMachine(ctx, 102)
+	assert.Nil(t, err)
+	assert.NotNil(t, vm)
+	assert.NotNil(t, vm.VirtualMachineConfig)
+
+	cfg := vm.VirtualMachineConfig
+
+	assert.Equal(t, "virtio=00:00:00:00:00:00,bridge=vmbr0", cfg.Nets["net0"])
+	assert.Equal(t, "virtio=00:00:00:00:00:15,bridge=vmbr15", cfg.Nets["net15"])
+	assert.Equal(t, "virtio=00:00:00:00:00:31,bridge=vmbr31", cfg.Nets["net31"])
+	assert.Equal(t, "local-lvm:vm-102-disk-30,size=32G", cfg.SCSIs["scsi30"])
+	assert.Equal(t, "local-lvm:vm-102-unused-15", cfg.Unuseds["unused15"])
+	assert.Equal(t, "local-lvm:vm-102-unused-255", cfg.Unuseds["unused255"])
+	assert.Equal(t, "0000:0f:00.0", cfg.HostPCIs["hostpci15"])
+	assert.Equal(t, "ip=10.0.0.20/24,gw=10.0.0.1", cfg.IPConfigs["ipconfig20"])
+	assert.Equal(t, "cpus=0-1,memory=2048", cfg.Numas["numa0"])
+
+	// Net0/Scsi0 keep the explicit-field mirror for back-compat.
+	assert.Equal(t, "virtio=00:00:00:00:00:00,bridge=vmbr0", cfg.Net0)
+	assert.Equal(t, "local-lvm:vm-102-disk-0,size=32G", cfg.SCSI0)
+
+	// scsihw must remain in the SCSIHW scalar — never in SCSIs.
+	assert.Equal(t, "virtio-scsi-pci", cfg.SCSIHW)
+	_, hasSCSIHW := cfg.SCSIs["scsihw"]
+	assert.False(t, hasSCSIHW)
+
+	// Bare numa scalar must remain in Numa — never in Numas.
+	assert.Equal(t, 1, cfg.Numa)
+	_, hasBareNuma := cfg.Numas["numa"]
+	assert.False(t, hasBareNuma)
+}
+
 func TestNode_VirtualMachineConfig_AllMergedMapsPopulated(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/virtual_machine_config_test.go
+++ b/virtual_machine_config_test.go
@@ -2,6 +2,7 @@ package proxmox
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -222,6 +223,91 @@ func TestVirtualMachineConfig_MergeIndexedDevices_IgnoresNonNumeric(t *testing.T
 	assert.Equal(t, "local-lvm:vm-100-disk-0,size=32G", scsis["scsi0"])
 	_, hasSCSIHW := scsis["scsihw"]
 	assert.False(t, hasSCSIHW, "SCSIHW should not be included in merge")
+}
+
+// TestVirtualMachineConfig_UnmarshalJSON_BeyondTen exercises issue #211: the
+// Proxmox API can return device indices well past 9 (net0..net31, scsi0..scsi30,
+// unused0..unused255 etc.). The explicit Net0..Net9 fields only cover 0..9, so
+// the maps must capture indices >9 directly from the raw JSON.
+func TestVirtualMachineConfig_UnmarshalJSON_BeyondTen(t *testing.T) {
+	body := []byte(`{
+		"net0": "virtio=00:00:00:00:00:00,bridge=vmbr0",
+		"net15": "virtio=00:00:00:00:00:15,bridge=vmbr15",
+		"net31": "virtio=00:00:00:00:00:31,bridge=vmbr31",
+		"scsi0": "local-lvm:vm-100-disk-0,size=32G",
+		"scsi30": "local-lvm:vm-100-disk-30,size=32G",
+		"unused15": "local-lvm:vm-100-unused-15",
+		"unused255": "local-lvm:vm-100-unused-255",
+		"hostpci15": "0000:0f:00.0",
+		"ipconfig20": "ip=10.0.0.20/24"
+	}`)
+
+	var cfg VirtualMachineConfig
+	assert.NoError(t, json.Unmarshal(body, &cfg))
+
+	assert.Equal(t, "virtio=00:00:00:00:00:15,bridge=vmbr15", cfg.Nets["net15"])
+	assert.Equal(t, "virtio=00:00:00:00:00:31,bridge=vmbr31", cfg.Nets["net31"])
+	assert.Equal(t, "local-lvm:vm-100-disk-30,size=32G", cfg.SCSIs["scsi30"])
+	assert.Equal(t, "local-lvm:vm-100-unused-15", cfg.Unuseds["unused15"])
+	assert.Equal(t, "local-lvm:vm-100-unused-255", cfg.Unuseds["unused255"])
+	assert.Equal(t, "0000:0f:00.0", cfg.HostPCIs["hostpci15"])
+	assert.Equal(t, "ip=10.0.0.20/24", cfg.IPConfigs["ipconfig20"])
+
+	// Net0 keeps the explicit-field mirror for back-compat with existing callers.
+	assert.Equal(t, "virtio=00:00:00:00:00:00,bridge=vmbr0", cfg.Net0)
+	assert.Equal(t, "virtio=00:00:00:00:00:00,bridge=vmbr0", cfg.Nets["net0"])
+}
+
+// TestVirtualMachineConfig_UnmarshalJSON_PrefixCollisions guards against the
+// regression that closed PR #217 would have introduced: routing keys via
+// strings.HasPrefix puts "scsihw" into the SCSIs map and the bare "numa"
+// scalar into the Numas map. The prefix-then-pure-digits routing skips both.
+func TestVirtualMachineConfig_UnmarshalJSON_PrefixCollisions(t *testing.T) {
+	body := []byte(`{
+		"scsihw": "virtio-scsi-pci",
+		"scsi0": "local-lvm:vm-100-disk-0,size=32G",
+		"numa": 1,
+		"numa0": "cpus=0-1,memory=2048"
+	}`)
+
+	var cfg VirtualMachineConfig
+	assert.NoError(t, json.Unmarshal(body, &cfg))
+
+	assert.Equal(t, "virtio-scsi-pci", cfg.SCSIHW)
+	_, hasSCSIHW := cfg.SCSIs["scsihw"]
+	assert.False(t, hasSCSIHW, "SCSIHW must not be routed into SCSIs")
+	assert.Equal(t, "local-lvm:vm-100-disk-0,size=32G", cfg.SCSIs["scsi0"])
+
+	assert.Equal(t, 1, cfg.Numa)
+	_, hasBareNuma := cfg.Numas["numa"]
+	assert.False(t, hasBareNuma, "bare numa scalar must not be routed into Numas")
+	assert.Equal(t, "cpus=0-1,memory=2048", cfg.Numas["numa0"])
+}
+
+func TestIndexedDeviceKey(t *testing.T) {
+	cases := []struct {
+		in     string
+		prefix string
+		ok     bool
+	}{
+		{"net0", "net", true},
+		{"net31", "net", true},
+		{"scsi30", "scsi", true},
+		{"unused255", "unused", true},
+		{"ipconfig20", "ipconfig", true},
+		{"scsihw", "", false},
+		{"numa", "", false},
+		{"net", "", false},
+		{"net0a", "", false},
+		{"123", "", false},
+		{"", "", false},
+		{"a1b", "", false},
+	}
+	for _, tc := range cases {
+		prefix, ok := indexedDeviceKey(tc.in)
+		assert.Equal(t, tc.ok, ok, "ok for %q", tc.in)
+		assert.Equal(t, tc.prefix, prefix, "prefix for %q", tc.in)
+	}
 }
 
 func TestNode_VirtualMachineConfig_AllMergedMapsPopulated(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #211 in the non-breaking direction. Proxmox returns indexed device entries past 9 (e.g. `net0..net31`, `scsi0..scsi30`, `virtio0..virtio15`, `unused0..unused255`, `hostpci0..hostpci15`, `ipconfig0..ipconfig31`, `mp0..mp255`, `dev0..dev255`), but the existing `UnmarshalJSON` populated the helper maps via reflection over the struct, so any index >9 was silently dropped — `encoding/json` discards JSON keys that have no matching struct field before reflection ever runs.

This rewrites `VirtualMachineConfig.UnmarshalJSON` and `ContainerConfig.UnmarshalJSON` to also parse the body into `map[string]json.RawMessage` and route every `<prefix><digits>` key into the corresponding helper map. The explicit `Net0..Net9` (and friends) fields stay populated unchanged for back-compat — adding `// Deprecated:` markers and removing them is the v0.7.x step, called out in the package comment on the new `indexedDeviceMaps` helper.

The router uses prefix-then-pure-digits, not `strings.HasPrefix`, so:

- `scsihw` stays in `SCSIHW` (does **not** leak into `SCSIs`)
- the bare `numa` scalar stays in `Numa` (does **not** leak into `Numas`)

This is the latent collision bug that the closed PR #217 would have introduced; we have an explicit unit test guarding against it.

## What changed

- `types.go` — new `indexedDeviceMaps()` per-config helper plus a shared `indexedDeviceKey()` parser; rewritten `UnmarshalJSON` for both configs.
- `virtual_machine_config_test.go` — direct-unmarshal tests covering net15/net31, scsi30, unused15/unused255, hostpci15, ipconfig20, the two prefix collisions, and a unit test for `indexedDeviceKey`.
- `containers_test.go` — direct-unmarshal test for mp42/mp255, dev15, net20, unused100.
- `tests/mocks/pve9x/{virtual_machines,containers}.go` — new gock mocks at `qemu/102/{config,status/current}` and `lxc/102/{config,status/current}` so the parsing fix is also exercised end-to-end through `node.VirtualMachine(ctx, 102)` / `node.Container(ctx, 102)`.

## Test plan

- [x] `go test ./...` (main package green; failing `tests/integration` is the live-Proxmox suite that needs credentials, unrelated)
- [x] `go vet ./...`
- [x] New direct-Unmarshal unit tests cover indices >9 and prefix collisions
- [x] New integration-shape tests assert the maps are populated when configs are fetched through `node.VirtualMachine` / `node.Container`
- [x] Existing `Merge*` helper tests still pass — helpers remain idempotent for hand-built configs that bypass `UnmarshalJSON`

## Follow-up (not in this PR)

- v0.7.x: add `// Deprecated: use Nets/SCSIs/...` markers to the explicit indexed fields and `Merge*` helpers, then remove them in a later release.