### PR TITLE
fix: accept JSON null in StringOrInt/StringOrUint64/StringOrFloat64 (#198)

### DIFF
--- a/nodes_test.go
+++ b/nodes_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/h2non/gock"
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClient_Nodes(t *testing.T) {
@@ -448,4 +450,79 @@ func TestNode_VzdumpExtractConfig(t *testing.T) {
 	assert.NotNil(t, config)
 	assert.Equal(t, uint64(2), config.Cores)
 	assert.Equal(t, "debian", config.OsType)
+}
+
+// TestNode_VirtualMachines_TemplateWithNullPID is the regression test for
+// issue #198: VM templates returned by GET /nodes/{node}/qemu carry "pid": null
+// and the listing previously failed with `failed to match ^[0-9.]*$: null`.
+func TestNode_VirtualMachines_TemplateWithNullPID(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(TestURI).
+		Get("^/nodes/node1/qemu$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "vmid": "113",
+            "name": "ubuntu24-template",
+            "status": "stopped",
+            "template": 1,
+            "pid": null,
+            "cpus": 1,
+            "mem": 0,
+            "maxmem": 2147483648,
+            "disk": 0,
+            "maxdisk": 34359738368,
+            "uptime": 0,
+            "netin": 0,
+            "netout": 0,
+            "diskread": 0,
+            "diskwrite": 0,
+            "cpu": 0
+        },
+        {
+            "vmid": "140",
+            "name": "os0107",
+            "status": "running",
+            "template": "",
+            "pid": "14558",
+            "cpus": 4,
+            "mem": 3007004179,
+            "maxmem": 17179869184,
+            "disk": 0,
+            "maxdisk": 119185342464,
+            "uptime": 16600781,
+            "netin": 6124487532,
+            "netout": 414087827,
+            "diskread": 0,
+            "diskwrite": 0,
+            "cpu": 0.0099720556493484
+        }
+    ]
+}`)
+
+	client := mockClient()
+	node := &Node{client: client, Name: "node1"}
+
+	vms, err := node.VirtualMachines(context.Background())
+	require.NoError(t, err, "listing VMs must not fail when a template returns pid:null")
+	require.Len(t, vms, 2)
+
+	var template, running *VirtualMachine
+	for _, vm := range vms {
+		if vm.VMID == StringOrUint64(113) {
+			template = vm
+		}
+		if vm.VMID == StringOrUint64(140) {
+			running = vm
+		}
+	}
+
+	require.NotNil(t, template, "template VM should be present in the listing")
+	assert.Equal(t, StringOrUint64(0), template.PID, "null PID should unmarshal to 0")
+	assert.Equal(t, IsTemplate(true), template.Template)
+
+	require.NotNil(t, running, "running VM should be present in the listing")
+	assert.Equal(t, StringOrUint64(14558), running.PID)
 }

--- a/types.go
+++ b/types.go
@@ -1269,7 +1269,10 @@ type StringOrInt int
 
 func (d *StringOrInt) UnmarshalJSON(b []byte) error {
 	str := strings.ReplaceAll(string(b), "\"", "")
-	if str == "" {
+	// Empty string and JSON null both yield the zero value. Proxmox returns
+	// null for fields that are simply absent on the resource (e.g. PID on a
+	// stopped VM template — see issue #198).
+	if str == "" || str == "null" {
 		*d = StringOrInt(0)
 		return nil
 	}
@@ -1291,7 +1294,7 @@ type StringOrUint64 uint64
 
 func (d *StringOrUint64) UnmarshalJSON(b []byte) error {
 	str := strings.ReplaceAll(string(b), "\"", "")
-	if str == "" {
+	if str == "" || str == "null" {
 		*d = StringOrUint64(0)
 		return nil
 	}
@@ -1314,7 +1317,7 @@ type StringOrFloat64 float64
 
 func (d *StringOrFloat64) UnmarshalJSON(b []byte) error {
 	str := strings.ReplaceAll(string(b), "\"", "")
-	if str == "" {
+	if str == "" || str == "null" {
 		*d = StringOrFloat64(0)
 		return nil
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -68,6 +68,10 @@ func TestStringOrUint64(t *testing.T) {
 			StringOrUint64(0),
 			nil,
 		}, {
+			nil, // JSON null — issue #198 (e.g. VM template returns pid: null)
+			StringOrUint64(0),
+			nil,
+		}, {
 			"bad-parse-1234-value", // parse error
 			StringOrUint64(0),
 			errors.New("failed to match ^[0-9.]*$: bad-parse-1234-value"),
@@ -81,6 +85,8 @@ func TestStringOrUint64(t *testing.T) {
 	for _, test := range cases {
 		var value string
 		switch v := test.input.(type) {
+		case nil:
+			value = "null"
 		case string:
 			value = fmt.Sprintf("\"%s\"", v)
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
@@ -157,6 +163,10 @@ func TestStringOrFloat64(t *testing.T) {
 			StringOrFloat64(0.1),
 			nil,
 		}, {
+			nil, // JSON null
+			StringOrFloat64(0),
+			nil,
+		}, {
 			"bad-parse-1234-value", // parse error
 			StringOrFloat64(0),
 			errors.New("failed to match ^[0-9.]*$: bad-parse-1234-value"),
@@ -170,6 +180,8 @@ func TestStringOrFloat64(t *testing.T) {
 	for _, test := range cases {
 		var value string
 		switch v := test.input.(type) {
+		case nil:
+			value = "null"
 		case string:
 			value = fmt.Sprintf("\"%s\"", v)
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
@@ -248,6 +260,10 @@ func TestStringOrInt(t *testing.T) {
 			"bad-parse-1234-value", // parse error
 			StringOrInt(0),
 			errors.New("failed to match ^[0-9.]*$: bad-parse-1234-value"),
+		}, {
+			nil, // JSON null
+			StringOrInt(0),
+			nil,
 		},
 	}
 
@@ -258,6 +274,8 @@ func TestStringOrInt(t *testing.T) {
 	for _, test := range cases {
 		var value string
 		switch v := test.input.(type) {
+		case nil:
+			value = "null"
 		case string:
 			value = fmt.Sprintf("\"%s\"", v)
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:


### PR DESCRIPTION
Closes #198.

## Summary

Proxmox returns `"pid": null` on stopped VM templates listed via `GET /nodes/{node}/qemu`. The current `StringOrUint64.UnmarshalJSON` strips quotes and only short-circuits on the empty-string case before running the `^[0-9.]*\$` regex, so the literal `null` falls through to the regex and produces:

```
failed to match ^[0-9.]*$: null
```

…which makes the entire VM listing fail whenever a template is present (the user-visible symptom in #198).

## Fix

One-line change per type: treat `"null"` the same way as `""` — zero-value, no error. This matches `encoding/json`'s built-in behavior (`json.Unmarshal([]byte("null"), &intPtr)` is a no-op) and matches the reasonable expectation that "no value on the wire" maps to the zero value.

The same fault applies to all three sibling types — they share the same shape:

- `StringOrInt`
- `StringOrUint64` (the one #198 surfaced via `VirtualMachine.PID`)
- `StringOrFloat64`

Fixed all three.

## Tests

- Extended the existing `TestStringOrUint64`, `TestStringOrFloat64`, `TestStringOrInt` table-driven tests with a `nil` input case that renders as JSON `null`.
- New `TestNode_VirtualMachines_TemplateWithNullPID` in `nodes_test.go` exercises the actual issue path: gock-mocked `GET /nodes/node1/qemu` returning one template (`pid: null`) and one running VM (`pid: "14558"`), then `node.VirtualMachines(ctx)` and assertions that the listing succeeds and `template.PID == 0`.

Backed the fix out locally to confirm both layers fail loudly without it (the integration test fails with the exact error from the issue body).

## Diff

3 files, +101 / −3.