### PR TITLE
feat: wrap /nodes/{node}/replication

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -537,3 +537,61 @@ func (n *Node) WakeOnLAN(ctx context.Context) (mac string, err error) {
 	err = n.client.Post(ctx, fmt.Sprintf("/nodes/%s/wakeonlan", n.Name), nil, &mac)
 	return
 }
+
+// ---- /nodes/{node}/replication ----------------------------------------------
+
+// Replications returns replication-job status from the node's perspective. The
+// cluster-wide job *configuration* lives at /cluster/replication; this endpoint
+// reports per-node runtime state (last sync, last duration, fail count, etc.)
+// for each job that targets or originates on this node. guest filters to a
+// specific VMID; pass 0 for all.
+func (n *Node) Replications(ctx context.Context, guest int) (status []*NodeReplicationStatus, err error) {
+	path := fmt.Sprintf("/nodes/%s/replication", n.Name)
+	if guest != 0 {
+		path += fmt.Sprintf("?guest=%d", guest)
+	}
+	err = n.client.Get(ctx, path, &status)
+	return
+}
+
+// ReplicationStatus returns runtime status for a single replication job.
+// GET /nodes/{node}/replication/{id}/status. The /replication/{id} root is
+// just a tree index and is intentionally not wrapped.
+func (n *Node) ReplicationStatus(ctx context.Context, id string) (status *NodeReplicationStatus, err error) {
+	status = &NodeReplicationStatus{}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/replication/%s/status", n.Name, id), status)
+	return
+}
+
+// ReplicationLog returns the job's log lines. start/limit are optional
+// pagination — pass 0 for default. PVE returns a list of {n, t} entries
+// where n is line number and t is the line text.
+func (n *Node) ReplicationLog(ctx context.Context, id string, start, limit int) (entries []*LogEntry, err error) {
+	path := fmt.Sprintf("/nodes/%s/replication/%s/log", n.Name, id)
+	q := ""
+	if start > 0 {
+		q = fmt.Sprintf("start=%d", start)
+	}
+	if limit > 0 {
+		if q != "" {
+			q += "&"
+		}
+		q += fmt.Sprintf("limit=%d", limit)
+	}
+	if q != "" {
+		path += "?" + q
+	}
+	err = n.client.Get(ctx, path, &entries)
+	return
+}
+
+// ReplicationScheduleNow asks PVE to run a replication job as soon as possible
+// (bypassing its schedule). POST /nodes/{node}/replication/{id}/schedule_now —
+// returns a Task UPID.
+func (n *Node) ReplicationScheduleNow(ctx context.Context, id string) (*Task, error) {
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/replication/%s/schedule_now", n.Name, id), nil, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -728,3 +728,52 @@ func TestNode_WakeOnLAN(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "AA:BB:CC:DD:EE:FF", mac)
 }
