### PR TITLE
feat: wrap /nodes/{node}/time

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -374,3 +374,18 @@ func (n *Node) parseVzdumpConfig(vzdumpExtractedConfig string) (*VzdumpConfig, e
 
 	return vzdumpCfg, nil
 }
+
+// Time returns the node's current time and timezone configuration.
+// GET /nodes/{node}/time. The "time" and "localtime" fields are unix epoch
+// seconds — see NodeTime.
+func (n *Node) Time(ctx context.Context) (t *NodeTime, err error) {
+	t = &NodeTime{}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/time", n.Name), t)
+	return
+}
+
+// SetTimezone sets the node's timezone. Valid names come from
+// /usr/share/zoneinfo/zone.tab. PUT /nodes/{node}/time.
+func (n *Node) SetTimezone(ctx context.Context, timezone string) error {
+	return n.client.Put(ctx, fmt.Sprintf("/nodes/%s/time", n.Name), map[string]string{"timezone": timezone}, nil)
+}

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -526,3 +526,30 @@ func TestNode_VirtualMachines_TemplateWithNullPID(t *testing.T) {
 	require.NotNil(t, running, "running VM should be present in the listing")
 	assert.Equal(t, StringOrUint64(14558), running.PID)
 }
+
+func TestNode_Time(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	tm, err := node.Time(ctx)
+	assert.Nil(t, err)
+	assert.NotNil(t, tm)
+	assert.Equal(t, "UTC", tm.Timezone)
+	assert.Equal(t, int64(1715500000), tm.Time)
+}
+
+func TestNode_SetTimezone(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+	assert.Nil(t, node.SetTimezone(ctx, "America/Los_Angeles"))
+}

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -642,4 +642,18 @@ func nodes() {
 		JSON(`{
     "data": "cores: 2\nmemory: 2048\nostype: debian\nrootfs: local-lvm:vm-100-disk-0,size=8G\nnet0: name=eth0,bridge=vmbr0,ip=dhcp"
 }`)
+
+	// GET /nodes/{node}/time - Read time + timezone
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/time$").
+		Reply(200).
+		JSON(`{"data": {"time": 1715500000, "localtime": 1715500000, "timezone": "UTC"}}`)
+
+	// PUT /nodes/{node}/time - Set timezone
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/time$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -684,4 +684,18 @@ func nodes() {
 		Put("^/nodes/node1/dns$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/time - Read time + timezone
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/time$").
+		Reply(200).
+		JSON(`{"data": {"time": 1715500000, "localtime": 1715500000, "timezone": "UTC"}}`)
+
+	// PUT /nodes/{node}/time - Set timezone
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/time$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/types.go
+++ b/types.go
@@ -50,6 +50,15 @@ type Version struct {
 	Version string `json:"version"`
 }
 
+// NodeTime is the response from GET /nodes/{node}/time. Time and Localtime
+// are unix epoch seconds (UTC and local-tz-adjusted respectively); Timezone
+// is the IANA name.
+type NodeTime struct {
+	Time      int64  `json:"time"`
+	Localtime int64  `json:"localtime"`
+	Timezone  string `json:"timezone"`
+}
+
 type Term struct {
 	Port   StringOrInt
 	Ticket string


### PR DESCRIPTION
Adds two-method wrapper for node time/timezone:

- `(*Node).Time(ctx)` → `GET /nodes/{node}/time` returns `*NodeTime` (time, localtime, timezone).
- `(*Node).SetTimezone(ctx, tz)` → `PUT /nodes/{node}/time` sets timezone from `/usr/share/zoneinfo` names.

Common in provisioning flows that pin nodes to a specific TZ after install. Two-endpoint area, fully covered after this.

Tests + pve8x/pve9x mocks included.

## Pre-flight
- [x] `go build ./...` clean
- [x] `go test -count=1 .` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues