### PR TITLE
feat(cloud-init): selectable iso storage + cross-storage deletion

### DIFF
--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -451,6 +451,27 @@ func nodes() {
     }
 }`)
 
+	// GET /nodes/{node}/storage/local-lvm/status — same listing entry as
+	// above's /storage but called by name. local-lvm only stores images and
+	// rootdir; used by tests that verify cloud-init refuses non-iso storages.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/local-lvm/status$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "storage": "local-lvm",
+        "content": "images,rootdir",
+        "type": "lvmthin",
+        "active": 1,
+        "avail": 100000000000,
+        "used": 20000000000,
+        "total": 120000000000,
+        "enabled": 1,
+        "shared": 0
+    }
+}`)
+
 	// GET /nodes/{node}/storage/{storage}/content - List storage content
 	gock.New(config.C.URI).
 		Persist().

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -138,11 +138,36 @@ func (v *VirtualMachine) SplitTags() {
 	v.VirtualMachineConfig.TagsSlice = strings.Split(v.VirtualMachineConfig.Tags, TagSeperator)
 }
 
+// CloudInitOption configures optional behavior on VirtualMachine.CloudInit.
+// Construct via the With*-prefixed CloudInit option helpers.
+type CloudInitOption func(*cloudInitConfig)
+
+type cloudInitConfig struct {
+	storage string
+}
+
+// WithCloudInitStorage selects a specific Proxmox storage (by name) to upload
+// the cloud-init ISO into. The storage must be enabled and accept "iso"
+// content. Without this option, CloudInit auto-selects the first enabled
+// iso-capable storage on the node, which is non-deterministic across nodes
+// with multiple iso-capable storages — see issue #119.
+func WithCloudInitStorage(name string) CloudInitOption {
+	return func(c *cloudInitConfig) { c.storage = name }
+}
+
 // CloudInit takes four yaml docs as a string and make an ISO, upload it to the data store as <vmid>-user-data.iso and will
 // mount it as a CD-ROM to be used with nocloud cloud-init. This is NOT how proxmox expects a user to do cloud-init
 // which can be found here: https://pve.proxmox.com/wiki/Cloud-Init_Support#:~:text=and%20meta.-,Cloud%2DInit%20specific%20Options,-cicustom%3A%20%5Bmeta
 // If you want to use the proxmox implementation you'll need to use the cloudinit APIs https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/cloudinit
