### PR TITLE
feat(lxc): close /nodes/{node}/lxc coverage gaps + bug fixes

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -165,7 +165,7 @@ func (c *Container) MoveVolume(ctx context.Context, params *VirtualMachineMoveDi
 }
 
 func (c *Container) RRDData(ctx context.Context, timeframe Timeframe, consolidationFunction ...ConsolidationFunction) (rrddata []*RRDData, err error) {
-	u := url.URL{Path: fmt.Sprintf("/lxc/%s/qemu/%d/rrddata", c.Node, c.VMID)}
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/lxc/%d/rrddata", c.Node, c.VMID)}
 
 	// consolidation functions are variadic because they're optional, but Proxmox only allows one cf parameter
 	params := url.Values{}
@@ -229,8 +229,13 @@ func (c *Container) GetSnapshotConfig(ctx context.Context, snapshot string) (con
 	return config, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/config", c.Node, c.VMID, snapshot), &config)
 }
 
-func (c *Container) UpdateSnapshot(ctx context.Context, snapshot string) error {
-	return c.client.Put(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/config", c.Node, c.VMID, snapshot), nil, nil)
+// UpdateSnapshot updates a container snapshot's metadata. PVE only allows
+// changing the description on this endpoint; pass nil options to clear it.
+func (c *Container) UpdateSnapshot(ctx context.Context, snapshot string, options *ContainerSnapshotUpdateOptions) error {
+	if options == nil {
+		options = &ContainerSnapshotUpdateOptions{}
+	}
+	return c.client.Put(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/config", c.Node, c.VMID, snapshot), options, nil)
 }
 
 func (c *Container) Firewall(ctx context.Context) (firewall *Firewall, err error) {
@@ -400,3 +405,58 @@ func (c *Container) RemoveTag(ctx context.Context, value string) (*Task, error) 
 func (c *Container) SplitTags() {
 	c.ContainerConfig.TagsSlice = strings.Split(c.ContainerConfig.Tags, TagSeperator)
 }
+
+// Pending returns the container's staged config changes — keys whose desired
+// value differs from the running value. Empty list when the container's live
+// config matches its on-disk config.
+func (c *Container) Pending(ctx context.Context) (pending []*ContainerPending, err error) {
+	return pending, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/pending", c.Node, c.VMID), &pending)
+}
+
+// RRD asks PVE to render a single timeframe PNG on the server and returns its
+// on-disk filename (the file lives in PVE's rrdcached dir). Most callers want
+// RRDData instead for numeric series; this exists for API parity.
+func (c *Container) RRD(ctx context.Context, ds string, timeframe Timeframe, consolidationFunction ...ConsolidationFunction) (rrd *ContainerRRD, err error) {
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/lxc/%d/rrd", c.Node, c.VMID)}
+	params := url.Values{}
+	if len(consolidationFunction) > 0 {
+		if len(consolidationFunction) != 1 {
+			return nil, fmt.Errorf("only one consolidation function allowed")
+		}
+		params.Add("cf", string(consolidationFunction[0]))
+	}
+	params.Add("ds", ds)
+	params.Add("timeframe", string(timeframe))
+	u.RawQuery = params.Encode()
+	err = c.client.Get(ctx, u.String(), &rrd)
+	return
+}
+
+// RemoteMigrate triggers a cross-cluster migration of this container. The
+// target endpoint is an API-token bundle string per PVE's pvesh docs.
+func (c *Container) RemoteMigrate(ctx context.Context, params *ContainerRemoteMigrateOptions) (task *Task, err error) {
+	var upid UPID
+	if err := c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/remote_migrate", c.Node, c.VMID), params, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, c.client), nil
+}
+
+// SpiceProxy returns SPICE proxy connection info for the container. PVE
+// supports SPICE primarily for QEMU VMs; LXC support depends on the
+// container's console configuration and may error on most setups.
+func (c *Container) SpiceProxy(ctx context.Context) (spice *SpiceProxy, err error) {
+	return spice, c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/spiceproxy", c.Node, c.VMID), nil, &spice)
+}
+
+// FirewallLog returns the per-container firewall log entries.
+func (c *Container) FirewallLog(ctx context.Context) (entries []*FirewallLogEntry, err error) {
+	return entries, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/log", c.Node, c.VMID), &entries)
+}
+
+// FirewallRefs returns the IPSets and aliases referenceable from this
+// container's firewall rules (cluster-level + node-level + container-level).
+func (c *Container) FirewallRefs(ctx context.Context) (refs []*FirewallRef, err error) {
+	return refs, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/refs", c.Node, c.VMID), &refs)
+}
+

--- a/containers_test.go
+++ b/containers_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/h2non/gock"
 	"github.com/luthermonson/go-proxmox/tests/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContainer(t *testing.T) {
@@ -414,4 +415,144 @@ func TestContainer_RemoveTag(t *testing.T) {
 	_, err = container.RemoveTag(ctx, "tag1")
 	assert.Nil(t, err)
 	assert.False(t, container.HasTag("tag1"))
+}
+
+func TestContainerRRDData(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	data, err := c.RRDData(ctx, TimeframeHour)
+	assert.Nil(t, err)
+	assert.Len(t, data, 2)
+	assert.Equal(t, uint64(1715299200), data[0].Time)
+}
+
+func TestContainerPending(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	pending, err := c.Pending(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, pending, 3)
+	assert.Equal(t, "memory", pending[0].Key)
+	assert.EqualValues(t, 2048, pending[0].Pending)
+	assert.Equal(t, "swap", pending[2].Key)
+	assert.Equal(t, 1, pending[2].Delete)
+}
+
+func TestContainerRRD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	rrd, err := c.RRD(ctx, "cpu", TimeframeHour)
+	assert.Nil(t, err)
+	require.NotNil(t, rrd)
+	assert.Contains(t, rrd.Filename, "101.png")
+}
+
+func TestContainerRemoteMigrate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	task, err := c.RemoteMigrate(ctx, &ContainerRemoteMigrateOptions{
+		TargetEndpoint: "apitoken=PVEAPIToken=user@pam!tok=secret host=target.example.com fingerprint=AA:BB",
+		TargetBridge:   "vmbr0=vmbr0",
+		TargetStorage:  "local=local",
+		TargetVMID:     201,
+		Online:         IntOrBool(true),
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+	assert.Contains(t, string(task.UPID), "vzremote-migrate")
+}
+
+func TestContainerSpiceProxy(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	spice, err := c.SpiceProxy(ctx)
+	assert.Nil(t, err)
+	require.NotNil(t, spice)
+	assert.Equal(t, "spice", spice.Type)
+	assert.Equal(t, "node1.example.com", spice.Host)
+	assert.Equal(t, "61024", spice.Port)
+	assert.Equal(t, "secret-ticket", spice.Password)
+	assert.Equal(t, "61025", spice.TLSPort)
+}
+
+func TestContainerFirewallLog(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	entries, err := c.FirewallLog(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	// PVE returns [n, "text"] tuples; verify the custom UnmarshalJSON flattens them
+	assert.Equal(t, 42, entries[0].LineNum)
+	assert.Contains(t, entries[0].Text, "policy DROP")
+	assert.Equal(t, 43, entries[1].LineNum)
+	assert.Contains(t, entries[1].Text, "policy ACCEPT")
+}
+
+func TestContainerFirewallRefs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	refs, err := c.FirewallRefs(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, refs, 2)
+	assert.Equal(t, "alias", refs[0].Type)
+	assert.Equal(t, "lan", refs[0].Name)
+	assert.Equal(t, "ipset", refs[1].Type)
+	assert.Equal(t, "blocked", refs[1].Name)
+}
+
+func TestContainerGetSnapshotConfig(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	config, err := c.GetSnapshotConfig(ctx, "snapshot1")
+	assert.Nil(t, err)
+	assert.Equal(t, "First snapshot", config["description"])
+}
+
+func TestContainerUpdateSnapshot(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	c := &Container{client: client, Node: "node1", VMID: 101}
+
+	// nil options still posts a body successfully (was broken pre-fix)
+	assert.Nil(t, c.UpdateSnapshot(ctx, "snapshot1", nil))
+
+	// explicit description
+	assert.Nil(t, c.UpdateSnapshot(ctx, "snapshot1", &ContainerSnapshotUpdateOptions{
+		Description: "updated by tests",
+	}))
 }

--- a/tests/mocks/pve9x/containers.go
+++ b/tests/mocks/pve9x/containers.go
@@ -201,6 +201,26 @@ func containers() {
 		Reply(200).
 		JSON(`{"data": "UPID:node1:00001234:00005678:5A3B7C8D:vzrollback:101:root@pam:"}`)
 
+	// GET /nodes/{node}/lxc/{vmid}/snapshot/{snapname}/config - Get snapshot config
+	gock.New(config.C.URI).
+		Get("^/nodes/node1/lxc/101/snapshot/snapshot1/config$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "description": "First snapshot",
+        "memory": 1024,
+        "cores": 2,
+        "ostype": "ubuntu"
+    }
+}`)
+
+	// PUT /nodes/{node}/lxc/{vmid}/snapshot/{snapname}/config - Update snapshot config
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/lxc/101/snapshot/snapshot1/config$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
 	// GET /nodes/{node}/lxc/{vmid}/interfaces - Get network interfaces
 	gock.New(config.C.URI).
 		Get("^/nodes/node1/lxc/101/interfaces$").
@@ -219,6 +239,85 @@ func containers() {
             "inet6": "fe80::be24:11ff:fe89:6707/64",
             "name": "eth0"
         }
+    ]
+}`)
+
+	// GET /nodes/{node}/lxc/{vmid}/rrddata
+	gock.New(config.C.URI).
+		Get("^/nodes/node1/lxc/101/rrddata$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"time": 1715299200, "cpu": 0.05, "mem": 268435456, "maxmem": 1073741824, "disk": 0, "maxdisk": 8589934592, "netin": 1000, "netout": 500, "diskread": 0, "diskwrite": 0},
+        {"time": 1715299260, "cpu": 0.10, "mem": 270000000, "maxmem": 1073741824, "disk": 0, "maxdisk": 8589934592, "netin": 1500, "netout": 700, "diskread": 0, "diskwrite": 0}
+    ]
+}`)
+
+	// GET /nodes/{node}/lxc/{vmid}/pending
+	gock.New(config.C.URI).
+		Get("^/nodes/node1/lxc/101/pending$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"key": "memory", "value": 1024, "pending": 2048},
+        {"key": "cores", "value": 2},
+        {"key": "swap", "value": 512, "delete": 1}
+    ]
+}`)
+
+	// GET /nodes/{node}/lxc/{vmid}/rrd
+	gock.New(config.C.URI).
+		Get("^/nodes/node1/lxc/101/rrd$").
+		Reply(200).
+		JSON(`{"data": {"filename": "/var/lib/rrdcached/db/pve2-vm/101.png"}}`)
+
+	// POST /nodes/{node}/lxc/{vmid}/remote_migrate
+	gock.New(config.C.URI).
+		Post("^/nodes/node1/lxc/101/remote_migrate$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00009ABC:0000DEAD:5A3B7C8D:vzremote-migrate:101:root@pam:"}`)
+
+	// POST /nodes/{node}/lxc/{vmid}/spiceproxy
+	gock.New(config.C.URI).
+		Post("^/nodes/node1/lxc/101/spiceproxy$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "type": "spice",
+        "host": "node1.example.com",
+        "port": "61024",
+        "tls-port": "61025",
+        "password": "secret-ticket",
+        "proxy": "http://proxy.example.com",
+        "title": "CT 101",
+        "host-subject": "OU=PVE Cluster Node,O=Proxmox VE,CN=node1",
+        "ca": "-----BEGIN CERTIFICATE-----\nMIIB...==\n-----END CERTIFICATE-----",
+        "delete-this-file": "1",
+        "secure-attention": "Ctrl+Alt+Ins",
+        "release-cursor": "Ctrl+Alt+R",
+        "toggle-fullscreen": "Shift+F11"
+    }
+}`)
+
+	// GET /nodes/{node}/lxc/{vmid}/firewall/log
+	gock.New(config.C.URI).
+		Get("^/nodes/node1/lxc/101/firewall/log$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        [42, "1 2 policy DROP: IN=eth0 OUT= MAC=... SRC=10.0.0.1 DST=10.0.0.2"],
+        [43, "1 3 policy ACCEPT: IN=eth0 OUT= SRC=10.0.0.3"]
+    ]
+}`)
+
+	// GET /nodes/{node}/lxc/{vmid}/firewall/refs
+	gock.New(config.C.URI).
+		Get("^/nodes/node1/lxc/101/firewall/refs$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"type": "alias", "name": "lan", "comment": "Local LAN range"},
+        {"type": "ipset", "name": "blocked", "comment": "Blocked sources"}
     ]
 }`)
 }

