### PR TITLE
feat: wrap /nodes/{node}/services

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -374,3 +374,53 @@ func (n *Node) parseVzdumpConfig(vzdumpExtractedConfig string) (*VzdumpConfig, e
 
 	return vzdumpCfg, nil
 }
+
+// ---- /nodes/{node}/services --------------------------------------------------
+
+// Services returns the list of services on the node (pveproxy, pvedaemon,
+// corosync, ssh, etc.). GET /nodes/{node}/services.
+func (n *Node) Services(ctx context.Context) (services []*NodeService, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/services", n.Name), &services)
+	return
+}
+
+// ServiceState returns the current state of a single service.
+// GET /nodes/{node}/services/{service}/state. The /services/{service} root is
+// just a directory index and is intentionally not wrapped — state is the only
+// useful read on a specific service.
+func (n *Node) ServiceState(ctx context.Context, service string) (state *NodeService, err error) {
+	state = &NodeService{}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/services/%s/state", n.Name, service), state)
+	return
+}
+
+// ServiceStart issues POST /nodes/{node}/services/{service}/start. Returns a
+// Task because PVE does service control asynchronously.
+func (n *Node) ServiceStart(ctx context.Context, service string) (*Task, error) {
+	return n.serviceAction(ctx, service, "start")
+}
+
+// ServiceStop issues POST /nodes/{node}/services/{service}/stop.
+func (n *Node) ServiceStop(ctx context.Context, service string) (*Task, error) {
+	return n.serviceAction(ctx, service, "stop")
+}
+
+// ServiceRestart issues POST /nodes/{node}/services/{service}/restart — a
+// hard restart. Use Reload for graceful restart of services that support it.
+func (n *Node) ServiceRestart(ctx context.Context, service string) (*Task, error) {
+	return n.serviceAction(ctx, service, "restart")
+}
+
+// ServiceReload issues POST /nodes/{node}/services/{service}/reload, which
+// PVE documents as "falls back to restart if reload isn't supported".
+func (n *Node) ServiceReload(ctx context.Context, service string) (*Task, error) {
+	return n.serviceAction(ctx, service, "reload")
+}
+
+func (n *Node) serviceAction(ctx context.Context, service, action string) (*Task, error) {
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/services/%s/%s", n.Name, service, action), nil, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -526,3 +526,54 @@ func TestNode_VirtualMachines_TemplateWithNullPID(t *testing.T) {
 	require.NotNil(t, running, "running VM should be present in the listing")
 	assert.Equal(t, StringOrUint64(14558), running.PID)
 }
+
+func TestNode_Services(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	services, err := node.Services(ctx)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, services)
+	assert.Equal(t, "pveproxy", services[0].Service)
+	assert.Equal(t, "running", services[0].State)
+}
+
+func TestNode_ServiceState(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	state, err := node.ServiceState(ctx, "pveproxy")
+	assert.Nil(t, err)
+	assert.Equal(t, "pveproxy", state.Service)
+	assert.Equal(t, "active", state.ActiveState)
+}
+
+func TestNode_ServiceActions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	// All four actions hit the same mock regex; just verify each method
+	// constructs the right URL by exercising it.
+	for _, fn := range []func(context.Context, string) (*Task, error){
+		node.ServiceStart, node.ServiceStop, node.ServiceRestart, node.ServiceReload,
+	} {
+		task, err := fn(ctx, "pveproxy")
+		assert.Nil(t, err)
+		assert.NotNil(t, task)
+	}
+}

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -642,4 +642,28 @@ func nodes() {
 		JSON(`{
     "data": "cores: 2\nmemory: 2048\nostype: debian\nrootfs: local-lvm:vm-100-disk-0,size=8G\nnet0: name=eth0,bridge=vmbr0,ip=dhcp"
 }`)
+
+	// GET /nodes/{node}/services
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/services$").
+		Reply(200).
+		JSON(`{"data": [
+			{"service": "pveproxy", "name": "pveproxy", "desc": "PVE API Proxy", "state": "running", "active-state": "active", "unit-state": "enabled"},
+			{"service": "sshd",     "name": "sshd",     "desc": "OpenSSH server",  "state": "running", "active-state": "active", "unit-state": "enabled"}
+		]}`)
+
+	// GET /nodes/{node}/services/{service}/state
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/services/pveproxy/state$").
+		Reply(200).
+		JSON(`{"data": {"service": "pveproxy", "name": "pveproxy", "desc": "PVE API Proxy", "state": "running", "active-state": "active", "unit-state": "enabled"}}`)
+
+	// POST /nodes/{node}/services/{service}/{action}
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/services/pveproxy/(start|stop|restart|reload)$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00012345:67890123:srvstart:pveproxy:root@pam:"}`)
 }

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -684,4 +684,28 @@ func nodes() {
 		Put("^/nodes/node1/dns$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/services
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/services$").
+		Reply(200).
+		JSON(`{"data": [
+			{"service": "pveproxy", "name": "pveproxy", "desc": "PVE API Proxy", "state": "running", "active-state": "active", "unit-state": "enabled"},
+			{"service": "sshd",     "name": "sshd",     "desc": "OpenSSH server",  "state": "running", "active-state": "active", "unit-state": "enabled"}
+		]}`)
+
+	// GET /nodes/{node}/services/{service}/state
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/services/pveproxy/state$").
+		Reply(200).
+		JSON(`{"data": {"service": "pveproxy", "name": "pveproxy", "desc": "PVE API Proxy", "state": "running", "active-state": "active", "unit-state": "enabled"}}`)
+
+	// POST /nodes/{node}/services/{service}/{action}
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/services/pveproxy/(start|stop|restart|reload)$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00012345:67890123:srvstart:pveproxy:root@pam:"}`)
 }

--- a/types.go
+++ b/types.go
@@ -50,6 +50,18 @@ type Version struct {
 	Version string `json:"version"`
 }
 
+// NodeService is one row of the services list and the response shape of
+// /nodes/{node}/services/{service}/state. The same struct fits both because
+// the list returns the same per-service info, just batched.
+type NodeService struct {
+	Service     string `json:"service"`
+	Name        string `json:"name,omitempty"`
+	Desc        string `json:"desc,omitempty"`
+	State       string `json:"state,omitempty"`        // running / stopped / unknown
+	ActiveState string `json:"active-state,omitempty"` // active / inactive / failed
+	UnitState   string `json:"unit-state,omitempty"`   // enabled / disabled / masked
+}
+
 type Term struct {
 	Port   StringOrInt
 	Ticket string


### PR DESCRIPTION
Six methods on `*Node` covering 6 of the 7 schema endpoints under `/nodes/{node}/services`:

- `Services(ctx)` — `GET /nodes/{node}/services` — list
- `ServiceState(ctx, service)` — `GET /nodes/{node}/services/{service}/state`
- `ServiceStart(ctx, service)` / `ServiceStop` / `ServiceRestart` / `ServiceReload` — corresponding `POST /nodes/{node}/services/{service}/{action}`

Service control returns `*Task` since PVE processes the actions asynchronously via UPID. The `/services/{service}` root endpoint is just a tree index and is intentionally not wrapped.

Same `NodeService` struct serves both the list response and per-service state — PVE returns the same shape.

## Pre-flight
- [x] `go build ./...` clean
- [x] `go test -count=1 .` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues