### PR TITLE
fix!: expose force/purge/destroy-unreferenced-disks on Container.Delete (#149)

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -32,9 +32,13 @@ func (c *Container) Clone(ctx context.Context, params *ContainerCloneOptions) (n
 	return newid, NewTask(upid, c.client), nil
 }
 
-func (c *Container) Delete(ctx context.Context) (task *Task, err error) {
+// Delete removes the container. Pass a non-nil *ContainerDeleteOptions to
+// force-delete a running container (Force), purge it from related
+// configurations (Purge), or destroy unreferenced disks
+// (DestroyUnreferencedDisks). nil applies the API defaults.
+func (c *Container) Delete(ctx context.Context, params *ContainerDeleteOptions) (task *Task, err error) {
 	var upid UPID
-	if err := c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/lxc/%d", c.Node, c.VMID), &upid); err != nil {
+	if err := c.client.DeleteWithParams(ctx, fmt.Sprintf("/nodes/%s/lxc/%d", c.Node, c.VMID), params, &upid); err != nil {
 		return nil, err
 	}
 

--- a/containers_test.go
+++ b/containers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/h2non/gock"
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -80,7 +81,65 @@ func TestContainerDelete(t *testing.T) {
 		Node:   "node1",
 		VMID:   101,
 	}
-	task, err := container.Delete(ctx)
+	task, err := container.Delete(ctx, nil)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, task)
+}
+
+// TestContainerDelete_ForceParam verifies issue #149: passing
+// ContainerDeleteOptions{Force: true} actually puts force=1 on the wire as a
+// query parameter to DELETE /nodes/{node}/lxc/{vmid}. The gock mock only
+// matches when the parameter is present, so a regression where the option is
+// silently dropped (as DeleteFirewallIPSet currently does, by passing the map
+// as the response target instead of via DeleteWithParams) makes this test fail
+// with "cannot match any request".
+func TestContainerDelete_ForceParam(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(TestURI).
+		Delete("^/nodes/node1/lxc/101$").
+		MatchParam("force", "1").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:5A3B7C8D:vzdestroy:101:root@pam:"}`)
+
+	client := mockClient()
+	container := Container{
+		client: client,
+		Node:   "node1",
+		VMID:   101,
+	}
+	task, err := container.Delete(context.Background(), &ContainerDeleteOptions{Force: true})
+	assert.Nil(t, err)
+	assert.NotEmpty(t, task)
+}
+
+// TestContainerDelete_AllOptionsOnWire is the equivalent for purge and
+// destroy-unreferenced-disks: all three options must appear in the query
+// string when set, with the spec-correct hyphenated key for the last one.
+func TestContainerDelete_AllOptionsOnWire(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(TestURI).
+		Delete("^/nodes/node1/lxc/101$").
+		MatchParams(map[string]string{
+			"force":                      "1",
+			"purge":                      "1",
+			"destroy-unreferenced-disks": "1",
+		}).
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:5A3B7C8D:vzdestroy:101:root@pam:"}`)
+
+	client := mockClient()
+	container := Container{
+		client: client,
+		Node:   "node1",
+		VMID:   101,
+	}
+	task, err := container.Delete(context.Background(), &ContainerDeleteOptions{
+		Force:                    true,
+		Purge:                    true,
+		DestroyUnreferencedDisks: true,
+	})
 	assert.Nil(t, err)
 	assert.NotEmpty(t, task)
 }

--- a/proxmox.go
+++ b/proxmox.go
@@ -225,6 +225,20 @@ func (c *Client) Delete(ctx context.Context, p string, v interface{}) error {
 	return c.Req(ctx, http.MethodDelete, p, nil, v)
 }
 
+// DeleteWithParams mirrors GetWithParams for DELETE: it serialises d into a
+// query string (Proxmox DELETE endpoints take options via query params, not
+// a request body) and unmarshals the response into v.
+func (c *Client) DeleteWithParams(ctx context.Context, p string, d interface{}, v interface{}) error {
+	if d != nil {
+		queryString, err := dataParserForURL(d)
+		if err != nil {
+			return err
+		}
+		p = p + "?" + queryString
+	}
+	return c.Req(ctx, http.MethodDelete, p, nil, v)
+}
+
 // Upload - There is some weird 16kb limit hardcoded in proxmox for the max POST size, hopefully in the future we make
 // a func to scp the file to the node directly as this API endpoint is kind of janky. For now big ISOs/vztmpl should
 // be put somewhere and a use DownloadUrl. code link for posterity, I think they meant to do 16mb and got the bit math wrong

--- a/types.go
+++ b/types.go
@@ -825,6 +825,20 @@ type ContainerMigrateOptions struct {
 	Restart IntOrBool `json:"restart,omitempty"`
 }
 
+// ContainerDeleteOptions maps to the optional query parameters that
+// DELETE /nodes/{node}/lxc/{vmid} accepts. A nil *ContainerDeleteOptions
+// passed to Container.Delete is equivalent to all defaults.
+type ContainerDeleteOptions struct {
+	// Force destroys the container even if it is currently running.
+	Force IntOrBool `json:"force,omitempty"`
+	// Purge also removes the container from all related configurations
+	// (backup jobs, replication jobs, HA), in addition to deleting it.
+	Purge IntOrBool `json:"purge,omitempty"`
+	// DestroyUnreferencedDisks also destroys disks across enabled storages
+	// that match the VMID but are not referenced by the container's config.
+	DestroyUnreferencedDisks IntOrBool `json:"destroy-unreferenced-disks,omitempty"`
+}
+
 type VirtualMachineCloneOptions struct {
 	NewID       int    `json:"newid"`
 	BWLimit     uint64 `json:"bwlimit,omitempty"`


### PR DESCRIPTION
Closes #149.

## Summary

Proxmox's `DELETE /nodes/{node}/lxc/{vmid}` accepts three optional query parameters that go-proxmox didn't expose:

| Param                        | Effect                                                                        |
|------------------------------|-------------------------------------------------------------------------------|
| `force`                      | Destroy the container even if it is running (the case from #149)              |
| `purge`                      | Also remove from related configs (backup jobs, replication, HA)               |
| `destroy-unreferenced-disks` | Also destroy disks across enabled storages with a matching VMID, unreferenced |

Without `force`, callers must stop the container first — that's what the issue reporter (adyanth) was hitting.

## Changes

- New `ContainerDeleteOptions` struct (`types.go`) with `Force`, `Purge`, `DestroyUnreferencedDisks` as `IntOrBool` so they serialise as `1`/`0` to match the rest of the codebase.
- `Container.Delete(ctx)` becomes `Container.Delete(ctx, *ContainerDeleteOptions)` — pass `nil` for "API defaults".
- New `Client.DeleteWithParams(ctx, path, d, v)` helper in `proxmox.go` that mirrors the existing `GetWithParams` — the previous `Client.Delete(ctx, path, v)` had no path for sending request options, so options-bearing DELETEs in this codebase couldn't actually send them.
- The one in-tree caller (`containers_test.go:TestContainerDelete`) was updated to pass `nil`.

## Tests

Two new wire-level tests in `containers_test.go`:

- `TestContainerDelete_ForceParam` — gock mock requires `force=1` to match. If the option is silently dropped, the request doesn't match any registered mock and the test fails with `cannot match any request`.
- `TestContainerDelete_AllOptionsOnWire` — same shape but also asserts the spec-correct hyphenated key `destroy-unreferenced-disks` (not the camelCase Go field name).

I temporarily reverted the fix locally to verify both tests fail loudly without it (they do).

## BREAKING CHANGE

`Container.Delete(ctx)` now takes a second `*ContainerDeleteOptions` parameter. Migration is mechanical:

```diff
- task, err := container.Delete(ctx)
+ task, err := container.Delete(ctx, nil)
```

Ship alongside the v0.7.0 changes already in flight (#260, #261).

## Related (out of scope, noted for follow-up)

`Container.DeleteFirewallIPSet` accepts a `force bool` and passes it to `c.client.Delete(...)` as the response-unmarshal target, not as a query param — so `force` is silently ignored on the wire there too. Same fault class. Easiest follow-up PR is to switch it to `DeleteWithParams` once this lands.