### PR TITLE
feat(pools): 100% endpoint coverage; migrate Update/Delete to non-deprecated paths

### DIFF
--- a/pools.go
+++ b/pools.go
@@ -2,6 +2,7 @@ package proxmox
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -59,10 +60,83 @@ func (c *Client) Pool(ctx context.Context, poolid string, filters ...string) (po
 	return
 }
 
+// Update modifies the pool via the non-deprecated PUT /pools endpoint
+// (poolid travels in the body alongside the other params). Use this in
+// preference to UpdateDeprecated so nested pools work correctly.
 func (p *Pool) Update(ctx context.Context, opt *PoolUpdateOption) error {
+	data, err := poolUpdatePayload(p.PoolID, opt)
+	if err != nil {
+		return err
+	}
+	return p.client.Put(ctx, "/pools", data, nil)
+}
+
+// Delete removes the pool via the non-deprecated DELETE /pools endpoint.
+// Use this in preference to DeleteDeprecated.
+func (p *Pool) Delete(ctx context.Context) error {
+	u := url.URL{Path: "/pools"}
+	q := url.Values{}
+	q.Set("poolid", p.PoolID)
+	u.RawQuery = q.Encode()
+	return p.client.Delete(ctx, u.String(), nil)
+}
+
+// poolUpdatePayload merges opt's set fields with poolid for the PUT body.
+// Going through JSON round-trip preserves opt's omitempty rules so we don't
+// duplicate that logic here.
+func poolUpdatePayload(poolid string, opt *PoolUpdateOption) (map[string]interface{}, error) {
+	data := map[string]interface{}{"poolid": poolid}
+	if opt == nil {
+		return data, nil
+	}
+	raw, err := json.Marshal(opt)
+	if err != nil {
+		return nil, err
+	}
+	var fields map[string]interface{}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, err
+	}
+	for k, v := range fields {
+		data[k] = v
+	}
+	return data, nil
+}
+
+// GetDeprecated reads the pool via the deprecated GET /pools/{poolid}
+// endpoint. It does not support nested pools — prefer Client.Pool, which
+// uses the non-deprecated /pools?poolid= form.
+//
+// Deprecated: use Client.Pool.
+func (p *Pool) GetDeprecated(ctx context.Context, filters ...string) (*Pool, error) {
+	u := url.URL{Path: fmt.Sprintf("/pools/%s", p.PoolID)}
+	if f := strings.ReplaceAll(strings.Join(filters, ""), " ", ""); f != "" {
+		q := url.Values{}
+		q.Set("type", f)
+		u.RawQuery = q.Encode()
+	}
+
+	// The deprecated endpoint returns the pool body directly (no poolid in
+	// the response payload), so we seed PoolID from the receiver.
+	pool := &Pool{client: p.client, PoolID: p.PoolID}
+	if err := p.client.Get(ctx, u.String(), pool); err != nil {
+		return nil, err
+	}
+	return pool, nil
+}
+
+// UpdateDeprecated writes to the deprecated PUT /pools/{poolid} endpoint.
+// It does not support nested pools.
+//
+// Deprecated: use Pool.Update.
+func (p *Pool) UpdateDeprecated(ctx context.Context, opt *PoolUpdateOption) error {
 	return p.client.Put(ctx, fmt.Sprintf("/pools/%s", p.PoolID), opt, nil)
 }
 
-func (p *Pool) Delete(ctx context.Context) error {
+// DeleteDeprecated removes the pool via the deprecated DELETE /pools/{poolid}
+// endpoint. It does not support nested pools.
+//
+// Deprecated: use Pool.Delete.
+func (p *Pool) DeleteDeprecated(ctx context.Context) error {
 	return p.client.Delete(ctx, fmt.Sprintf("/pools/%s", p.PoolID), nil)
 }

--- a/pools_test.go
+++ b/pools_test.go
@@ -56,10 +56,26 @@ func TestPoolUpdate(t *testing.T) {
 		err = pool.Update(ctx, &PoolUpdateOption{
 			Comment:         "Test pool updated",
 			Delete:          true,
+			AllowMove:       true,
 			Storage:         "local-zfs",
 			VirtualMachines: "100",
 		})
 		assert.Nil(t, err)
+	}
+}
+
+func TestPoolUpdateNilOption(t *testing.T) {
+	// poolUpdatePayload must tolerate a nil option and still send poolid.
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	pool, err := client.Pool(ctx, "test-pool")
+	assert.Nil(t, err)
+	assert.NotNil(t, pool)
+	if pool != nil {
+		assert.Nil(t, pool.Update(ctx, nil))
 	}
 }
 
