### PR TITLE
feat: add prune-backups and import-metadata storage endpoints

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -3,8 +3,10 @@ package proxmox
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -292,6 +294,71 @@ func (b *Backup) Delete(ctx context.Context) (*Task, error) {
 
 func (i *ISO) Delete(ctx context.Context) (*Task, error) {
 	return deleteVolume(ctx, i.client, i.Node, i.Storage, i.VolID, i.Path, "iso")
+}
+
+// PreviewPruneBackups returns the list of backup volumes the prune call would
+// keep, remove, retain by protection flag, or skip due to non-standard
+// naming. Pass nil opts to use the storage's configured retention spec across
+// every guest. This is a dryrun — nothing on disk changes.
+func (s *Storage) PreviewPruneBackups(ctx context.Context, opts *StoragePruneBackupsOptions) ([]*PruneBackupItem, error) {
+	p := fmt.Sprintf("/nodes/%s/storage/%s/prunebackups", s.Node, s.Name)
+	if q := opts.queryString(); q != "" {
+		p = p + "?" + q
+	}
+	var items []*PruneBackupItem
+	err := s.client.Get(ctx, p, &items)
+	return items, err
+}
+
+// PruneBackups deletes the backup volumes a PreviewPruneBackups call with the
+// same opts would mark "remove". Returns the task so callers can Wait on it.
+// Note that backups added/removed between preview and prune may shift which
+// volumes get deleted; the preview is informational, not a transaction.
+func (s *Storage) PruneBackups(ctx context.Context, opts *StoragePruneBackupsOptions) (*Task, error) {
+	p := fmt.Sprintf("/nodes/%s/storage/%s/prunebackups", s.Node, s.Name)
+	if q := opts.queryString(); q != "" {
+		p = p + "?" + q
+	}
+	var upid UPID
+	if err := s.client.Delete(ctx, p, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
+}
+
+func (o *StoragePruneBackupsOptions) queryString() string {
+	if o == nil {
+		return ""
+	}
+	v := url.Values{}
+	if o.PruneBackups != "" {
+		v.Set("prune-backups", o.PruneBackups)
+	}
+	if o.Type != "" {
+		v.Set("type", o.Type)
+	}
+	if o.VMID != 0 {
+		v.Set("vmid", strconv.FormatUint(o.VMID, 10))
+	}
+	return v.Encode()
+}
+
+// ImportMetadata fetches the metadata Proxmox extracts from an importable
+// guest volume — currently ESXi-sourced VM disks on an "import"-capable
+// storage. Use this as a pre-flight before constructing a VM with the
+// "import-from=" disk option to see the disks/network mapping PVE detected
+// and any warnings about unsupported fields.
+//
+// volume is the standard PVE volume identifier, e.g.
+// "esxi-store:ha-datacenter/MyVM/MyVM.vmx".
+func (s *Storage) ImportMetadata(ctx context.Context, volume string) (*ImportMetadata, error) {
+	p := fmt.Sprintf("/nodes/%s/storage/%s/import-metadata?%s",
+		s.Node, s.Name, url.Values{"volume": {volume}}.Encode())
+	var meta ImportMetadata
+	if err := s.client.Get(ctx, p, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
 }
 
 func deleteVolume(ctx context.Context, c *Client, n, s, v, p, t string) (*Task, error) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -422,3 +422,107 @@ func TestClient_UploadReader(t *testing.T) {
 	assert.Equal(t, "hello.txt", capture.LastUpload.Filename)
 	assert.Equal(t, payload, capture.LastUpload.Body)
 }
+
+func TestStorage_PreviewPruneBackups(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+
+	items, err := storage.PreviewPruneBackups(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, items, 4)
+
+	marks := make(map[string]*PruneBackupItem, len(items))
+	for _, it := range items {
+		marks[it.Mark] = it
+	}
+	require.Contains(t, marks, "keep")
+	require.Contains(t, marks, "remove")
+	require.Contains(t, marks, "protected")
+	require.Contains(t, marks, "renamed")
+
+	assert.Equal(t, "local:backup/vzdump-qemu-100-2024_01_08-03_00_00.vma.zst", marks["remove"].Volid)
+	assert.Equal(t, "qemu", marks["remove"].Type)
+	assert.Equal(t, uint64(100), marks["remove"].VMID)
+	assert.Equal(t, StringOrUint64(1704682800), marks["remove"].Ctime)
+}
+
+func TestStorage_PreviewPruneBackups_WithFilters(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+
+	items, err := storage.PreviewPruneBackups(context.Background(), &StoragePruneBackupsOptions{
+		PruneBackups: "keep-last=3,keep-monthly=4",
+		Type:         "qemu",
+		VMID:         100,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+}
+
+func TestStorage_PruneBackups(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+
+	task, err := storage.PruneBackups(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, "node1", task.Node)
+	assert.Equal(t, "prunebackups", task.Type)
+}
+
+func TestStoragePruneBackupsOptions_QueryString(t *testing.T) {
+	cases := []struct {
+		name string
+		opts *StoragePruneBackupsOptions
+		want string
+	}{
+		{"nil", nil, ""},
+		{"empty", &StoragePruneBackupsOptions{}, ""},
+		{
+			"all fields",
+			&StoragePruneBackupsOptions{PruneBackups: "keep-last=3", Type: "qemu", VMID: 100},
+			"prune-backups=keep-last%3D3&type=qemu&vmid=100",
+		},
+		{"vmid only", &StoragePruneBackupsOptions{VMID: 100}, "vmid=100"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.opts.queryString())
+		})
+	}
+}
+
+func TestStorage_ImportMetadata(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	storage := &Storage{client: mockClient(), Node: "node1", Name: "esxi"}
+
+	meta, err := storage.ImportMetadata(context.Background(), "esxi:ha-datacenter/MyVM/MyVM.vmx")
+	require.NoError(t, err)
+	require.NotNil(t, meta)
+
+	assert.Equal(t, "vm", meta.Type)
+	assert.Equal(t, "esxi", meta.Source)
+	assert.Equal(t, "imported-vm", meta.CreateArgs["name"])
+	assert.Equal(t, float64(4096), meta.CreateArgs["memory"])
+
+	require.Len(t, meta.Disks, 2)
+	assert.Equal(t, "esxi:ha-datacenter/MyVM/MyVM.vmdk", meta.Disks["scsi0"])
+
+	require.Len(t, meta.Net, 1)
+	net0, ok := meta.Net["net0"].(map[string]interface{})
+	require.True(t, ok, "net0 should unmarshal as a map")
+	assert.Equal(t, "vmxnet3", net0["model"])
+
+	require.Len(t, meta.Warnings, 1)
+	assert.Equal(t, "guest-is-running", meta.Warnings[0].Type)
+	assert.Equal(t, "power", meta.Warnings[0].Key)
+	assert.Equal(t, "poweredOn", meta.Warnings[0].Value)
+}

--- a/tests/mocks/pve9x/storage.go
+++ b/tests/mocks/pve9x/storage.go
@@ -155,4 +155,87 @@ func storage() {
 		JSON(`{
     "data": "UPID:node1:00000004:00000004:00000004:imgcopy:upload:root@pam:"
 }`)
+
+	// GET /nodes/{node}/storage/{storage}/prunebackups - Dryrun prune preview.
+	// Matches with or without filter query params.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/local/prunebackups").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "volid": "local:backup/vzdump-qemu-100-2024_01_15-03_00_00.vma.zst",
+            "ctime": 1705287600,
+            "mark": "keep",
+            "type": "qemu",
+            "vmid": 100
+        },
+        {
+            "volid": "local:backup/vzdump-qemu-100-2024_01_08-03_00_00.vma.zst",
+            "ctime": 1704682800,
+            "mark": "remove",
+            "type": "qemu",
+            "vmid": 100
+        },
+        {
+            "volid": "local:backup/vzdump-qemu-100-2023_12_25-03_00_00.vma.zst",
+            "ctime": 1703473200,
+            "mark": "protected",
+            "type": "qemu",
+            "vmid": 100
+        },
+        {
+            "volid": "local:backup/manual-snapshot-before-upgrade.vma.zst",
+            "ctime": 1703300000,
+            "mark": "renamed",
+            "type": "qemu",
+            "vmid": 100
+        }
+    ]
+}`)
+
+	// DELETE /nodes/{node}/storage/{storage}/prunebackups - Execute prune.
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/storage/local/prunebackups").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00000005:00000005:00000005:prunebackups:local:root@pam:"
+}`)
+
+	// GET /nodes/{node}/storage/{storage}/import-metadata - ESXi disk import metadata.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/esxi/import-metadata").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "type": "vm",
+        "source": "esxi",
+        "create-args": {
+            "name": "imported-vm",
+            "memory": 4096,
+            "cores": 2,
+            "ostype": "l26"
+        },
+        "disks": {
+            "scsi0": "esxi:ha-datacenter/MyVM/MyVM.vmdk",
+            "scsi1": "esxi:ha-datacenter/MyVM/MyVM_1.vmdk"
+        },
+        "net": {
+            "net0": {
+                "model": "vmxnet3",
+                "bridge": "vmbr0"
+            }
+        },
+        "warnings": [
+            {
+                "type": "guest-is-running",
+                "key": "power",
+                "value": "poweredOn"
+            }
+        ]
+    }
+}`)
 }

--- a/types.go
+++ b/types.go
@@ -1692,6 +1692,50 @@ type StorageContent struct {
 	VMID         uint64         `json:"vmid,omitempty"`
 }
 
+// StoragePruneBackupsOptions filters which backups PreviewPruneBackups and
+// PruneBackups operate on. The zero value means "use the storage's configured
+// retention spec and apply to every backup".
+type StoragePruneBackupsOptions struct {
+	// PruneBackups overrides the storage's configured retention spec for this
+	// call only. Example: "keep-last=3,keep-monthly=4". Empty uses the storage default.
+	PruneBackups string
+	// Type filters by guest type: "qemu" or "lxc". Empty considers both.
+	Type string
+	// VMID filters to a single guest. Zero considers all guests.
+	VMID uint64
+}
+
+// PruneBackupItem is one row in the dryrun listing returned by
+// Storage.PreviewPruneBackups. Mark indicates what PruneBackups would do with
+// this volume: "keep", "remove", "protected" (retained by a protection flag),
+// or "renamed" (retained because its name doesn't match the standard scheme).
+type PruneBackupItem struct {
+	Volid string         `json:"volid"`
+	Ctime StringOrUint64 `json:"ctime"`
+	Mark  string         `json:"mark"`
+	Type  string         `json:"type"`
+	VMID  uint64         `json:"vmid,omitempty"`
+}
+
+// ImportMetadata is the result of Storage.ImportMetadata for an external disk
+// volume on an "import"-capable storage (e.g. an ESXi-imported guest). It
+// describes how Proxmox interprets the source and supplies ready-to-use
+// arguments for creating a guest from it.
+type ImportMetadata struct {
+	Type       string                  `json:"type"`
+	Source     string                  `json:"source"`
+	CreateArgs map[string]interface{}  `json:"create-args"`
+	Disks      map[string]string       `json:"disks,omitempty"`
+	Net        map[string]interface{}  `json:"net,omitempty"`
+	Warnings   []ImportMetadataWarning `json:"warnings,omitempty"`
+}
+
+type ImportMetadataWarning struct {
+	Type  string `json:"type"`
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
 type NodeCertificates []*NodeCertificate
 
 type NodeCertificate struct {


### PR DESCRIPTION
## Summary

Wraps three Proxmox storage REST endpoints that previously had no Go bindings. First slice of work from the API-coverage audit ("Tier 1") — chose these two features because they unblock real workflows (backup retention, ESXi disk import pre-flight) and are tightly scoped.

- `GET /nodes/{node}/storage/{storage}/prunebackups` → `Storage.PreviewPruneBackups` (dryrun preview)
- `DELETE /nodes/{node}/storage/{storage}/prunebackups` → `Storage.PruneBackups` (execute, returns `*Task`)
- `GET /nodes/{node}/storage/{storage}/import-metadata` → `Storage.ImportMetadata` (read metadata for an importable guest volume — relates to the workaround discussed in #145)

Both prune calls share `StoragePruneBackupsOptions` (override retention spec, filter by guest type/vmid). Preview and execute use the same query-string encoder so filters stay consistent across the dryrun/execute pair.

## API surface added

```go
type StoragePruneBackupsOptions struct {
    PruneBackups string // override retention spec for this call
    Type         string // "qemu" | "lxc" | "" (both)
    VMID         uint64 // 0 = all guests
}

type PruneBackupItem struct {
    Volid string
    Ctime StringOrUint64
    Mark  string // keep | remove | protected | renamed
    Type  string // qemu | lxc | openvz | unknown
    VMID  uint64
}

type ImportMetadata struct {
    Type, Source string
    CreateArgs   map[string]interface{}
    Disks        map[string]string
    Net          map[string]interface{}
    Warnings     []ImportMetadataWarning
}

func (s *Storage) PreviewPruneBackups(ctx, *StoragePruneBackupsOptions) ([]*PruneBackupItem, error)
func (s *Storage) PruneBackups(ctx, *StoragePruneBackupsOptions) (*Task, error)
func (s *Storage) ImportMetadata(ctx, volume string) (*ImportMetadata, error)
```

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test .` — full package suite passes (1.37s)
- [x] New tests cover: nil/empty options, all-fields options, vmid-only options, the four prune marks (keep/remove/protected/renamed), and an ESXi import payload with disks + net + warnings
- [ ] Integration test against a real PVE 9 instance with at least one stored backup and one ESXi-imported volume (not run locally — requires live cluster)