-func (v *VirtualMachine) CloudInit(ctx context.Context, device, userdata, metadata, vendordata, networkconfig string) error {
+//
+// Pass WithCloudInitStorage("name") to control which storage receives the ISO.
+// Without it, the first enabled iso-capable storage returned by the node is used.
+func (v *VirtualMachine) CloudInit(ctx context.Context, device, userdata, metadata, vendordata, networkconfig string, opts ...CloudInitOption) error {
+	var cfg cloudInitConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	isoName := fmt.Sprintf(UserDataISOFormat, v.VMID)
 	// create userdata iso file on the local fs
 	isofilename, err := makeCloudInitISO(isoName, userdata, metadata, vendordata, networkconfig)
@@ -161,7 +186,7 @@ func (v *VirtualMachine) CloudInit(ctx context.Context, device, userdata, metada
 		return err
 	}
 
-	storage, err := node.StorageISO(ctx)
+	storage, err := resolveCloudInitStorage(ctx, node, &cfg)
 	if err != nil {
 		return err
 	}
@@ -193,6 +218,23 @@ func (v *VirtualMachine) CloudInit(ctx context.Context, device, userdata, metada
 	}
 
 	return task.WaitFor(ctx, 2)
+}
+
+// resolveCloudInitStorage picks the *Storage that CloudInit should upload to.
+// If cfg.storage is set, the named storage is fetched and validated to accept
+// iso content. Otherwise the node's auto-select for iso content is used.
+func resolveCloudInitStorage(ctx context.Context, node *Node, cfg *cloudInitConfig) (*Storage, error) {
+	if cfg.storage == "" {
+		return node.StorageISO(ctx)
+	}
+	s, err := node.Storage(ctx, cfg.storage)
+	if err != nil {
+		return nil, fmt.Errorf("cloud-init storage %q: %w", cfg.storage, err)
+	}
+	if !strings.Contains(s.Content, "iso") {
+		return nil, fmt.Errorf("cloud-init storage %q does not accept iso content (got %q)", cfg.storage, s.Content)
+	}
+	return s, nil
 }
 
 func makeCloudInitISO(filename, userdata, metadata, vendordata, networkconfig string) (isopath string, err error) {
@@ -384,32 +426,47 @@ func (v *VirtualMachine) Delete(ctx context.Context) (task *Task, err error) {
 	return NewTask(upid, v.client), nil
 }
 
+// deleteCloudInitISO scans every enabled iso-capable storage on the VM's node
+// for the cloud-init user-data ISO and removes it from the first one that has
+// it. Iterating across storages (rather than relying on the auto-selected one,
+// as the original code did) keeps deletion correct when CloudInit was called
+// with WithCloudInitStorage targeting a non-default storage.
 func (v *VirtualMachine) deleteCloudInitISO(ctx context.Context) (ok bool, err error) {
-	if v.HasTag(MakeTag(TagCloudInit)) {
-		node, err := v.client.Node(ctx, v.Node)
-		if err != nil {
-			return false, err
-		}
-		isoStorage, err := node.StorageISO(ctx)
-		if err != nil {
-			return false, err
-		}
-
-		var iso *ISO
-		iso, err = isoStorage.ISO(ctx, fmt.Sprintf(UserDataISOFormat, v.VMID))
-		if err != nil {
-			// skipping, iso not found return no error.
-			return true, nil
-		}
-		task, err := iso.Delete(ctx)
-		if err != nil {
-			return false, err
-		}
-		if err := task.WaitFor(ctx, 5); err != nil {
-			return false, err
-		}
+	if !v.HasTag(MakeTag(TagCloudInit)) {
+		return true, nil
 	}
 
+	node, err := v.client.Node(ctx, v.Node)
+	if err != nil {
+		return false, err
+	}
+
+	storages, err := node.Storages(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	isoFilename := fmt.Sprintf(UserDataISOFormat, v.VMID)
+	for _, s := range storages {
+		if s.Enabled == 0 || !strings.Contains(s.Content, "iso") {
+			continue
+		}
+		iso, ierr := s.ISO(ctx, isoFilename)
+		if ierr != nil {
+			// not on this storage; try the next
+			continue
+		}
+		task, terr := iso.Delete(ctx)
+		if terr != nil {
+			return false, terr
+		}
+		if werr := task.WaitFor(ctx, 5); werr != nil {
+			return false, werr
+		}
+		return true, nil
+	}
+
+	// Not found anywhere — already gone, treat as no-op (matches prior behavior).
 	return true, nil
 }
 

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -426,6 +426,59 @@ func closeBackend(t *testing.T, bk backend.Storage) {
 	}
 }
 
+func TestWithCloudInitStorage(t *testing.T) {
+	var cfg cloudInitConfig
+	WithCloudInitStorage("templates")(&cfg)
+	assert.Equal(t, "templates", cfg.storage)
+}
+
+func TestResolveCloudInitStorage_FallbackWhenUnset(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	storage, err := resolveCloudInitStorage(ctx, node, &cloudInitConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, storage)
+	assert.Contains(t, storage.Content, "iso",
+		"fallback should resolve to an iso-capable storage")
+}
+
+func TestResolveCloudInitStorage_NamedISOCapable(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	storage, err := resolveCloudInitStorage(ctx, node, &cloudInitConfig{storage: "local"})
+	require.NoError(t, err)
+	require.NotNil(t, storage)
+	assert.Equal(t, "local", storage.Name)
+	assert.Contains(t, storage.Content, "iso")
+}
+
+func TestResolveCloudInitStorage_NamedRejectsNonISO(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	_, err = resolveCloudInitStorage(ctx, node, &cloudInitConfig{storage: "local-lvm"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "local-lvm")
+	assert.Contains(t, err.Error(), "iso content")
+}
+
 func TestMakeCloudInitISO(t *testing.T) {
 	userdata := "#cloud-config\npassword: test\n"
 	metadata := "instance-id: test-vm\nlocal-hostname: test\n"


### PR DESCRIPTION
## Summary

Two related fixes for cloud-init ISO handling on nodes that have more than one iso-capable storage. Closes #119.

### 1. `CloudInit` accepts a storage selector via variadic options

```go
vm.CloudInit(ctx, "ide0", userdata, metadata, "", "")                                       // unchanged — auto-selects
vm.CloudInit(ctx, "ide0", userdata, metadata, "", "", proxmox.WithCloudInitStorage("templates"))  // new
```

- New type: `CloudInitOption func(*cloudInitConfig)`.
- New helper: `WithCloudInitStorage(name string) CloudInitOption`.
- `CloudInit`'s signature gained a trailing `...CloudInitOption`. Existing callers compile unchanged (variadic).
- When the option is set, the named storage is fetched via `node.Storage(...)` and validated to contain `iso` in its `content`. If the storage doesn't accept iso content, `CloudInit` returns a clear error before any upload happens.
- When the option is **not** set, the original `node.StorageISO(...)` auto-select kicks in — preserving today's behavior.

The new logic lives in a small, testable helper, `resolveCloudInitStorage`, so the option semantics can be exercised directly without standing up the full upload mock chain.

### 2. `deleteCloudInitISO` no longer relies on auto-select

Pre-fix, deletion called `node.StorageISO(...)` and gave up if the ISO wasn't on the first iso-capable storage returned — meaning anything uploaded to a non-default storage was orphaned forever.

Post-fix, deletion iterates every enabled iso-capable storage on the VM's node and removes the user-data ISO from the first one that has it. This keeps the upload/delete pair symmetric regardless of which storage `CloudInit` targeted, and is also self-healing if the storage list ordering shifts between upload and delete (which the issue thread observed in the wild).

The "ISO not found anywhere → return `(true, nil)`" no-op semantics are preserved.

## Why variadic options vs. a `CloudInitWithStorage(...)` overload

The maintainer's last comment on #119 already pointed in this direction: ""we could allow for allowing the storage to be passed in or filtered differently."" The existing five required args (`device` + four cloud-init blobs) stay positional because they're inputs that define the call, not optional knobs. Anything genuinely optional (storage now, more later) slots in via the variadic tail without further signature churn.

## Disabled-storage half of #119

The disabled-storage portion of the original report was already addressed by #205 (`Skip disabled storage in Node.findStorageByContent`), which lands the `Enabled == 0` skip in `nodes.go:275-277`. This PR doesn't redo that work; it covers the remaining ""I want to choose"" half.

Closes #119

## Test plan
- [x] `TestWithCloudInitStorage` — option helper sets the field on `cloudInitConfig`.
- [x] `TestResolveCloudInitStorage_FallbackWhenUnset` — empty option falls back to auto-select; resolved storage's content contains `iso`.
- [x] `TestResolveCloudInitStorage_NamedISOCapable` — named iso-capable storage is returned without error.
- [x] `TestResolveCloudInitStorage_NamedRejectsNonISO` — named non-iso storage (`local-lvm`) errors with a message naming the storage and the missing content type.
- [x] Added `local-lvm/status` mock in `pve9x/nodes.go` to back the negative case.
- [x] `go vet ./...` clean; full unit test suite passes.

Not covered (deliberately): full end-to-end `CloudInit` with HTTP upload + config update + tag — the existing test suite never set that up either, and the new logic is fully exercised through the testable helper.