### PR TITLE
feat: cluster backup schedules

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -2,6 +2,7 @@ package proxmox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -70,6 +71,61 @@ func (cl *Cluster) Resources(ctx context.Context, filters ...string) (rs Cluster
 	}
 
 	return rs, cl.client.Get(ctx, u.String(), &rs)
+}
+
+// Backups returns all configured cluster backup schedules (vzdump jobs).
+// See https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/backup
+func (cl *Cluster) Backups(ctx context.Context) (ClusterBackups, error) {
+	var backups ClusterBackups
+	if err := cl.client.Get(ctx, "/cluster/backup", &backups); err != nil {
+		return nil, err
+	}
+	for _, b := range backups {
+		b.client = cl.client
+	}
+	return backups, nil
+}
+
+// Backup returns the cluster backup schedule with the given job ID.
+func (cl *Cluster) Backup(ctx context.Context, id string) (*ClusterBackup, error) {
+	if id == "" {
+		return nil, errors.New("backup id can not be empty")
+	}
+	backup := &ClusterBackup{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/backup/%s", id), backup); err != nil {
+		return nil, err
+	}
+	backup.client = cl.client
+	backup.ID = id
+	return backup, nil
+}
+
+// NewBackup creates a new cluster backup schedule. The created schedule is
+// not returned by the API; call Backups or Backup(id) to retrieve it.
+func (cl *Cluster) NewBackup(ctx context.Context, opts *ClusterBackupOptions) error {
+	if opts == nil {
+		opts = &ClusterBackupOptions{}
+	}
+	return cl.client.Post(ctx, "/cluster/backup", opts, nil)
+}
+
+// Update updates this backup schedule's configuration.
+func (b *ClusterBackup) Update(ctx context.Context, opts *ClusterBackupOptions) error {
+	if b.ID == "" {
+		return errors.New("backup id can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterBackupOptions{}
+	}
+	return b.client.Put(ctx, fmt.Sprintf("/cluster/backup/%s", b.ID), opts, nil)
+}
+
+// Delete removes this backup schedule.
+func (b *ClusterBackup) Delete(ctx context.Context) error {
+	if b.ID == "" {
+		return errors.New("backup id can not be empty")
+	}
+	return b.client.Delete(ctx, fmt.Sprintf("/cluster/backup/%s", b.ID), nil)
 }
 
 func (cl *Cluster) Tasks(ctx context.Context) (Tasks, error) {

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -96,6 +96,116 @@ func TestCluster_SDNZones(t *testing.T) {
 	assert.Equal(t, "pve", zones[0].IPAM)
 }
 
+func TestCluster_Backups(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	backups, err := cluster.Backups(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, backups, 2)
+
+	assert.Equal(t, "backup-1", backups[0].ID)
+	assert.Equal(t, "*/30", backups[0].Schedule)
+	assert.Equal(t, "snapshot", backups[0].Mode)
+	assert.Equal(t, IntOrBool(true), backups[0].Enabled)
+	assert.Equal(t, IntOrBool(true), backups[0].All)
+
+	assert.Equal(t, "backup-2", backups[1].ID)
+	assert.Equal(t, IntOrBool(false), backups[1].Enabled)
+	assert.Equal(t, "101,102", backups[1].VMID)
+	assert.Equal(t, "keep-daily=7,keep-weekly=4", backups[1].PruneBackups)
+
+	// every returned backup must carry the client back so receivers (Update/Delete) work
+	for _, b := range backups {
+		assert.NotNil(t, b.client, "ClusterBackup.client must be wired for %s", b.ID)
+	}
+}
+
+func TestCluster_Backup(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	// empty id guard
+	_, err = cluster.Backup(ctx, "")
+	assert.Error(t, err)
+
+	backup, err := cluster.Backup(ctx, "backup-1")
+	assert.Nil(t, err)
+	assert.Equal(t, "backup-1", backup.ID)
+	assert.Equal(t, "snapshot", backup.Mode)
+	assert.Equal(t, "local", backup.Storage)
+	assert.NotNil(t, backup.client)
+}
+
+func TestCluster_NewBackup(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	assert.Nil(t, cluster.NewBackup(ctx, &ClusterBackupOptions{
+		Schedule: "daily 02:00",
+		Mode:     "snapshot",
+		Storage:  "local",
+		All:      true,
+	}))
+
+	// nil opts is allowed; method should still POST without panicking
+	assert.Nil(t, cluster.NewBackup(ctx, nil))
+}
+
+func TestClusterBackup_Update(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	// empty id guard — no HTTP request issued
+	empty := ClusterBackup{client: client}
+	assert.Error(t, empty.Update(ctx, &ClusterBackupOptions{}))
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+	backup, err := cluster.Backup(ctx, "backup-1")
+	assert.Nil(t, err)
+
+	assert.Nil(t, backup.Update(ctx, &ClusterBackupOptions{
+		Schedule: "weekly",
+	}))
+	assert.Nil(t, backup.Update(ctx, nil)) // nil opts ok
+}
+
+func TestClusterBackup_Delete(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	// empty id guard
+	empty := ClusterBackup{client: client}
+	assert.Error(t, empty.Delete(ctx))
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+	backup, err := cluster.Backup(ctx, "backup-1")
+	assert.Nil(t, err)
+
+	assert.Nil(t, backup.Delete(ctx))
+}
+
 func TestCluster_SDNVNets(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/tests/mocks/pve7x/cluster.go
+++ b/tests/mocks/pve7x/cluster.go
@@ -526,4 +526,76 @@ func cluster() {
 		JSON(`{
 		"data": null
 	}`)
+
+	clusterBackup()
+}
+
+func clusterBackup() {
+	// GET /cluster/backup — list all backup schedules
+	gock.New(config.C.URI).
+		Get("^/cluster/backup$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "id": "backup-1",
+            "schedule": "*/30",
+            "mode": "snapshot",
+            "storage": "local",
+            "type": "vzdump",
+            "enabled": 1,
+            "all": 1,
+            "next-run": 1715299200,
+            "mailnotification": "always",
+            "notes-template": "{{guestname}}"
+        },
+        {
+            "id": "backup-2",
+            "schedule": "sat 02:00",
+            "mode": "stop",
+            "storage": "nfs-backups",
+            "type": "vzdump",
+            "enabled": 0,
+            "vmid": "101,102",
+            "mailto": "ops@example.com",
+            "prune-backups": "keep-daily=7,keep-weekly=4"
+        }
+    ]
+}`)
+
+	// GET /cluster/backup/{id} — single backup schedule
+	gock.New(config.C.URI).
+		Get("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "id": "backup-1",
+        "schedule": "*/30",
+        "mode": "snapshot",
+        "storage": "local",
+        "type": "vzdump",
+        "enabled": 1,
+        "all": 1
+    }
+}`)
+
+	// POST /cluster/backup — create
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/backup$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /cluster/backup/{id} — update
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /cluster/backup/{id} — delete
+	gock.New(config.C.URI).
+		Delete("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/tests/mocks/pve8x/cluster.go
+++ b/tests/mocks/pve8x/cluster.go
@@ -526,4 +526,76 @@ func cluster() {
 		JSON(`{
 		"data": null
 	}`)
+
+	clusterBackup()
+}
+
+func clusterBackup() {
+	// GET /cluster/backup — list all backup schedules
+	gock.New(config.C.URI).
+		Get("^/cluster/backup$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "id": "backup-1",
+            "schedule": "*/30",
+            "mode": "snapshot",
+            "storage": "local",
+            "type": "vzdump",
+            "enabled": 1,
+            "all": 1,
+            "next-run": 1715299200,
+            "mailnotification": "always",
+            "notes-template": "{{guestname}}"
+        },
+        {
+            "id": "backup-2",
+            "schedule": "sat 02:00",
+            "mode": "stop",
+            "storage": "nfs-backups",
+            "type": "vzdump",
+            "enabled": 0,
+            "vmid": "101,102",
+            "mailto": "ops@example.com",
+            "prune-backups": "keep-daily=7,keep-weekly=4"
+        }
+    ]
+}`)
+
+	// GET /cluster/backup/{id} — single backup schedule
+	gock.New(config.C.URI).
+		Get("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "id": "backup-1",
+        "schedule": "*/30",
+        "mode": "snapshot",
+        "storage": "local",
+        "type": "vzdump",
+        "enabled": 1,
+        "all": 1
+    }
+}`)
+
+	// POST /cluster/backup — create
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/backup$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /cluster/backup/{id} — update
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /cluster/backup/{id} — delete
+	gock.New(config.C.URI).
+		Delete("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -526,4 +526,76 @@ func cluster() {
 		JSON(`{
 		"data": null
 	}`)
+
+	clusterBackup()
+}
+
+func clusterBackup() {
+	// GET /cluster/backup — list all backup schedules
+	gock.New(config.C.URI).
+		Get("^/cluster/backup$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "id": "backup-1",
+            "schedule": "*/30",
+            "mode": "snapshot",
+            "storage": "local",
+            "type": "vzdump",
+            "enabled": 1,
+            "all": 1,
+            "next-run": 1715299200,
+            "mailnotification": "always",
+            "notes-template": "{{guestname}}"
+        },
+        {
+            "id": "backup-2",
+            "schedule": "sat 02:00",
+            "mode": "stop",
+            "storage": "nfs-backups",
+            "type": "vzdump",
+            "enabled": 0,
+            "vmid": "101,102",
+            "mailto": "ops@example.com",
+            "prune-backups": "keep-daily=7,keep-weekly=4"
+        }
+    ]
+}`)
+
+	// GET /cluster/backup/{id} — single backup schedule
+	gock.New(config.C.URI).
+		Get("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "id": "backup-1",
+        "schedule": "*/30",
+        "mode": "snapshot",
+        "storage": "local",
+        "type": "vzdump",
+        "enabled": 1,
+        "all": 1
+    }
+}`)
+
+	// POST /cluster/backup — create
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/backup$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /cluster/backup/{id} — update
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /cluster/backup/{id} — delete
+	gock.New(config.C.URI).
+		Delete("^/cluster/backup/backup-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/types.go
+++ b/types.go
@@ -1205,6 +1205,78 @@ func (storages *Storages) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type ClusterBackups []*ClusterBackup
+
+// ClusterBackup is a single configured cluster-wide backup schedule
+// (a vzdump job). See https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/backup
+type ClusterBackup struct {
+	client *Client
+
+	ID               string    `json:"id,omitempty"`
+	Schedule         string    `json:"schedule,omitempty"`
+	Enabled          IntOrBool `json:"enabled,omitempty"`
+	RepeatMissed     IntOrBool `json:"repeat-missed,omitempty"`
+	All              IntOrBool `json:"all,omitempty"`
+	NotesTemplate    string    `json:"notes-template,omitempty"`
+	MailNotification string    `json:"mailnotification,omitempty"`
+	MailTo           string    `json:"mailto,omitempty"`
+	Mode             string    `json:"mode,omitempty"`
+	Type             string    `json:"type,omitempty"`
+	NextRun          uint64    `json:"next-run,omitempty"`
+	Storage          string    `json:"storage,omitempty"`
+	VMID             string    `json:"vmid,omitempty"`
+	Exclude          string    `json:"exclude,omitempty"`
+	Node             string    `json:"node,omitempty"`
+	Pool             string    `json:"pool,omitempty"`
+	BwLimit          uint64    `json:"bwlimit,omitempty"`
+	Comment          string    `json:"comment,omitempty"`
+	PruneBackups     string    `json:"prune-backups,omitempty"`
+}
+
+// ClusterBackupOptions is the request body for POST /cluster/backup
+// (create) and PUT /cluster/backup/{id} (update). All fields are optional;
+// see the PVE API docs for semantics.
+type ClusterBackupOptions struct {
+	All                bool   `json:"all,omitempty"`
+	BwLimit            uint64 `json:"bwlimit,omitempty"`
+	Comment            string `json:"comment,omitempty"`
+	Compress           string `json:"compress,omitempty"`
+	Dow                string `json:"dow,omitempty"`
+	DumpDir            string `json:"dumpdir,omitempty"`
+	Enabled            bool   `json:"enabled,omitempty"`
+	Exclude            string `json:"exclude,omitempty"`
+	ExcludePath        string `json:"exclude-path,omitempty"`
+	ID                 string `json:"id,omitempty"`
+	IoNice             uint   `json:"ionice,omitempty"`
+	LockWait           uint   `json:"lockwait,omitempty"`
+	MailNotification   string `json:"mailnotification,omitempty"`
+	MailTo             string `json:"mailto,omitempty"`
+	MaxFiles           uint   `json:"maxfiles,omitempty"`
+	Mode               string `json:"mode,omitempty"`
+	Node               string `json:"node,omitempty"`
+	NotesTemplate      string `json:"notes-template,omitempty"`
+	NotificationMode   string `json:"notification-mode,omitempty"`
+	NotificationPolicy string `json:"notification-policy,omitempty"`
+	NotificationTarget string `json:"notification-target,omitempty"`
+	Performance        string `json:"performance,omitempty"`
+	Pigz               int    `json:"pigz,omitempty"`
+	Pool               string `json:"pool,omitempty"`
+	Protected          bool   `json:"protected,omitempty"`
+	PruneBackups       string `json:"prune-backups,omitempty"`
+	Quiet              bool   `json:"quiet,omitempty"`
+	Remove             bool   `json:"remove,omitempty"`
+	RepeatMissed       bool   `json:"repeat-missed,omitempty"`
+	Schedule           string `json:"schedule,omitempty"`
+	Script             string `json:"script,omitempty"`
+	StdExcludes        bool   `json:"stdexcludes,omitempty"`
+	Stop               bool   `json:"stop,omitempty"`
+	StopWait           uint   `json:"stopwait,omitempty"`
+	Storage            string `json:"storage,omitempty"`
+	TmpDir             string `json:"tmpdir,omitempty"`
+	VMID               string `json:"vmid,omitempty"`
+	Zstd               uint   `json:"zstd,omitempty"`
+}
+
 type ClusterStorages []*ClusterStorage
 
 type ClusterStorage struct {


### PR DESCRIPTION
## Summary

Adds API coverage for `/cluster/backup` — managing cluster-wide vzdump backup jobs (schedules). Picks up the crude implementation @slade991 posted in his fork from his comment on #143 and reshapes it to the maintainer's suggestion in that same thread:

> how do you feel about making the type `ClusterBackup` since that's the URL and then moving to receiver funcs off that?

That's the shape this PR uses.

### `*Cluster` methods
- `Backups(ctx) (ClusterBackups, error)` — list all backup schedules
- `Backup(ctx, id) (*ClusterBackup, error)` — get one by job ID
- `NewBackup(ctx, *ClusterBackupOptions) error` — create

### `*ClusterBackup` receiver methods
- `Update(ctx, *ClusterBackupOptions) error`
- `Delete(ctx) error`

### Notes
- `POST`/`PUT`/`DELETE /cluster/backup[/{id}]` return `null` per the PVE API (config endpoints, not async jobs), so these methods return `error` only. If you want the actual backup execution as a `*Task`, that's a different endpoint (`POST /nodes/{node}/vzdump`) and is already covered elsewhere in the lib.
- `Backups()` wires the client pointer onto each `*ClusterBackup` in the returned slice so receivers work without a refetch — same pattern as `Domains()`.
- `Update`/`Delete` guard against an empty `ID` (mirrors `Domain.Update`'s realm check).
- The `enabled`/`all`/`repeat-missed` booleans on the response use `IntOrBool`, consistent with how PVE returns `0`/`1` on similar fields elsewhere.

Closes #143

## Test plan
- [x] `TestCluster_Backups` — list returns both fixture schedules, fields decode correctly, every returned `*ClusterBackup` has its client wired.
- [x] `TestCluster_Backup` — get-by-id works; empty-id call errors without an HTTP request.
- [x] `TestCluster_NewBackup` — POST with opts and with nil both succeed.
- [x] `TestClusterBackup_Update` — PUT with opts and with nil both succeed; empty-id receiver errors locally.
- [x] `TestClusterBackup_Delete` — DELETE succeeds; empty-id receiver errors locally.
- [x] Gock mocks added to `pve7x`, `pve8x`, `pve9x` cluster mock files.
- [x] `go vet ./...` clean; full unit test suite passes.