### PR TITLE
feat: wrap /nodes/{node}/apt — repositories, update, versions, changelog

### DIFF
--- a/nodes_apt.go
+++ b/nodes_apt.go
@@ -1,0 +1,107 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// APT returns the directory index for /nodes/{node}/apt — a small list of
+// child handles (changelog, repositories, update, versions). Mostly useful as
+// a probe; the real data lives on the children.
+func (n *Node) APT(ctx context.Context) (entries []*APTIndexEntry, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/apt", n.Name), &entries)
+	return
+}
+
+// APTUpdates lists the packages with available upgrades on the node, as
+// produced by the last `apt-get update`. Empty list means the index is clean
+// or has never been refreshed; call APTUpdate to resync first.
+func (n *Node) APTUpdates(ctx context.Context) (updates []*APTUpdate, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/apt/update", n.Name), &updates)
+	return
+}
+
+// APTUpdate resynchronizes the apt package index (apt-get update) on the
+// node. notify=true asks PVE to send its configured "new packages available"
+// notification; quiet=true suppresses progress output in the task log.
+// Returns the worker task.
+func (n *Node) APTUpdate(ctx context.Context, notify, quiet bool) (*Task, error) {
+	body := map[string]interface{}{}
+	if notify {
+		body["notify"] = 1
+	}
+	if quiet {
+		body["quiet"] = 1
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/apt/update", n.Name), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// APTChangelog returns the changelog text for a single package. version is
+// optional — when empty PVE picks the candidate version. The endpoint returns
+// a single string, not structured data.
+func (n *Node) APTChangelog(ctx context.Context, name, version string) (changelog string, err error) {
+	q := url.Values{}
+	q.Set("name", name)
+	if version != "" {
+		q.Set("version", version)
+	}
+	path := fmt.Sprintf("/nodes/%s/apt/changelog?%s", n.Name, q.Encode())
+	err = n.client.Get(ctx, path, &changelog)
+	return
+}
+
+// APTRepositories returns the parsed contents of /etc/apt/sources.list(.d) on
+// the node, plus a digest used for optimistic-concurrency on writes and a
+// catalog of standard repositories PVE knows how to add.
+func (n *Node) APTRepositories(ctx context.Context) (repos *APTRepositories, err error) {
+	repos = &APTRepositories{}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/apt/repositories", n.Name), repos)
+	return
+}
+
+// APTChangeRepository enables or disables an existing repository entry,
+// identified by the containing file path and its index within that file.
+// digest is optional; pass the value from APTRepositories to detect concurrent
+// edits. enabled is *bool because both true and false are meaningful — leave
+// it nil to skip toggling.
+func (n *Node) APTChangeRepository(ctx context.Context, path string, index int, enabled *bool, digest string) error {
+	body := map[string]interface{}{
+		"path":  path,
+		"index": index,
+	}
+	if enabled != nil {
+		if *enabled {
+			body["enabled"] = 1
+		} else {
+			body["enabled"] = 0
+		}
+	}
+	if digest != "" {
+		body["digest"] = digest
+	}
+	return n.client.Post(ctx, fmt.Sprintf("/nodes/%s/apt/repositories", n.Name), body, nil)
+}
+
+// APTAddRepository adds one of PVE's standard repositories (identified by
+// handle, e.g. "no-subscription", "enterprise") to the node's apt
+// configuration. digest is optional for optimistic concurrency.
+func (n *Node) APTAddRepository(ctx context.Context, handle, digest string) error {
+	body := map[string]interface{}{"handle": handle}
+	if digest != "" {
+		body["digest"] = digest
+	}
+	return n.client.Put(ctx, fmt.Sprintf("/nodes/%s/apt/repositories", n.Name), body, nil)
+}
+
+// APTVersions returns the installed versions of the Proxmox-relevant packages
+// (pve-manager, kernel, qemu-server, etc.) — the same data shown on the GUI
+// "Updates → Package Versions" panel.
+func (n *Node) APTVersions(ctx context.Context) (versions []*APTPackageVersion, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/apt/versions", n.Name), &versions)
+	return
+}

--- a/nodes_apt.go
+++ b/nodes_apt.go
@@ -70,9 +70,12 @@ func (n *Node) APTRepositories(ctx context.Context) (repos *APTRepositories, err
 // edits.
 func (n *Node) APTChangeRepository(ctx context.Context, path string, index int, enabled bool, digest string) error {
 	body := map[string]interface{}{
-		"path":  path,
-		"index": index,
-		"enabled": map[bool]int{true: 1, false: 0}[enabled],
+		"path":    path,
+		"index":   index,
+		"enabled": 0,
+	}
+	if enabled {
+		body["enabled"] = 1
 	}
 	if digest != "" {
 		body["digest"] = digest

--- a/nodes_apt.go
+++ b/nodes_apt.go
@@ -67,19 +67,12 @@ func (n *Node) APTRepositories(ctx context.Context) (repos *APTRepositories, err
 // APTChangeRepository enables or disables an existing repository entry,
 // identified by the containing file path and its index within that file.
 // digest is optional; pass the value from APTRepositories to detect concurrent
-// edits. enabled is *bool because both true and false are meaningful — leave
-// it nil to skip toggling.
-func (n *Node) APTChangeRepository(ctx context.Context, path string, index int, enabled *bool, digest string) error {
+// edits.
+func (n *Node) APTChangeRepository(ctx context.Context, path string, index int, enabled bool, digest string) error {
 	body := map[string]interface{}{
 		"path":  path,
 		"index": index,
-	}
-	if enabled != nil {
-		if *enabled {
-			body["enabled"] = 1
-		} else {
-			body["enabled"] = 0
-		}
+		"enabled": map[bool]int{true: 1, false: 0}[enabled],
 	}
 	if digest != "" {
 		body["digest"] = digest

--- a/nodes_apt_test.go
+++ b/nodes_apt_test.go
@@ -109,8 +109,7 @@ func TestNode_APTChangeRepository(t *testing.T) {
 	defer mocks.Off()
 
 	node := &Node{client: mockClient(), Name: "node1"}
-	enabled := false
-	err := node.APTChangeRepository(context.Background(), "/etc/apt/sources.list.d/pve-enterprise.list", 0, &enabled, "abcdef0123456789")
+	err := node.APTChangeRepository(context.Background(), "/etc/apt/sources.list.d/pve-enterprise.list", 0, false, "abcdef0123456789")
 	assert.NoError(t, err)
 }
 

--- a/nodes_apt_test.go
+++ b/nodes_apt_test.go
@@ -1,0 +1,140 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNode_APT(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	entries, err := node.APT(context.Background())
+	require.NoError(t, err)
+	require.Len(t, entries, 4)
+	ids := []string{entries[0].ID, entries[1].ID, entries[2].ID, entries[3].ID}
+	assert.Contains(t, ids, "changelog")
+	assert.Contains(t, ids, "repositories")
+	assert.Contains(t, ids, "update")
+	assert.Contains(t, ids, "versions")
+}
+
+func TestNode_APTUpdates(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	updates, err := node.APTUpdates(context.Background())
+	require.NoError(t, err)
+	require.Len(t, updates, 1)
+	assert.Equal(t, "pve-manager", updates[0].Package)
+	assert.Equal(t, "9.1-2", updates[0].Version)
+	assert.Equal(t, "9.1-1", updates[0].OldVersion)
+	assert.Equal(t, "Proxmox", updates[0].Origin)
+}
+
+func TestNode_APTUpdate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	task, err := node.APTUpdate(context.Background(), true, false)
+	require.NoError(t, err)
+	require.NotNil(t, task)
+	assert.Equal(t, "node1", task.Node)
+	assert.Equal(t, "aptupdate", task.Type)
+}
+
+func TestNode_APTChangelog(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	cl, err := node.APTChangelog(context.Background(), "pve-manager", "")
+	require.NoError(t, err)
+	assert.Contains(t, cl, "pve-manager")
+	assert.Contains(t, cl, "urgency=medium")
+}
+
+func TestNode_APTRepositories(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	repos, err := node.APTRepositories(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, repos)
+	assert.Equal(t, "abcdef0123456789", repos.Digest)
+	require.Len(t, repos.Files, 1)
+	assert.Equal(t, "/etc/apt/sources.list", repos.Files[0].Path)
+	assert.Equal(t, "list", repos.Files[0].FileType)
+	require.Len(t, repos.Files[0].Repositories, 1)
+	assert.True(t, repos.Files[0].Repositories[0].Enabled)
+	assert.Contains(t, repos.Files[0].Repositories[0].URIs, "http://deb.debian.org/debian")
+
+	require.Len(t, repos.Infos, 1)
+	assert.Equal(t, "warning", repos.Infos[0].Kind)
+
+	// Standard-repos status is *bool to distinguish "configured but disabled" (false)
+	// from "not present" (nil).
+	require.GreaterOrEqual(t, len(repos.StandardRepos), 2)
+	var ent, nosub *APTStandardRepo
+	for _, sr := range repos.StandardRepos {
+		switch sr.Handle {
+		case "enterprise":
+			ent = sr
+		case "no-subscription":
+			nosub = sr
+		}
+	}
+	require.NotNil(t, ent)
+	require.NotNil(t, ent.Status)
+	assert.False(t, *ent.Status)
+	require.NotNil(t, nosub)
+	assert.Nil(t, nosub.Status)
+}
+
+func TestNode_APTChangeRepository(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+	enabled := false
+	err := node.APTChangeRepository(context.Background(), "/etc/apt/sources.list.d/pve-enterprise.list", 0, &enabled, "abcdef0123456789")
+	assert.NoError(t, err)
+}
+
+func TestNode_APTAddRepository(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+	err := node.APTAddRepository(context.Background(), "no-subscription", "abcdef0123456789")
+	assert.NoError(t, err)
+}
+
+func TestNode_APTVersions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	node := &Node{client: mockClient(), Name: "node1"}
+
+	versions, err := node.APTVersions(context.Background())
+	require.NoError(t, err)
+	require.Len(t, versions, 2)
+	assert.Equal(t, "pve-manager", versions[0].Package)
+	assert.Equal(t, "Installed", versions[0].CurrentState)
+	assert.Equal(t, "9.1-1", versions[0].ManagerVersion)
+	assert.Equal(t, "proxmox-ve", versions[1].Package)
+	assert.NotEmpty(t, versions[1].RunningKernel)
+}

--- a/tests/mocks/pve8x/nodes.go
+++ b/tests/mocks/pve8x/nodes.go
@@ -741,4 +741,81 @@ func nodes() {
 		Post("^/nodes/node1/replication/100-0/schedule_now$").
 		Reply(200).
 		JSON(`{"data": "UPID:node1:00001234:00012345:67890124:replicate:100-0:root@pam:"}`)
+
+	// GET /nodes/{node}/apt
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt$").
+		Reply(200).
+		JSON(`{"data": [
+			{"id": "changelog"},
+			{"id": "repositories"},
+			{"id": "update"},
+			{"id": "versions"}
+		]}`)
+
+	// GET /nodes/{node}/apt/update
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/update$").
+		Reply(200).
+		JSON(`{"data": [
+			{"Package": "pve-manager", "Title": "Proxmox VE Management", "Description": "PVE manager", "Version": "8.4-1", "OldVersion": "8.3-1", "Origin": "Proxmox", "Arch": "amd64", "Section": "admin", "Priority": "optional"}
+		]}`)
+
+	// POST /nodes/{node}/apt/update
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/apt/update$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:0000ABCD:0001ABCD:67890125:aptupdate::root@pam:"}`)
+
+	// GET /nodes/{node}/apt/changelog
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/changelog").
+		Reply(200).
+		JSON(`{"data": "pve-manager (8.4-1) bookworm; urgency=medium\n"}`)
+
+	// GET /nodes/{node}/apt/repositories
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/repositories$").
+		Reply(200).
+		JSON(`{"data": {
+			"digest": "abcdef0123456789",
+			"files": [
+				{"path": "/etc/apt/sources.list", "file-type": "list", "digest": [1,2,3,4], "repositories": [
+					{"Enabled": true, "FileType": "list", "Types": ["deb"], "URIs": ["http://deb.debian.org/debian"], "Suites": ["bookworm"], "Components": ["main"]}
+				]}
+			],
+			"errors": [],
+			"infos": [],
+			"standard-repos": [
+				{"handle": "enterprise", "name": "Proxmox VE Enterprise"}
+			]
+		}}`)
+
+	// POST /nodes/{node}/apt/repositories
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/apt/repositories$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /nodes/{node}/apt/repositories
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/apt/repositories$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/apt/versions
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/versions$").
+		Reply(200).
+		JSON(`{"data": [
+			{"Package": "pve-manager", "Title": "Proxmox VE Management", "Description": "PVE manager", "Version": "8.4-1", "Origin": "Proxmox", "Arch": "amd64", "Section": "admin", "Priority": "optional", "CurrentState": "Installed", "ManagerVersion": "8.4-1"}
+		]}`)
 }

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -817,4 +817,90 @@ func nodes() {
 		Post("^/nodes/node1/replication/100-0/schedule_now$").
 		Reply(200).
 		JSON(`{"data": "UPID:node1:00001234:00012345:67890124:replicate:100-0:root@pam:"}`)
+
+	// GET /nodes/{node}/apt
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt$").
+		Reply(200).
+		JSON(`{"data": [
+			{"id": "changelog"},
+			{"id": "repositories"},
+			{"id": "update"},
+			{"id": "versions"}
+		]}`)
+
+	// GET /nodes/{node}/apt/update — pending upgrades
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/update$").
+		Reply(200).
+		JSON(`{"data": [
+			{"Package": "pve-manager", "Title": "Proxmox VE Management", "Description": "PVE manager", "Version": "9.1-2", "OldVersion": "9.1-1", "Origin": "Proxmox", "Arch": "amd64", "Section": "admin", "Priority": "optional"}
+		]}`)
+
+	// POST /nodes/{node}/apt/update — refresh index, returns UPID
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/apt/update$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:0000ABCD:0001ABCD:67890125:aptupdate::root@pam:"}`)
+
+	// GET /nodes/{node}/apt/changelog
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/changelog").
+		Reply(200).
+		JSON(`{"data": "pve-manager (9.1-2) bookworm; urgency=medium\n  * fix things\n"}`)
+
+	// GET /nodes/{node}/apt/repositories
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/repositories$").
+		Reply(200).
+		JSON(`{"data": {
+			"digest": "abcdef0123456789",
+			"files": [
+				{
+					"path": "/etc/apt/sources.list",
+					"file-type": "list",
+					"digest": [1,2,3,4],
+					"repositories": [
+						{"Enabled": true, "FileType": "list", "Types": ["deb"], "URIs": ["http://deb.debian.org/debian"], "Suites": ["bookworm"], "Components": ["main", "contrib"]}
+					]
+				}
+			],
+			"errors": [],
+			"infos": [
+				{"path": "/etc/apt/sources.list.d/pve-enterprise.list", "index": "0", "kind": "warning", "message": "Enterprise repo configured without subscription", "property": "Enabled"}
+			],
+			"standard-repos": [
+				{"handle": "enterprise", "name": "Proxmox VE Enterprise", "status": false},
+				{"handle": "no-subscription", "name": "Proxmox VE No-Subscription"}
+			]
+		}}`)
+
+	// POST /nodes/{node}/apt/repositories — change (enable/disable) existing repo
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/apt/repositories$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /nodes/{node}/apt/repositories — add standard repository
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/apt/repositories$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/apt/versions
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/apt/versions$").
+		Reply(200).
+		JSON(`{"data": [
+			{"Package": "pve-manager", "Title": "Proxmox VE Management", "Description": "PVE manager", "Version": "9.1-1", "Origin": "Proxmox", "Arch": "amd64", "Section": "admin", "Priority": "optional", "CurrentState": "Installed", "ManagerVersion": "9.1-1"},
+			{"Package": "proxmox-ve", "Title": "Proxmox VE", "Description": "Proxmox VE metapackage", "Version": "9.1-1", "Origin": "Proxmox", "Arch": "all", "Section": "admin", "Priority": "optional", "CurrentState": "Installed", "RunningKernel": "6.8.12-1-pve"}
+		]}`)
 }

--- a/types.go
+++ b/types.go
@@ -119,6 +119,114 @@ type NodeReplicationStatus struct {
 	State     string  `json:"state,omitempty"`
 }
 
+// APTIndexEntry is one row of the /nodes/{node}/apt directory index. PVE
+// returns objects with a single "id" field naming each child resource
+// (changelog, repositories, update, versions).
+type APTIndexEntry struct {
+	ID string `json:"id"`
+}
+
+// APTUpdate is one pending package upgrade as reported by /apt/update. Fields
+// use PVE's upper-case names verbatim — these come straight from the apt
+// metadata.
+type APTUpdate struct {
+	Package      string `json:"Package"`
+	Title        string `json:"Title"`
+	Description  string `json:"Description"`
+	Version      string `json:"Version"`                // new version
+	OldVersion   string `json:"OldVersion,omitempty"`   // installed version
+	Origin       string `json:"Origin"`                 // "Proxmox", "Debian", ...
+	Arch         string `json:"Arch"`
+	Section      string `json:"Section"`
+	Priority     string `json:"Priority"`
+	NotifyStatus string `json:"NotifyStatus,omitempty"` // version PVE has already notified about
+}
+
+// APTPackageVersion is one row of /apt/versions — package info for the
+// Proxmox-relevant subset of installed packages, including current install
+// state. Used by the GUI's "Updates → Package Versions" panel.
+type APTPackageVersion struct {
+	Package        string `json:"Package"`
+	Title          string `json:"Title"`
+	Description    string `json:"Description"`
+	Version        string `json:"Version"`
+	OldVersion     string `json:"OldVersion,omitempty"`
+	Origin         string `json:"Origin"`
+	Arch           string `json:"Arch"`
+	Section        string `json:"Section"`
+	Priority       string `json:"Priority"`
+	CurrentState   string `json:"CurrentState"`             // Installed / NotInstalled / ...
+	ManagerVersion string `json:"ManagerVersion,omitempty"` // only on pve-manager
+	RunningKernel  string `json:"RunningKernel,omitempty"`  // only on proxmox-ve
+	NotifyStatus   string `json:"NotifyStatus,omitempty"`
+}
+
+// APTRepositories is the parsed view of /etc/apt/sources.list(.d) plus a
+// global Digest used as an etag for concurrent edits. StandardRepos is PVE's
+// catalog of repositories the GUI knows how to add; the per-handle Status is
+// nil when the repo isn't configured on the node.
+type APTRepositories struct {
+	Digest        string                  `json:"digest"`
+	Files         []*APTRepositoryFile    `json:"files,omitempty"`
+	Errors        []*APTRepositoryError   `json:"errors,omitempty"`
+	Infos         []*APTRepositoryInfo    `json:"infos,omitempty"`
+	StandardRepos []*APTStandardRepo      `json:"standard-repos,omitempty"`
+}
+
+// APTRepositoryFile is one apt sources file on disk. FileType is "list"
+// (one-line) or "sources" (deb822). Digest is the per-file digest as a byte
+// array (PVE returns it as a JSON array of integers).
+type APTRepositoryFile struct {
+	Path         string            `json:"path"`
+	FileType     string            `json:"file-type"`
+	Digest       []int             `json:"digest,omitempty"`
+	Repositories []*APTRepository  `json:"repositories,omitempty"`
+}
+
+// APTRepository is a single repository entry within a file. Components,
+// Options and Comment are only populated where the underlying file format
+// supports them.
+type APTRepository struct {
+	Enabled    bool                   `json:"Enabled"`
+	FileType   string                 `json:"FileType"`
+	Types      []string               `json:"Types"`
+	URIs       []string               `json:"URIs"`
+	Suites     []string               `json:"Suites"`
+	Components []string               `json:"Components,omitempty"`
+	Options    []*APTRepositoryOption `json:"Options,omitempty"`
+	Comment    string                 `json:"Comment,omitempty"`
+}
+
+type APTRepositoryOption struct {
+	Key    string   `json:"Key"`
+	Values []string `json:"Values"`
+}
+
+type APTRepositoryError struct {
+	Path  string `json:"path"`
+	Error string `json:"error"`
+}
+
+// APTRepositoryInfo is a warning/info note PVE attaches to a specific entry
+// within a specific file (e.g. "use of subscription repo on free system").
+// Index is a string in the schema even though it names a numeric position.
+type APTRepositoryInfo struct {
+	Path     string `json:"path"`
+	Index    string `json:"index"`
+	Kind     string `json:"kind"`
+	Message  string `json:"message"`
+	Property string `json:"property,omitempty"`
+}
+
+// APTStandardRepo is one entry from PVE's catalog of well-known repos.
+// Status is *bool because tri-state: true = configured+enabled,
+// false = configured+disabled, nil = not present on the node.
+type APTStandardRepo struct {
+	Handle string `json:"handle"`
+	Name   string `json:"name"`
+	Status *bool  `json:"status,omitempty"`
+}
+
 type Term struct {
 	Port   StringOrInt
 	Ticket string


### PR DESCRIPTION
## Summary

Closes the `/nodes/{node}/apt` coverage gap (0/8 → 8/8). All 8 endpoints wrapped:

- `APT` — `GET apt` (directory index)
- `APTUpdates` — `GET apt/update` (list pending updates)
- `APTUpdate` — `POST apt/update` (refresh index, returns Task)
- `APTChangelog` — `GET apt/changelog`
- `APTRepositories` — `GET apt/repositories`
- `APTChangeRepository` — `POST apt/repositories` (toggle enable, change properties)
- `APTAddRepository` — `PUT apt/repositories` (add a standard PVE repo)
- `APTVersions` — `GET apt/versions`

Mocks for pve8x and pve9x (apt didn't exist in pve7x mocks).

### Schema notes
- `apt/repositories` `status` is tri-state — modeled as `*bool` (nil = not configured, false = configured+disabled, true = configured+enabled). Same for the `enabled` toggle param.
- `APTRepositoryInfo.Index` typed as `string` per schema even though it names a numeric position.
- `APTRepositoryFile.Digest` is `[]int` (PVE returns a byte array).

## Test plan
- [x] \`go test .\`
- [x] \`go build ./...\`
- [ ] Smoke against a live PVE node