### PR TITLE
feat: wrap node-wide mass operations

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -3,6 +3,7 @@ package proxmox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -471,4 +472,68 @@ func (n *Node) RefreshSubscription(ctx context.Context, force bool) error {
 // to community-edition status. DELETE /nodes/{node}/subscription.
 func (n *Node) DeleteSubscription(ctx context.Context) error {
 	return n.client.Delete(ctx, fmt.Sprintf("/nodes/%s/subscription", n.Name), nil)
+}
+
+// ---- node-wide mass operations -----------------------------------------------
+
+// StartAll starts every VM and container on the node honoring the configured
+// startup order. Pass NodeStartAllOptions{Force: IntOrBool(true)} to bypass
+// the order, or VMs to limit the set of guests started.
+func (n *Node) StartAll(ctx context.Context, opts *NodeStartAllOptions) (*Task, error) {
+	if opts == nil {
+		opts = &NodeStartAllOptions{}
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/startall", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// StopAll stops every VM and container on the node. ForceStop defaults to 1
+// (true) server-side; pass a populated NodeStopAllOptions to override timeout
+// or restrict which guests are stopped.
+func (n *Node) StopAll(ctx context.Context, opts *NodeStopAllOptions) (*Task, error) {
+	if opts == nil {
+		opts = &NodeStopAllOptions{}
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/stopall", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// SuspendAll suspends every VM on the node. (LXC containers are not suspended
+// by this endpoint — PVE only honors VMs here.)
+func (n *Node) SuspendAll(ctx context.Context, opts *NodeSuspendAllOptions) (*Task, error) {
+	if opts == nil {
+		opts = &NodeSuspendAllOptions{}
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/suspendall", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// MigrateAll migrates every VM and container on the node to opts.Target.
+// Target is required.
+func (n *Node) MigrateAll(ctx context.Context, opts *NodeMigrateAllOptions) (*Task, error) {
+	if opts == nil || opts.Target == "" {
+		return nil, errors.New("migrateall target can not be empty")
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/migrateall", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// WakeOnLAN sends a Wake-on-LAN magic packet to the node and returns the MAC
+// address that was woken. PVE looks up the WoL MAC from the cluster config —
+// the node's wakeonlan setting (see datacenter.cfg) must be configured.
+func (n *Node) WakeOnLAN(ctx context.Context) (mac string, err error) {
+	err = n.client.Post(ctx, fmt.Sprintf("/nodes/%s/wakeonlan", n.Name), nil, &mac)
+	return
 }

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -635,3 +635,96 @@ func TestNode_SetRefreshDeleteSubscription(t *testing.T) {
 	assert.Nil(t, node.RefreshSubscription(ctx, true))
 	assert.Nil(t, node.DeleteSubscription(ctx))
 }
+
+func TestNode_StartAll(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	// nil opts is allowed
+	task, err := node.StartAll(ctx, nil)
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+	assert.Contains(t, string(task.UPID), ":startall:")
+
+	// with opts
+	task, err = node.StartAll(ctx, &NodeStartAllOptions{
+		Force: IntOrBool(true),
+		VMs:   "101,102",
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+}
+
+func TestNode_StopAll(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	task, err := node.StopAll(ctx, &NodeStopAllOptions{Timeout: 60})
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+	assert.Contains(t, string(task.UPID), ":stopall:")
+}
+
+func TestNode_SuspendAll(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	task, err := node.SuspendAll(ctx, nil)
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+	assert.Contains(t, string(task.UPID), ":suspendall:")
+}
+
+func TestNode_MigrateAll(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	// empty target guard — no HTTP request issued
+	_, err = node.MigrateAll(ctx, &NodeMigrateAllOptions{})
+	assert.Error(t, err)
+	_, err = node.MigrateAll(ctx, nil)
+	assert.Error(t, err)
+
+	task, err := node.MigrateAll(ctx, &NodeMigrateAllOptions{
+		Target:         "node2",
+		MaxWorkers:     4,
+		WithLocalDisks: IntOrBool(true),
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+	assert.Contains(t, string(task.UPID), ":migrateall:")
+}
+
+func TestNode_WakeOnLAN(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	require.NoError(t, err)
+
+	mac, err := node.WakeOnLAN(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "AA:BB:CC:DD:EE:FF", mac)
+}

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -750,4 +750,38 @@ func nodes() {
 		Delete("^/nodes/node1/subscription$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// POST /nodes/{node}/startall — mass start
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/startall$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001111:00002222:5A3B7C8D:startall::root@pam:"}`)
+
+	// POST /nodes/{node}/stopall — mass stop
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/stopall$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001111:00002222:5A3B7C8D:stopall::root@pam:"}`)
+
+	// POST /nodes/{node}/suspendall — mass suspend
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/suspendall$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001111:00002222:5A3B7C8D:suspendall::root@pam:"}`)
+
+	// POST /nodes/{node}/migrateall — mass migrate
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/migrateall$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001111:00002222:5A3B7C8D:migrateall::root@pam:"}`)
+
+	// POST /nodes/{node}/wakeonlan — returns the MAC string
+	gock.New(config.C.URI).
+		Post("^/nodes/node1/wakeonlan$").
+		Reply(200).
+		JSON(`{"data": "AA:BB:CC:DD:EE:FF"}`)
 }

--- a/types.go
+++ b/types.go
@@ -456,6 +456,33 @@ type NodeStatus struct {
 	Local  int    `json:",omitempty"`
 }
 
+// NodeStartAllOptions is the optional body for POST /nodes/{node}/startall.
+type NodeStartAllOptions struct {
+	Force IntOrBool `json:"force,omitempty"` // bypass configured startup order
+	VMs   string    `json:"vms,omitempty"`   // comma-separated VMID list to limit which guests are started
+}
+
+// NodeStopAllOptions is the optional body for POST /nodes/{node}/stopall.
+type NodeStopAllOptions struct {
+	ForceStop IntOrBool `json:"force-stop,omitempty"` // PVE default 1; pass IntOrBool(false) to allow graceful shutdown to time out
+	Timeout   uint64    `json:"timeout,omitempty"`    // per-guest shutdown timeout in seconds (PVE default 180)
+	VMs       string    `json:"vms,omitempty"`        // comma-separated VMID list to limit
+}
+
+// NodeSuspendAllOptions is the optional body for POST /nodes/{node}/suspendall.
+type NodeSuspendAllOptions struct {
+	VMs string `json:"vms,omitempty"` // comma-separated VMID list to limit
+}
+
+// NodeMigrateAllOptions is the body for POST /nodes/{node}/migrateall.
+// Target is required — the destination node name.
+type NodeMigrateAllOptions struct {
+	Target         string    `json:"target"`
+	MaxWorkers     uint64    `json:"maxworkers,omitempty"`       // parallel migration workers
+	VMs            string    `json:"vms,omitempty"`              // comma-separated VMID list to limit
+	WithLocalDisks IntOrBool `json:"with-local-disks,omitempty"` // include local disks via storage migration
+}
+
 type Node struct {
 	Name       string
 	client     *Client


### PR DESCRIPTION
## Summary

Wraps the five POST `/nodes/{node}/{op}` endpoints that operate on every guest on a node — covered by the audit's P2 mass-operations group ("could bundle into one PR").

### New methods on `*Node`

| Method | Endpoint | Returns | Notes |
|---|---|---|---|
| `StartAll(ctx, opts)` | `POST /startall` | `*Task` | Honors configured startup order; `Force: IntOrBool(true)` to bypass; `VMs` to limit. |
| `StopAll(ctx, opts)` | `POST /stopall` | `*Task` | `ForceStop` defaults server-side to 1; `Timeout` (sec) and `VMs` available. |
| `SuspendAll(ctx, opts)` | `POST /suspendall` | `*Task` | Suspends VMs only — PVE doesn't suspend LXC via this endpoint. |
| `MigrateAll(ctx, opts)` | `POST /migrateall` | `*Task` | `Target` required; `MaxWorkers`, `WithLocalDisks`, `VMs` available. Empty-target guard avoids a server round-trip. |
| `WakeOnLAN(ctx)` | `POST /wakeonlan` | `string` (MAC) | PVE returns just the MAC of the woken host, not a UPID, so this is plain `string` rather than `*Task`. |

All options types use `IntOrBool` for PVE's 0/1 booleans, consistent with the rest of the lib.

## Test plan
- [x] One test per method, each verifying the returned `*Task` UPID contains the expected worker type (`:startall:`, `:stopall:`, `:suspendall:`, `:migrateall:`) or, for `WakeOnLAN`, the mocked MAC string.
- [x] `StartAll` test exercises both `nil` opts and a populated `NodeStartAllOptions`.
- [x] `MigrateAll` test covers both empty-target guards (`nil` opts and `Target: ""`) plus the happy path.
- [x] Gock mocks added at the end of `pve9x/nodes.go`; the four task-returning ones are `.Persist()` so multiple calls in a single test don't exhaust them.
- [x] `go vet ./...` clean; full unit suite passes.

## Audit context

P2 list (skipping per audit guidance unless asked):
- Console proxies (spiceshell/vncshell/vncwebsocket) — audit says "skip unless someone asks for spice support"
- Internal/auxiliary (execute/query-oci-repo-tags/query-url-metadata) — "low automation value"
- `/nodes/{node}/sdn` — "do cluster sdn first if SDN matters at all"

Diagnostics group (`rrd`/`rrddata`/`netstat`/`capabilities`/`scan`) is the next candidate if wanted; flagged separately rather than rolled into this PR.