### PR TITLE
feat: add Spice field to VirtualMachine struct

### DIFF
--- a/tests/mocks/pve7x/nodes.go
+++ b/tests/mocks/pve7x/nodes.go
@@ -14,6 +14,7 @@ func nodes() {
         "pid": 1563102,
         "shares": 1000,
         "agent": 1,
+        "spice": 1,
         "diskwrite": 1515457024,
         "cpus": 8,
         "ha": {

--- a/tests/mocks/pve8x/virtual_machines.go
+++ b/tests/mocks/pve8x/virtual_machines.go
@@ -15,6 +15,7 @@ func virtualMachines() {
         "pid": 1563102,
         "shares": 1000,
         "agent": 1,
+        "spice": 1,
         "diskwrite": 1515457024,
         "cpus": 8,
         "ha": {

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -48,6 +48,7 @@ func virtualMachines() {
         "pid": 1563102,
         "shares": 1000,
         "agent": 1,
+        "spice": 1,
         "diskwrite": 1515457024,
         "cpus": 8,
         "ha": {

--- a/types.go
+++ b/types.go
@@ -442,6 +442,7 @@ type VirtualMachine struct {
 	Node string
 
 	Agent          IntOrBool
+	Spice          IntOrBool
 	NetIn          uint64
 	CPUs           int
 	DiskWrite      uint64

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -30,6 +30,7 @@ func TestVirtualMachine_Ping(t *testing.T) {
 
 	assert.Nil(t, vm.Ping(ctx))
 	assert.Equal(t, StringOrUint64(101), vm.VMID)
+	assert.Equal(t, IntOrBool(true), vm.Spice)
 }
 
 func TestVirtualMachine_RRDData(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds a `Spice` field (`IntOrBool`) to the `VirtualMachine` struct so callers can tell whether a VM's QEMU VGA configuration supports SPICE without having to define a custom struct.
- Mirrors the existing `Agent IntOrBool` pattern, since Proxmox returns the value as 0/1 from `GET /nodes/{node}/qemu/{vmid}/status/current`.

Closes #134

## Test plan
- [x] Added `"spice": 1` to the gock status/current mocks for pve7x, pve8x, and pve9x.
- [x] Extended `TestVirtualMachine_Ping` to assert `vm.Spice == IntOrBool(true)` after calling `Ping`.
- [x] `go vet ./...` clean.
- [x] `go test ./.` passes.