+
+func TestNode_Replications(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	reps, err := node.Replications(ctx, 0)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, reps)
+	assert.Equal(t, "100-0", reps[0].ID)
+	assert.Equal(t, 100, reps[0].Guest)
+}
+
+func TestNode_ReplicationStatusAndLog(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	st, err := node.ReplicationStatus(ctx, "100-0")
+	assert.Nil(t, err)
+	assert.Equal(t, "100-0", st.ID)
+
+	log, err := node.ReplicationLog(ctx, "100-0", 0, 0)
+	assert.Nil(t, err)
+	assert.Len(t, log, 2)
+	assert.Equal(t, 1, log[0].N)
+}
+
+func TestNode_ReplicationScheduleNow(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	task, err := node.ReplicationScheduleNow(ctx, "100-0")
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+}

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -708,4 +708,37 @@ func nodes() {
 		Delete("^/nodes/node1/subscription$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/replication
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/replication$").
+		Reply(200).
+		JSON(`{"data": [
+			{"id": "100-0", "type": "local", "source": "node1", "target": "node2", "guest": 100, "jobnum": 0, "last_sync": 1715500000, "next_sync": 1715501000, "state": "idle"}
+		]}`)
+
+	// GET /nodes/{node}/replication/{id}/status
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/replication/100-0/status$").
+		Reply(200).
+		JSON(`{"data": {"id": "100-0", "type": "local", "target": "node2", "guest": 100, "jobnum": 0, "last_sync": 1715500000, "state": "idle", "fail_count": 0}}`)
+
+	// GET /nodes/{node}/replication/{id}/log
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/replication/100-0/log$").
+		Reply(200).
+		JSON(`{"data": [
+			{"n": 1, "t": "2025-05-12 10:00:00 100-0: start replication job"},
+			{"n": 2, "t": "2025-05-12 10:00:05 100-0: end replication job"}
+		]}`)
+
+	// POST /nodes/{node}/replication/{id}/schedule_now
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/replication/100-0/schedule_now$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00012345:67890124:replicate:100-0:root@pam:"}`)
 }

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -784,4 +784,37 @@ func nodes() {
 		Post("^/nodes/node1/wakeonlan$").
 		Reply(200).
 		JSON(`{"data": "AA:BB:CC:DD:EE:FF"}`)
+
+	// GET /nodes/{node}/replication
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/replication$").
+		Reply(200).
+		JSON(`{"data": [
+			{"id": "100-0", "type": "local", "source": "node1", "target": "node2", "guest": 100, "jobnum": 0, "last_sync": 1715500000, "next_sync": 1715501000, "state": "idle"}
+		]}`)
+
+	// GET /nodes/{node}/replication/{id}/status
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/replication/100-0/status$").
+		Reply(200).
+		JSON(`{"data": {"id": "100-0", "type": "local", "target": "node2", "guest": 100, "jobnum": 0, "last_sync": 1715500000, "state": "idle", "fail_count": 0}}`)
+
+	// GET /nodes/{node}/replication/{id}/log
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/replication/100-0/log$").
+		Reply(200).
+		JSON(`{"data": [
+			{"n": 1, "t": "2025-05-12 10:00:00 100-0: start replication job"},
+			{"n": 2, "t": "2025-05-12 10:00:05 100-0: end replication job"}
+		]}`)
+
+	// POST /nodes/{node}/replication/{id}/schedule_now
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/replication/100-0/schedule_now$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00012345:67890124:replicate:100-0:root@pam:"}`)
 }

--- a/types.go
+++ b/types.go
@@ -90,6 +90,35 @@ type Subscription struct {
 	Signature      string `json:"signature,omitempty"`
 }
 
+// LogEntry is a single line from PVE log endpoints (task log, replication
+// log, etc.) — N is the 1-based line number, T the line text.
+type LogEntry struct {
+	N int    `json:"n"`
+	T string `json:"t"`
+}
+
+// NodeReplicationStatus is runtime state for a replication job on a node:
+// what was last synced, fail count, next-sync time. The cluster-wide
+// configuration of the job lives at /cluster/replication; this is the
+// per-node view of how that job is *running*.
+type NodeReplicationStatus struct {
+	ID        string  `json:"id"`
+	Type      string  `json:"type,omitempty"`
+	Source    string  `json:"source,omitempty"`
+	Target    string  `json:"target,omitempty"`
+	Guest     int     `json:"guest,omitempty"`
+	JobNum    int     `json:"jobnum,omitempty"`
+	Schedule  string  `json:"schedule,omitempty"`
+	LastSync  int64   `json:"last_sync,omitempty"` // epoch
+	LastTry   int64   `json:"last_try,omitempty"`  // epoch
+	NextSync  int64   `json:"next_sync,omitempty"` // epoch
+	Duration  float64 `json:"duration,omitempty"`  // seconds
+	FailCount int     `json:"fail_count,omitempty"`
+	Error     string  `json:"error,omitempty"`
+	PID       int     `json:"pid,omitempty"`
+	State     string  `json:"state,omitempty"`
+}
+
 type Term struct {
 	Port   StringOrInt
 	Ticket string


### PR DESCRIPTION
Four methods on `*Node` covering 4 of the 5 schema endpoints under `/nodes/{node}/replication`:

- `Replications(ctx, guest)` — `GET /nodes/{node}/replication` (with optional guest filter)
- `ReplicationStatus(ctx, id)` — `GET /nodes/{node}/replication/{id}/status`
- `ReplicationLog(ctx, id, start, limit)` — `GET /nodes/{node}/replication/{id}/log` with optional pagination
- `ReplicationScheduleNow(ctx, id)` — `POST /nodes/{node}/replication/{id}/schedule_now`

`/replication/{id}` (the directory index for one job) is intentionally not wrapped.

This is the per-node *runtime* view: what each replication job is doing on a particular node. The cluster-wide *configuration* of those same jobs lives at `/cluster/replication` (wrapped in PR #274).

New types: `LogEntry` (generic line-number/text pair, reusable for other log endpoints), `NodeReplicationStatus`.

## Pre-flight
- [x] `go build ./...` clean
- [x] `go test -count=1 .` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues