### PR TITLE
feat: wrap /nodes/{node}/dns

### DIFF
--- a/nodes_dns.go
+++ b/nodes_dns.go
@@ -1,0 +1,25 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+)
+
+// DNS returns the resolver configuration for this node — what gets written to
+// /etc/resolv.conf. Any of search/dns1/dns2/dns3 may be empty if the node has
+// no value set for that slot.
+func (n *Node) DNS(ctx context.Context) (*NodeDNS, error) {
+	var dns NodeDNS
+	if err := n.client.Get(ctx, fmt.Sprintf("/nodes/%s/dns", n.Name), &dns); err != nil {
+		return nil, err
+	}
+	return &dns, nil
+}
+
+// UpdateDNS rewrites the node's resolver configuration. The Search field is
+// required by PVE; an empty Search will be rejected by the server. The three
+// DNS slots are optional individually but supplied together — sending the
+// struct replaces all of them.
+func (n *Node) UpdateDNS(ctx context.Context, dns *NodeDNS) error {
+	return n.client.Put(ctx, fmt.Sprintf("/nodes/%s/dns", n.Name), dns, nil)
+}

--- a/nodes_dns_test.go
+++ b/nodes_dns_test.go
@@ -1,0 +1,38 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNode_DNS(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	dns, err := node.DNS(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, dns)
+	assert.Equal(t, "example.com", dns.Search)
+	assert.Equal(t, "1.1.1.1", dns.DNS1)
+	assert.Equal(t, "8.8.8.8", dns.DNS2)
+	assert.Equal(t, "9.9.9.9", dns.DNS3)
+}
+
+func TestNode_UpdateDNS(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	err := node.UpdateDNS(context.Background(), &NodeDNS{
+		Search: "example.com",
+		DNS1:   "1.1.1.1",
+	})
+	assert.NoError(t, err)
+}

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -663,4 +663,25 @@ func nodes() {
 		JSON(`{
     "data": "cores: 2\nmemory: 2048\nostype: debian\nrootfs: local-lvm:vm-100-disk-0,size=8G\nnet0: name=eth0,bridge=vmbr0,ip=dhcp"
 }`)
+
+	// GET /nodes/{node}/dns - Read resolver config.
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/dns$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "search": "example.com",
+        "dns1": "1.1.1.1",
+        "dns2": "8.8.8.8",
+        "dns3": "9.9.9.9"
+    }
+}`)
+
+	// PUT /nodes/{node}/dns - Replace resolver config. Returns null on success.
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/dns$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/types.go
+++ b/types.go
@@ -1813,6 +1813,16 @@ type ImportMetadataWarning struct {
 	Value string `json:"value,omitempty"`
 }
 
+// NodeDNS represents the resolver configuration for a single node, as
+// returned by GET /nodes/{node}/dns and accepted by PUT /nodes/{node}/dns.
+// Search is required on update; the three DNS slots are individually optional.
+type NodeDNS struct {
+	Search string `json:"search,omitempty"`
+	DNS1   string `json:"dns1,omitempty"`
+	DNS2   string `json:"dns2,omitempty"`
+	DNS3   string `json:"dns3,omitempty"`
+}
+
 type NodeCertificates []*NodeCertificate
 
 type NodeCertificate struct {


### PR DESCRIPTION
## Summary

Adds Go bindings for the two routes Proxmox exposes for per-node resolver configuration. First of the P1 endpoint batch — kept tightly scoped on purpose so we can validate the style on a small PR before scaling up.

- \`GET /nodes/{node}/dns\` → \`Node.DNS(ctx) (*NodeDNS, error)\`
- \`PUT /nodes/{node}/dns\` → \`Node.UpdateDNS(ctx, *NodeDNS) error\`

The PUT route returns null on success, so the wrapper returns just \`error\` — no Task. PVE requires \`Search\` on update; the three DNS slots are individually optional and supplying the struct replaces all of them.

## API surface added

\`\`\`go
type NodeDNS struct {
    Search string \`json:"search,omitempty"\`
    DNS1   string \`json:"dns1,omitempty"\`
    DNS2   string \`json:"dns2,omitempty"\`
    DNS3   string \`json:"dns3,omitempty"\`
}

func (n *Node) DNS(ctx context.Context) (*NodeDNS, error)
func (n *Node) UpdateDNS(ctx context.Context, dns *NodeDNS) error
\`\`\`

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test .\` — full package suite passes (1.34s)
- [x] New tests verify GET returns all four fields populated and PUT succeeds against the null-data fixture
- [ ] Integration test against a real PVE node (not run locally — requires live cluster)