### PR TITLE
feat: wrap /nodes/{node}/certificates/acme — order/renew/revoke

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -326,6 +326,80 @@ func (n *Node) GetCustomCertificates(ctx context.Context) (certs *NodeCertificat
 	return
 }
 
+// ListCertificateSubresources enumerates the children of
+// /nodes/{node}/certificates (typically "info", "custom", "acme"). The PVE
+// schema only documents this as a directory index, so we collapse the
+// {"name": ...} link objects into a flat []string.
+func (n *Node) ListCertificateSubresources(ctx context.Context) ([]string, error) {
+	var items []struct {
+		Name string `json:"name"`
+	}
+	if err := n.client.Get(ctx, fmt.Sprintf("/nodes/%s/certificates", n.Name), &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Name)
+	}
+	return out, nil
+}
+
+// ListACMECertificateSubresources enumerates the children of
+// /nodes/{node}/certificates/acme (typically just "certificate").
+func (n *Node) ListACMECertificateSubresources(ctx context.Context) ([]string, error) {
+	var items []struct {
+		Name string `json:"name"`
+	}
+	if err := n.client.Get(ctx, fmt.Sprintf("/nodes/%s/certificates/acme", n.Name), &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Name)
+	}
+	return out, nil
+}
+
+// OrderACMECertificate orders a new ACME certificate using the node's
+// configured ACME account/plugin. force=true overwrites an existing custom
+// or ACME certificate. POST /nodes/{node}/certificates/acme/certificate.
+func (n *Node) OrderACMECertificate(ctx context.Context, force bool) (*Task, error) {
+	body := map[string]any{}
+	if force {
+		body["force"] = 1
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/certificates/acme/certificate", n.Name), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// RenewACMECertificate renews the node's ACME certificate. PVE skips renewal
+// when the cert is more than 30 days from expiry — force=true overrides that
+// check. PUT /nodes/{node}/certificates/acme/certificate.
+func (n *Node) RenewACMECertificate(ctx context.Context, force bool) (*Task, error) {
+	body := map[string]any{}
+	if force {
+		body["force"] = 1
+	}
+	var upid UPID
+	if err := n.client.Put(ctx, fmt.Sprintf("/nodes/%s/certificates/acme/certificate", n.Name), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// RevokeACMECertificate revokes the node's ACME certificate with the issuing
+// CA. DELETE /nodes/{node}/certificates/acme/certificate.
+func (n *Node) RevokeACMECertificate(ctx context.Context) (*Task, error) {
+	var upid UPID
+	if err := n.client.Delete(ctx, fmt.Sprintf("/nodes/%s/certificates/acme/certificate", n.Name), &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
 func (n *Node) Vzdump(ctx context.Context, params *VirtualMachineBackupOptions) (task *Task, err error) {
 	var upid UPID
 

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -411,6 +411,81 @@ func TestNode_DeleteCustomCertificate(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestNode_ListCertificateSubresources(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	names, err := node.ListCertificateSubresources(ctx)
+	assert.Nil(t, err)
+	assert.Contains(t, names, "info")
+	assert.Contains(t, names, "custom")
+	assert.Contains(t, names, "acme")
+}
+
+func TestNode_ListACMECertificateSubresources(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	names, err := node.ListACMECertificateSubresources(ctx)
+	assert.Nil(t, err)
+	assert.Contains(t, names, "certificate")
+}
+
+func TestNode_OrderACMECertificate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	task, err := node.OrderACMECertificate(ctx, false)
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "acme-new-cert", task.Type)
+}
+
+func TestNode_RenewACMECertificate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	task, err := node.RenewACMECertificate(ctx, true)
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "acme-renew-cert", task.Type)
+}
+
+func TestNode_RevokeACMECertificate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	node, err := client.Node(ctx, "node1")
+	assert.Nil(t, err)
+
+	task, err := node.RevokeACMECertificate(ctx)
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "acme-revoke-cert", task.Type)
+}
+
 func TestNode_Vzdump(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/tests/mocks/pve7x/nodes.go
+++ b/tests/mocks/pve7x/nodes.go
@@ -1388,6 +1388,57 @@ func nodes() {
     "data": null
 }`)
 
+	// GET /nodes/{node}/certificates - Directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/certificates$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "info"},
+        {"name": "custom"},
+        {"name": "acme"}
+    ]
+}`)
+
+	// GET /nodes/{node}/certificates/acme - ACME directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/certificates/acme$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "certificate"}
+    ]
+}`)
+
+	// POST /nodes/{node}/certificates/acme/certificate - Order ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-new-cert:pveproxy:root@pam:"
+}`)
+
+	// PUT /nodes/{node}/certificates/acme/certificate - Renew ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-renew-cert:pveproxy:root@pam:"
+}`)
+
+	// DELETE /nodes/{node}/certificates/acme/certificate - Revoke ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-revoke-cert:pveproxy:root@pam:"
+}`)
+
 	// POST /nodes/{node}/vzdump - Backup VMs
 	gock.New(config.C.URI).
 		Persist().

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -625,6 +625,57 @@ func nodes() {
     "data": null
 }`)
 
+	// GET /nodes/{node}/certificates - Directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/certificates$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "info"},
+        {"name": "custom"},
+        {"name": "acme"}
+    ]
+}`)
+
+	// GET /nodes/{node}/certificates/acme - ACME directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/certificates/acme$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "certificate"}
+    ]
+}`)
+
+	// POST /nodes/{node}/certificates/acme/certificate - Order ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-new-cert:pveproxy:root@pam:"
+}`)
+
+	// PUT /nodes/{node}/certificates/acme/certificate - Renew ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-renew-cert:pveproxy:root@pam:"
+}`)
+
+	// DELETE /nodes/{node}/certificates/acme/certificate - Revoke ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-revoke-cert:pveproxy:root@pam:"
+}`)
+
 	// POST /nodes/{node}/vzdump - Backup VMs
 	gock.New(config.C.URI).
 		Persist().

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -646,6 +646,57 @@ func nodes() {
     "data": null
 }`)
 
+	// GET /nodes/{node}/certificates - Directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/certificates$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "info"},
+        {"name": "custom"},
+        {"name": "acme"}
+    ]
+}`)
+
+	// GET /nodes/{node}/certificates/acme - ACME directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/certificates/acme$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "certificate"}
+    ]
+}`)
+
+	// POST /nodes/{node}/certificates/acme/certificate - Order ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-new-cert:pveproxy:root@pam:"
+}`)
+
+	// PUT /nodes/{node}/certificates/acme/certificate - Renew ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-renew-cert:pveproxy:root@pam:"
+}`)
+
+	// DELETE /nodes/{node}/certificates/acme/certificate - Revoke ACME cert
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/certificates/acme/certificate$").
+		Reply(200).
+		JSON(`{
+    "data": "UPID:node1:00001234:00005678:12345678:acme-revoke-cert:pveproxy:root@pam:"
+}`)
+
 	// POST /nodes/{node}/vzdump - Backup VMs
 	gock.New(config.C.URI).
 		Persist().


### PR DESCRIPTION
## Summary

Closes the remaining gaps in `/nodes/{node}/certificates` (3/8 → 8/8 covered):

- `OrderACMECertificate` — `POST /nodes/{node}/certificates/acme/certificate` (returns Task)
- `RenewACMECertificate` — `PUT  /nodes/{node}/certificates/acme/certificate` (returns Task)
- `RevokeACMECertificate` — `DELETE /nodes/{node}/certificates/acme/certificate` (returns Task)
- `ListCertificateSubresources` — `GET /nodes/{node}/certificates`
- `ListACMECertificateSubresources` — `GET /nodes/{node}/certificates/acme`

The three ACME ops return `*Task` since PVE runs them as UPIDs (cert issuance/renewal/revocation talks to the upstream CA and can take a while).

Mocks added for pve7x/pve8x/pve9x.

## Test plan
- [x] `go test .` (8 cert tests pass)
- [x] `go build ./...`
- [ ] Manual smoke against a live PVE node with an ACME plugin configured