@@ -76,5 +92,54 @@ func TestPoolDelete(t *testing.T) {
 	if pool != nil {
 		err = pool.Delete(ctx)
 		assert.Nil(t, err)
+	}
+}
+
+func TestPoolGetDeprecated(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	// Seed a Pool struct without going through Client.Pool so we exercise
+	// the deprecated GET /pools/{poolid} path directly.
+	stub := &Pool{client: client, PoolID: "test-pool"}
+	pool, err := stub.GetDeprecated(ctx)
+	assert.Nil(t, err)
+	assert.NotNil(t, pool)
+	if pool != nil {
+		assert.Equal(t, "test-pool", pool.PoolID)
+		assert.Equal(t, "Test pool", pool.Comment)
+		assert.Len(t, pool.Members, 3)
+	}
+}
+
+func TestPoolUpdateDeprecated(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	pool, err := client.Pool(ctx, "test-pool")
+	assert.Nil(t, err)
+	assert.NotNil(t, pool)
+	if pool != nil {
+		assert.Nil(t, pool.UpdateDeprecated(ctx, &PoolUpdateOption{
+			Comment: "via deprecated path",
+		}))
+	}
+}
+
+func TestPoolDeleteDeprecated(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	pool, err := client.Pool(ctx, "test-pool")
+	assert.Nil(t, err)
+	assert.NotNil(t, pool)
+	if pool != nil {
+		assert.Nil(t, pool.DeleteDeprecated(ctx))
 	}
 }

--- a/tests/mocks/pve9x/pools.go
+++ b/tests/mocks/pve9x/pools.go
@@ -152,12 +152,32 @@ func pool() {
 		Reply(200).
 		JSON(`{"data": null}`)
 
+	// Modern PUT /pools (poolid in body). Persisted so Pool.Update tests can
+	// share with any future tests that hit the same route.
 	gock.New(config.C.URI).
+		Persist().
+		Put("^/pools$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// Modern DELETE /pools?poolid=test-pool.
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/pools$").
+		MatchParam("poolid", "test-pool").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// Deprecated PUT /pools/{poolid} (covered by Pool.UpdateDeprecated).
+	gock.New(config.C.URI).
+		Persist().
 		Put("^/pools/test-pool$").
 		Reply(200).
 		JSON(`{"data": null}`)
 
+	// Deprecated DELETE /pools/{poolid} (covered by Pool.DeleteDeprecated).
 	gock.New(config.C.URI).
+		Persist().
 		Delete("^/pools/test-pool$").
 		Reply(200).
 		JSON(`{"data": null}`)

--- a/types.go
+++ b/types.go
@@ -1523,6 +1523,9 @@ type PoolUpdateOption struct {
 	Comment string `json:"comment,omitempty"`
 	// Delete objects rather than adding them
 	Delete bool `json:"delete,omitempty"` // FIXME(issue-178): schema "boolean"; use IntOrBool (defaults match — no pointer needed).
+	// AllowMove permits adding a guest that already belongs to another pool;
+	// the guest is silently moved instead of the request being rejected.
+	AllowMove bool `json:"allow-move,omitempty"` // FIXME(issue-178): schema "boolean"; use IntOrBool (defaults match — no pointer needed).
 	// Comma separated lists of Storage names to add/delete to the pool
 	Storage string `json:"storage,omitempty"`
 	// Comma separated lists of Virtual Machine IDs to add/delete to the pool


### PR DESCRIPTION
## Summary

Brings `/pools` coverage from 4/7 to 7/7 against the PVE API schema.

The PVE API exposes seven pool endpoints — four on `/pools` (modern, support nested pools) and three on `/pools/{poolid}` (deprecated, no nested-pool support). Before this PR, `Pool.Update` and `Pool.Delete` hit the deprecated paths and `GET /pools/{poolid}` had no Go wrapper at all.

### Endpoint map (after this PR)

| Verb | Path | Method | Notes |
|------|------|--------|-------|
| GET | `/pools` | `Client.Pools`, `Client.Pool` | unchanged |
| POST | `/pools` | `Client.NewPool` | unchanged |
| PUT | `/pools` | `Pool.Update` | **migrated from `/pools/{poolid}`**; new `AllowMove` field |
| DELETE | `/pools` | `Pool.Delete` | **migrated from `/pools/{poolid}`** |
| GET | `/pools/{poolid}` | `Pool.GetDeprecated` | new; godoc `Deprecated:` |
| PUT | `/pools/{poolid}` | `Pool.UpdateDeprecated` | new; godoc `Deprecated:` |
| DELETE | `/pools/{poolid}` | `Pool.DeleteDeprecated` | new; godoc `Deprecated:` |

### Wire change, not API change

`Pool.Update` and `Pool.Delete` keep their Go signatures but now hit the non-deprecated URLs (poolid in body / query). This matches `Client.Pool`, which already preferred the `/pools?poolid=` form because the deprecated path doesn't support nested pools. Callers with restrictive ACLs scoped to the old paths will need to update; the legacy paths remain reachable via the new `*Deprecated` helpers.

### Schema notes

- `AllowMove` and `Delete` are declared as `bool` with `omitempty` and `FIXME(issue-178)` markers — PVE schema types them as `boolean`, defaults are `0`/false in both cases, so Go's zero value matches the PVE default and no pointer is required per the AGENTS.md rule. The `IntOrBool` migration is scoped to the #178 fix work.

## Test plan
- [x] `go test ./...` — all unit tests pass (9 pool tests, full suite green)
- [x] `golangci-lint run` — 0 issues
- [x] `go vet ./...` — clean
- [ ] No integration test changes; existing `tests/integration/proxmox_test.go` pool flow continues to use the same `Pool.Update`/`Pool.Delete` signatures and now exercises the modern endpoints.