--- a/types.go
+++ b/types.go
@@ -1046,6 +1046,105 @@ type ContainerDeleteOptions struct {
 	DestroyUnreferencedDisks IntOrBool `json:"destroy-unreferenced-disks,omitempty"`
 }
 
+// ContainerRemoteMigrateOptions configures POST /nodes/{node}/lxc/{vmid}/remote_migrate
+// (cross-cluster migration). TargetEndpoint is the API-token bundle string PVE
+// accepts ("apitoken=PVEAPIToken=... host=... fingerprint=..."); see the
+// pvesh docs for the exact shape.
+type ContainerRemoteMigrateOptions struct {
+	TargetEndpoint string    `json:"target-endpoint"`
+	TargetBridge   string    `json:"target-bridge"`            // "src=tgt,src2=tgt2" map
+	TargetStorage  string    `json:"target-storage"`           // "src=tgt,src2=tgt2" map
+	TargetVMID     int       `json:"target-vmid,omitempty"`
+	BWLimit        uint64    `json:"bwlimit,omitempty"`
+	Delete         IntOrBool `json:"delete,omitempty"`
+	Online         IntOrBool `json:"online,omitempty"`
+	Restart        IntOrBool `json:"restart,omitempty"`
+	Timeout        uint64    `json:"timeout,omitempty"`
+}
+
+// ContainerPending describes a single staged config change returned by
+// GET /nodes/{node}/lxc/{vmid}/pending. Value is the currently active value;
+// Pending is the value queued for the next start. Delete is set when the key
+// is queued for removal.
+type ContainerPending struct {
+	Key     string      `json:"key"`
+	Value   interface{} `json:"value,omitempty"`
+	Pending interface{} `json:"pending,omitempty"`
+	Delete  int         `json:"delete,omitempty"`
+}
+
+// ContainerRRD is the response from GET /nodes/{node}/lxc/{vmid}/rrd. PVE
+// renders a single PNG on the server and returns its on-disk filename;
+// callers typically want RRDData instead for usable numeric series.
+type ContainerRRD struct {
+	Filename string `json:"filename"`
+}
+
+// SpiceProxy carries the SPICE connection info returned by /spiceproxy.
+// The field names match the keys remote-viewer expects in its .vv config.
+type SpiceProxy struct {
+	Type             string `json:"type"`
+	Host             string `json:"host"`
+	Port             string `json:"port,omitempty"`
+	Password         string `json:"password,omitempty"`
+	Proxy            string `json:"proxy,omitempty"`
+	Title            string `json:"title,omitempty"`
+	TLSPort          string `json:"tls-port,omitempty"`
+	CA               string `json:"ca,omitempty"`
+	HostSubject      string `json:"host-subject,omitempty"`
+	DeleteThisFile   string `json:"delete-this-file,omitempty"`
+	SecureAttention  string `json:"secure-attention,omitempty"`
+	ReleaseCursor    string `json:"release-cursor,omitempty"`
+	ToggleFullscreen string `json:"toggle-fullscreen,omitempty"`
+}
+
+// FirewallLogEntry is one line from GET /firewall/log. PVE returns each entry
+// as a [line-number, text] JSON tuple — the custom UnmarshalJSON below
+// flattens that into named fields.
+type FirewallLogEntry struct {
+	LineNum int    `json:"n"`
+	Text    string `json:"t"`
+}
+
+func (f *FirewallLogEntry) UnmarshalJSON(b []byte) error {
+	// Tuple form (current PVE): [n, "text"]
+	var tuple []interface{}
+	if err := json.Unmarshal(b, &tuple); err == nil && len(tuple) == 2 {
+		if n, ok := tuple[0].(float64); ok {
+			f.LineNum = int(n)
+		}
+		if t, ok := tuple[1].(string); ok {
+			f.Text = t
+		}
+		return nil
+	}
+	// Object fallback in case PVE ever switches shape.
+	aux := struct {
+		N int    `json:"n"`
+		T string `json:"t"`
+	}{}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	f.LineNum = aux.N
+	f.Text = aux.T
+	return nil
+}
+
+// FirewallRef is one entry from GET /firewall/refs — a referencable IPSet or
+// alias visible at this container/VM's scope.
+type FirewallRef struct {
+	Type    string `json:"type"` // "alias" or "ipset"
+	Name    string `json:"name"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// ContainerSnapshotUpdateOptions is the body for PUT /snapshot/{name}/config.
+// PVE accepts only the description field on this endpoint.
+type ContainerSnapshotUpdateOptions struct {
+	Description string `json:"description,omitempty"`
+}
+
 type VirtualMachineCloneOptions struct {
 	NewID       int    `json:"newid"`
 	BWLimit     uint64 `json:"bwlimit,omitempty"` // FIXME(issue-199): PVE default = datacenter/storage clone limit; use *uint64 so unset doesn't impose 0.


### PR DESCRIPTION
## Summary

Brings the LXC API surface up against the recent coverage audit's headline ("76% — minor gaps in pending, rrd, remote-migrate"). The audit understated it slightly — the actual surface gap was these six endpoints, plus two latent bugs in already-implemented methods. All resolved here.

### New methods on `*Container`

| Method | Endpoint | Notes |
|---|---|---|
| `Pending(ctx)` | `GET /pending` | Returns the staged-but-not-applied config keys (key/value/pending/delete). |
| `RRD(ctx, ds, timeframe, ...cf)` | `GET /rrd` | Single-PNG render path; sibling of the already-implemented `RRDData` numeric series. |
| `RemoteMigrate(ctx, opts)` | `POST /remote_migrate` | Cross-cluster migration via an API-token endpoint bundle. Returns `*Task`. |
| `SpiceProxy(ctx)` | `POST /spiceproxy` | SPICE connection bundle (host/port/password/etc.) for remote-viewer. |
| `FirewallLog(ctx)` | `GET /firewall/log` | Per-container firewall log entries. PVE returns `[n, "text"]` tuples — custom `UnmarshalJSON` on `FirewallLogEntry` flattens that into named fields. |
| `FirewallRefs(ctx)` | `GET /firewall/refs` | IPSet and alias names referenceable from container rules. |

The agent's gap audit originally listed `firewall/options` and `firewall/rules` as missing — they're actually already implemented on `*Container` (`GetFirewallOptions`/`UpdateFirewallOptions` and the five rule CRUD methods), so this PR doesn't re-add them.

### Bug fixes

**`RRDData` URL path (`containers.go:164`)** — was building `/lxc/<node>/qemu/<vmid>/rrddata`. Missing `/nodes/` prefix, stray `qemu` segment from what looks like a copy-paste off the VM side. Would 404 against real PVE — almost certainly why there was never a `TestContainerRRDData`. Fixed to `/nodes/<node>/lxc/<vmid>/rrddata`; new test asserts the response decodes.

**`UpdateSnapshot` signature (`containers.go:228`)** — sent `nil` body to `PUT /snapshot/{name}/config`, so callers had no way to set the description (the only field the endpoint accepts). Signature now takes `*ContainerSnapshotUpdateOptions`. Breaking change vs the old signature, but the old one was unusable so I'm not preserving back-compat for it. Callers passing the old `UpdateSnapshot(ctx, "name")` need `UpdateSnapshot(ctx, "name", nil)`.

### Shared types (new in `types.go`)

- `ContainerRemoteMigrateOptions`, `ContainerPending`, `ContainerRRD`, `ContainerSnapshotUpdateOptions`
- `SpiceProxy` — shaped for remote-viewer `.vv` consumers; LXC support depends on the CT's console config but the type is generically useful (could be reused for a VM-side `SpiceProxy()` later)
- `FirewallLogEntry` (with custom `UnmarshalJSON` for the `[n, "text"]` tuple)
- `FirewallRef`

## Test plan
- [x] `TestContainerPending`, `TestContainerRRD`, `TestContainerRemoteMigrate`, `TestContainerSpiceProxy`, `TestContainerFirewallLog`, `TestContainerFirewallRefs` — one per new method
- [x] `TestContainerRRDData` — regression test that the URL fix actually decodes the mocked response (no test existed before because the broken path would never have matched a mock)
- [x] `TestContainerUpdateSnapshot` — covers both `nil` options and an explicit description; mock marked `Persist()` to handle the two calls
- [x] `TestContainerGetSnapshotConfig` — backfill while I was in there since the GET endpoint had no test either
- [x] All 32 container tests pass (23 pre-existing + 9 new)
- [x] `go vet ./...` clean; full unit test suite passes