### PR TITLE
feat: EncodeSSHKeys helper for PVE's strict url-encoding

### DIFF
--- a/proxmox.go
+++ b/proxmox.go
@@ -72,6 +72,22 @@ func MakeTag(v string) string {
 	return fmt.Sprintf(TagFormat, v)
 }
 
+// EncodeSSHKeys returns the given SSH public keys encoded the way Proxmox's
+// sshkeys parameter requires. Multiple keys are joined with newlines (PVE's
+// documented separator) before encoding.
+//
+// PVE applies its own urlencoded-string validator that rejects '+' as a space
+// encoding and requires every reserved character to be percent-encoded — the
+// Python urllib.parse.quote(s, safe='') style. Go's net/url.QueryEscape emits
+// '+' for spaces (HTML form encoding), so its output alone fails validation
+// with "invalid format - invalid urlencoded string". See issue #144.
+//
+// Use the result as the Value on a VirtualMachineOption{Name: "sshkeys", ...}
+// or assign it to VirtualMachineConfig.SSHKeys.
+func EncodeSSHKeys(keys ...string) string {
+	return strings.ReplaceAll(url.QueryEscape(strings.Join(keys, "\n")), "+", "%20")
+}
+
 type Client struct {
 	httpClient  *http.Client
 	userAgent   string

--- a/proxmox_test.go
+++ b/proxmox_test.go
@@ -28,6 +28,48 @@ func TestMakeTag(t *testing.T) {
 	assert.Equal(t, "go-proxmox+tagname", MakeTag("tagname"))
 }
 
+func TestEncodeSSHKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "single key encodes spaces as %20 not +",
+			in:   []string{"ssh-rsa AAAAB3NzaC1yc2EAAAA user@host"},
+			want: "ssh-rsa%20AAAAB3NzaC1yc2EAAAA%20user%40host",
+		},
+		{
+			name: "literal plus in key is preserved as %2B, not turned into %20",
+			in:   []string{"ssh-rsa A+B C"},
+			want: "ssh-rsa%20A%2BB%20C",
+		},
+		{
+			name: "multiple keys are joined with newline before encoding",
+			in:   []string{"ssh-rsa AAA u@h1", "ssh-ed25519 BBB u@h2"},
+			want: "ssh-rsa%20AAA%20u%40h1%0Assh-ed25519%20BBB%20u%40h2",
+		},
+		{
+			name: "no plus signs leak through",
+			in:   []string{"a b c d"},
+			want: "a%20b%20c%20d",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := EncodeSSHKeys(tc.in...)
+			assert.Equal(t, tc.want, got)
+			assert.NotContains(t, got, "+",
+				"EncodeSSHKeys output must never contain '+'; PVE rejects it")
+		})
+	}
+}
+
 // options tested in options_test.go
 func TestNewClient(t *testing.T) {
 	v := NewClient(TestURI)

--- a/types.go
+++ b/types.go
@@ -755,8 +755,10 @@ type VirtualMachineConfig struct {
 	CIPassword   string `json:"cipassword,omitempty"`
 	Nameserver   string `json:"nameserver,omitempty"`
 	Searchdomain string `json:"searchdomain,omitempty"`
-	SSHKeys      string `json:"sshkeys,omitempty"`
-	CICustom     string `json:"cicustom,omitempty"`
+	// SSHKeys must be encoded with EncodeSSHKeys — PVE's API validator
+	// rejects loose url-encoding (e.g. '+' for spaces). See issue #144.
+	SSHKeys  string `json:"sshkeys,omitempty"`
+	CICustom string `json:"cicustom,omitempty"`
 	CIUpgrade    int    `json:"ciupgrade,omitempty"` // FIXME(issue-199+178): PVE default 1, schema "boolean"; use *IntOrBool — type mismatch + default differs (unset would skip package upgrade).
 
 	// Cloud-init interfaces
@@ -1872,9 +1874,12 @@ type VzdumpConfig struct {
 	Numa       string `json:"numa"`
 	OsType     string `json:"ostype"`
 	Scsihw     string `json:"scsihw"`
-	Sockets    uint64 `json:"sockets,string"`
-	SSHKeys    string `json:"sshkeys"`
-	VmgenID    string `json:"vmgenid"`
+	Sockets uint64 `json:"sockets,string"`
+	// SSHKeys is reflected back from VzDump's recorded VM config; if you
+	// round-trip this into a VirtualMachineConfig.SSHKeys, the value is
+	// already PVE-encoded — re-encoding it would double-encode. See #144.
+	SSHKeys string `json:"sshkeys"`
+	VmgenID string `json:"vmgenid"`
 
 	IDE0 string `json:"ide0,omitempty"`
 	IDE1 string `json:"ide1,omitempty"`


### PR DESCRIPTION
## Summary

Closes #144 — the long-standing "weird sshkeys SSH public key validation error" UX.

### The actual bug

The Proxmox `/qemu/{vmid}/config` endpoint validates `sshkeys` against its own urlencoded-string validator in [PVE::JSONSchema](https://github.com/proxmox/pve-common/blob/master/src/PVE/JSONSchema.pm). That validator rejects `+` as a space encoding and requires strict percent-encoding — the Python `urllib.parse.quote(s, safe='')` style. Go's `net/url.QueryEscape` emits `+` for spaces (HTML form encoding), so its output alone fails with `invalid format - invalid urlencoded string`.

There's been no helper in the library for this, so every caller has had to rediscover the quirk. The issue thread accumulated three different people (including the maintainer at one point) recommending plain `QueryEscape` — which doesn't work — before @abbaszai posted a working version.

### The fix

A tiny exported helper in `proxmox.go`, sitting next to `MakeTag`:

```go
func EncodeSSHKeys(keys ...string) string {
    return strings.ReplaceAll(url.QueryEscape(strings.Join(keys, "\n")), "+", "%20")
}
```

Variadic so a single key is `EncodeSSHKeys(pub)` and multi-key works as `EncodeSSHKeys(k1, k2)` — joined with newline before encoding, which is PVE's documented multi-key separator. The `+`-to-`%20` swap is safe because `QueryEscape` only emits `+` for literal spaces; pluses in the input are already encoded as `%2B`.

Usage:

```go
opts := []proxmox.VirtualMachineOption{
    // ...
    {Name: "sshkeys", Value: proxmox.EncodeSSHKeys("ssh-rsa AAAA... user@host")},
}
```

### What I did NOT do (and why)

- **No auto-encoding inside Post.** Callers who already encoded would get double-encoded values, silently producing broken keys on the VM. Opt-in helper is the safe shape.
- **No "is this already encoded?" heuristic.** Fragile and surprising.
- **Did not touch VzdumpConfig's reading semantics** — only added a doc comment noting that round-tripping its `SSHKeys` is already encoded by PVE.

## Test plan
- [x] `TestEncodeSSHKeys` table-driven:
  - empty input → empty string
  - single key with spaces → `%20` (and `@` → `%40`)
  - literal `+` in key → `%2B` (not collapsed back to `%20` by the replace)
  - multiple keys → joined with `%0A` (URL-encoded newline)
  - blanket assertion: output never contains `+` (PVE rejects it)
- [x] Doc comments added on both `SSHKeys` struct fields (`VirtualMachineConfig.SSHKeys` at `types.go:758` and `VzdumpConfig.SSHKeys` at `types.go:1876`) pointing at the helper and explaining the round-trip caveat.
- [x] `go vet ./...` clean; full unit test suite passes.