### PR TITLE
feat: wrap /nodes/{node}/subscription

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -439,3 +439,36 @@ func (n *Node) Time(ctx context.Context) (t *NodeTime, err error) {
 func (n *Node) SetTimezone(ctx context.Context, timezone string) error {
 	return n.client.Put(ctx, fmt.Sprintf("/nodes/%s/time", n.Name), map[string]string{"timezone": timezone}, nil)
 }
+
+// ---- /nodes/{node}/subscription ----------------------------------------------
+
+// Subscription reads the node's subscription state — license level, status,
+// next-due-date, etc. GET /nodes/{node}/subscription.
+func (n *Node) Subscription(ctx context.Context) (sub *Subscription, err error) {
+	sub = &Subscription{}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/subscription", n.Name), sub)
+	return
+}
+
+// SetSubscription registers a Proxmox VE subscription key on the node.
+// PUT /nodes/{node}/subscription.
+func (n *Node) SetSubscription(ctx context.Context, key string) error {
+	return n.client.Put(ctx, fmt.Sprintf("/nodes/%s/subscription", n.Name), map[string]string{"key": key}, nil)
+}
+
+// RefreshSubscription asks the node to re-validate the cached subscription
+// status against Proxmox's servers. force=true bypasses the local cache and
+// always hits the upstream. POST /nodes/{node}/subscription.
+func (n *Node) RefreshSubscription(ctx context.Context, force bool) error {
+	body := map[string]any{}
+	if force {
+		body["force"] = 1
+	}
+	return n.client.Post(ctx, fmt.Sprintf("/nodes/%s/subscription", n.Name), body, nil)
+}
+
+// DeleteSubscription removes the subscription key from the node, returning it
+// to community-edition status. DELETE /nodes/{node}/subscription.
+func (n *Node) DeleteSubscription(ctx context.Context) error {
+	return n.client.Delete(ctx, fmt.Sprintf("/nodes/%s/subscription", n.Name), nil)
+}

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -605,3 +605,33 @@ func TestNode_SetTimezone(t *testing.T) {
 
 	assert.Nil(t, node.SetTimezone(ctx, "America/Los_Angeles"))
 }
+
+func TestNode_Subscription(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	sub, err := node.Subscription(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "active", sub.Status)
+	assert.Equal(t, "c", sub.Level)
+	assert.Equal(t, 1, sub.Sockets)
+}
+
+func TestNode_SetRefreshDeleteSubscription(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	assert.Nil(t, node.SetSubscription(ctx, "pve8c-newkey"))
+	assert.Nil(t, node.RefreshSubscription(ctx, true))
+	assert.Nil(t, node.DeleteSubscription(ctx))
+}

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -680,4 +680,32 @@ func nodes() {
 		Put("^/nodes/node1/time$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": {"status": "active", "key": "pve8c-1234567890", "level": "c", "productname": "PVE Community 1 CPU/year", "sockets": 1, "nextduedate": "2026-12-31"}}`)
+
+	// PUT /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// POST /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -722,4 +722,32 @@ func nodes() {
 		Put("^/nodes/node1/time$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": {"status": "active", "key": "pve8c-1234567890", "level": "c", "productname": "PVE Community 1 CPU/year", "sockets": 1, "nextduedate": "2026-12-31"}}`)
+
+	// PUT /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// POST /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /nodes/{node}/subscription
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/subscription$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/types.go
+++ b/types.go
@@ -71,6 +71,25 @@ type NodeTime struct {
 	Timezone  string `json:"timezone"`
 }
 
+// Subscription mirrors GET /nodes/{node}/subscription. Fields are loosely
+// typed because PVE's response varies between license levels (community,
+// basic, standard, premium) and between current-vs-expired states.
+type Subscription struct {
+	Status         string `json:"status,omitempty"` // active / inactive / notfound / expired / suspended / new
+	Key            string `json:"key,omitempty"`
+	Level          string `json:"level,omitempty"` // c=community, b=basic, s=standard, p=premium
+	ProductName    string `json:"productname,omitempty"`
+	RegDate        string `json:"regdate,omitempty"`     // YYYY-MM-DD HH:MM:SS
+	NextDueDate    string `json:"nextduedate,omitempty"` // YYYY-MM-DD
+	Validdirectory string `json:"validdirectory,omitempty"`
+	Sockets        int    `json:"sockets,omitempty"`
+	Checktime      int64  `json:"checktime,omitempty"` // epoch
+	ServerID       string `json:"serverid,omitempty"`
+	URL            string `json:"url,omitempty"`
+	Message        string `json:"message,omitempty"`
+	Signature      string `json:"signature,omitempty"`
+}
+
 type Term struct {
 	Port   StringOrInt
 	Ticket string


### PR DESCRIPTION
Four methods on `*Node` covering all 4 endpoints under `/nodes/{node}/subscription`:

- `Subscription(ctx)` — `GET` — returns `*Subscription` (status, key, level, productname, nextduedate, etc.)
- `SetSubscription(ctx, key)` — `PUT` — register a subscription key
- `RefreshSubscription(ctx, force)` — `POST` — re-validate against Proxmox servers; `force=true` bypasses the local cache
- `DeleteSubscription(ctx)` — `DELETE` — remove the key, return to community-edition state

Subscription is a single per-node resource (no IDs), so the four HTTP methods map directly to lifecycle ops.

Tests + pve8x/pve9x mocks included.

## Pre-flight
- [x] `go build ./...` clean
- [x] `go test -count=1 .` passes
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues