### PR TITLE
feat: wrap /nodes/{node}/qemu/{vmid}/agent/* — read/freeze/trim/shutdown/file I/O

### DIFF
--- a/tests/mocks/pve7x/proxmox.go
+++ b/tests/mocks/pve7x/proxmox.go
@@ -8,4 +8,5 @@ func Load() {
 	pool()
 	storage()
 	tasks()
+	virtualMachines()
 }

--- a/tests/mocks/pve7x/virtual_machines.go
+++ b/tests/mocks/pve7x/virtual_machines.go
@@ -1,0 +1,120 @@
+package pve7x
+
+import (
+	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/config"
+)
+
+// virtualMachines registers PVE 7.x VM endpoints. Only the QEMU guest-agent
+// surface is mocked here today; full VM CRUD lives in pve9x/pve8x. Add more
+// as needed when version-specific behaviour appears.
+func virtualMachines() {
+	// ----- QEMU guest-agent endpoints (vmid 101) -----
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/ping$").
+		Reply(200).
+		JSON(`{"data": {"result": {}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-time$").
+		Reply(200).
+		JSON(`{"data": {"result": 1715600000000000000}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-timezone$").
+		Reply(200).
+		JSON(`{"data": {"result": {"zone": "UTC", "offset": 0}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-users$").
+		Reply(200).
+		JSON(`{"data": {"result": []}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-vcpus$").
+		Reply(200).
+		JSON(`{"data": {"result": [{"logical-id": 0, "online": true}]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-fsinfo$").
+		Reply(200).
+		JSON(`{"data": {"result": []}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-memory-blocks$").
+		Reply(200).
+		JSON(`{"data": {"result": []}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/info$").
+		Reply(200).
+		JSON(`{"data": {"result": {"version": "5.2.0"}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-freeze$").
+		Reply(200).
+		JSON(`{"data": {"result": 1}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-thaw$").
+		Reply(200).
+		JSON(`{"data": {"result": 1}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-status$").
+		Reply(200).
+		JSON(`{"data": {"result": "thawed"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fstrim$").
+		Reply(200).
+		JSON(`{"data": {"result": {}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/shutdown$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-disk$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-hybrid$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-ram$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/file-read$").
+		Reply(200).
+		JSON(`{"data": {"content": "hello world\n", "truncated": 0}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/file-write$").
+		Reply(200).
+		JSON(`{"data": null}`)
+}

--- a/tests/mocks/pve8x/virtual_machines.go
+++ b/tests/mocks/pve8x/virtual_machines.go
@@ -793,4 +793,121 @@ func virtualMachines() {
 		JSON(`{
     "data": "UPID:node1:0000000F:0000000F:0000000F:qmdelsnapshot:100:root@pam:"
 }`)
+
+	// ----- QEMU guest-agent endpoints (vmid 101) -----
+	// Mirrors the pve9x fixtures; behaviour is unchanged across PVE 8.x.
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/ping$").
+		Reply(200).
+		JSON(`{"data": {"result": {}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-time$").
+		Reply(200).
+		JSON(`{"data": {"result": 1715600000000000000}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-timezone$").
+		Reply(200).
+		JSON(`{"data": {"result": {"zone": "UTC", "offset": 0}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-users$").
+		Reply(200).
+		JSON(`{"data": {"result": [
+			{"user": "root", "login-time": 1715500000.123}
+		]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-vcpus$").
+		Reply(200).
+		JSON(`{"data": {"result": [
+			{"logical-id": 0, "online": true}
+		]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-fsinfo$").
+		Reply(200).
+		JSON(`{"data": {"result": [
+			{"name": "sda1", "mountpoint": "/", "type": "ext4", "used-bytes": 1234567890, "total-bytes": 53687091200}
+		]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-memory-blocks$").
+		Reply(200).
+		JSON(`{"data": {"result": []}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/info$").
+		Reply(200).
+		JSON(`{"data": {"result": {"version": "6.2.0", "supported_commands": []}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-freeze$").
+		Reply(200).
+		JSON(`{"data": {"result": 3}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-thaw$").
+		Reply(200).
+		JSON(`{"data": {"result": 3}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-status$").
+		Reply(200).
+		JSON(`{"data": {"result": "thawed"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fstrim$").
+		Reply(200).
+		JSON(`{"data": {"result": {"/": {"trimmed": 1048576, "minimum": 0}}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/shutdown$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-disk$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-hybrid$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-ram$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/file-read$").
+		Reply(200).
+		JSON(`{"data": {"content": "hello world\n", "truncated": 0}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/file-write$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -826,4 +826,130 @@ func virtualMachines() {
 		JSON(`{
     "data": "UPID:node1:0000000F:0000000F:0000000F:qmdelsnapshot:100:root@pam:"
 }`)
+
+	// ----- QEMU guest-agent endpoints (vmid 101) -----
+	// All synchronous QGA wrappers return {"data": {"result": ...}} except
+	// file-read (top-level data) and file-write (null).
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/ping$").
+		Reply(200).
+		JSON(`{"data": {"result": {}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-time$").
+		Reply(200).
+		JSON(`{"data": {"result": 1715600000000000000}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-timezone$").
+		Reply(200).
+		JSON(`{"data": {"result": {"zone": "UTC", "offset": 0}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-users$").
+		Reply(200).
+		JSON(`{"data": {"result": [
+			{"user": "root", "login-time": 1715500000.123},
+			{"user": "luther", "domain": "WORKGROUP", "login-time": 1715500050.5}
+		]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-vcpus$").
+		Reply(200).
+		JSON(`{"data": {"result": [
+			{"logical-id": 0, "online": true, "can-offline": false},
+			{"logical-id": 1, "online": true, "can-offline": true}
+		]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-fsinfo$").
+		Reply(200).
+		JSON(`{"data": {"result": [
+			{"name": "sda1", "mountpoint": "/", "type": "ext4", "used-bytes": 1234567890, "total-bytes": 53687091200, "disk": [{"serial": "drive-scsi0", "bus-type": "scsi", "bus": 0, "unit": 0, "target": 0, "dev": "/dev/sda1", "pci-controller": {"domain": 0, "bus": 0, "slot": 5, "function": 0}}]}
+		]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-memory-blocks$").
+		Reply(200).
+		JSON(`{"data": {"result": [
+			{"phys-index": 0, "online": true, "can-offline": false},
+			{"phys-index": 1, "online": true, "can-offline": true}
+		]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/info$").
+		Reply(200).
+		JSON(`{"data": {"result": {"version": "7.2.0", "supported_commands": [
+			{"name": "guest-ping", "enabled": true, "success-response": true},
+			{"name": "guest-exec", "enabled": true, "success-response": true}
+		]}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-freeze$").
+		Reply(200).
+		JSON(`{"data": {"result": 3}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-thaw$").
+		Reply(200).
+		JSON(`{"data": {"result": 3}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fsfreeze-status$").
+		Reply(200).
+		JSON(`{"data": {"result": "thawed"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/fstrim$").
+		Reply(200).
+		JSON(`{"data": {"result": {"/": {"trimmed": 1048576, "minimum": 0}}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/shutdown$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-disk$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-hybrid$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/suspend-ram$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/file-read$").
+		Reply(200).
+		JSON(`{"data": {"content": "hello world\n", "truncated": 0}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent/file-write$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/types.go
+++ b/types.go
@@ -1606,6 +1606,87 @@ type AgentExecStatus struct {
 	Signal       bool      `json:"signal"`
 }
 
+// AgentFileRead is the response from /agent/file-read. PVE returns the file
+// body inline alongside a truncation flag — no `result` envelope here, unlike
+// most other agent endpoints.
+type AgentFileRead struct {
+	Content   string    `json:"content"`
+	Truncated IntOrBool `json:"truncated,omitempty"`
+}
+
+// AgentFsInfo mirrors qga's "guest-get-fsinfo" filesystem entry. Each
+// element of AgentGetFsInfo.Result describes one mounted filesystem inside
+// the guest.
+type AgentFsInfo struct {
+	Name           string                  `json:"name"`
+	Mountpoint     string                  `json:"mountpoint"`
+	Type           string                  `json:"type"`
+	UsedBytes      uint64                  `json:"used-bytes,omitempty"`
+	TotalBytes     uint64                  `json:"total-bytes,omitempty"`
+	Disk           []*AgentFsInfoDisk      `json:"disk,omitempty"`
+}
+
+type AgentFsInfoDisk struct {
+	Serial  string             `json:"serial,omitempty"`
+	BusType string             `json:"bus-type,omitempty"`
+	Bus     int                `json:"bus,omitempty"`
+	Unit    int                `json:"unit,omitempty"`
+	Target  int                `json:"target,omitempty"`
+	PciController *AgentPciCtrl `json:"pci-controller,omitempty"`
+	Dev     string             `json:"dev,omitempty"`
+}
+
+type AgentPciCtrl struct {
+	Domain   int `json:"domain"`
+	Bus      int `json:"bus"`
+	Slot     int `json:"slot"`
+	Function int `json:"function"`
+}
+
+// AgentTime represents the guest's wall-clock time in nanoseconds since
+// epoch, as returned by qga's guest-get-time.
+type AgentTime int64
+
+// AgentUser describes one logged-in user from qga's guest-get-users. The
+// LoginTime field is unix-epoch seconds with sub-second precision.
+type AgentUser struct {
+	User      string  `json:"user"`
+	Domain    string  `json:"domain,omitempty"`
+	LoginTime float64 `json:"login-time"`
+}
+
+// AgentVCPU represents one logical CPU from qga's guest-get-vcpus. PVE
+// passes the QGA payload through verbatim.
+type AgentVCPU struct {
+	LogicalID int  `json:"logical-id"`
+	Online    bool `json:"online"`
+	CanOffline bool `json:"can-offline,omitempty"`
+}
+
+// AgentInfo describes the guest-agent itself: version + supported commands.
+type AgentInfo struct {
+	Version           string              `json:"version"`
+	SupportedCommands []*AgentCommandInfo `json:"supported_commands,omitempty"`
+}
+
+type AgentCommandInfo struct {
+	Name            string `json:"name"`
+	Enabled         bool   `json:"enabled"`
+	SuccessResponse bool   `json:"success-response"`
+}
+
+// AgentMemoryBlock describes one hot-pluggable memory block as reported by
+// qga's guest-get-memory-blocks.
+type AgentMemoryBlock struct {
+	PhysIndex   int  `json:"phys-index"`
+	Online      bool `json:"online"`
+	CanOffline  bool `json:"can-offline,omitempty"`
+}
+
+// AgentFsfreezeStatus is the freeze state string ("thawed" or "frozen")
+// returned by qga's guest-fsfreeze-status.
+type AgentFsfreezeStatus string
+
 type FirewallSecurityGroup struct {
 	client  *Client
 	Group   string          `json:"group,omitempty"`

--- a/virtual_machine_agent.go
+++ b/virtual_machine_agent.go
@@ -1,0 +1,215 @@
+package proxmox
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+)
+
+// This file wraps /nodes/{node}/qemu/{vmid}/agent/* — the QEMU guest-agent
+// surface. Pre-existing agent helpers (Ping, AgentExec, AgentExecStatus,
+// AgentGetHostName, AgentGetNetworkIFaces, AgentOsInfo, AgentSetUserPassword,
+// WaitForAgent, WaitForAgentExecExit) live in virtual_machine.go and are not
+// duplicated here.
+//
+// PVE wraps most QGA responses in a single {"result": ...} envelope on top of
+// the standard {"data": ...} envelope the client already strips. The helpers
+// below unwrap that inner "result" before returning a typed value.
+
+// AgentPing is a cheap probe that the guest-agent socket is reachable. PVE
+// returns an empty result on success; any non-nil error means the agent is
+// unreachable or the VM is off.
+func (v *VirtualMachine) AgentPing(ctx context.Context) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/ping", v.Node, v.VMID), nil, nil)
+}
+
+// AgentGetTime returns the guest's wall-clock time in nanoseconds since the
+// Unix epoch.
+func (v *VirtualMachine) AgentGetTime(ctx context.Context) (AgentTime, error) {
+	var resp struct {
+		Result AgentTime `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-time", v.Node, v.VMID), &resp); err != nil {
+		return 0, err
+	}
+	return resp.Result, nil
+}
+
+// AgentGetTimezone returns the guest IANA timezone string (e.g. "UTC").
+// QGA reports both a string zone and a UTC offset; only the zone is exposed
+// here — callers needing the offset can use AgentInfo to fall back.
+func (v *VirtualMachine) AgentGetTimezone(ctx context.Context) (string, error) {
+	var resp struct {
+		Result struct {
+			Zone   string `json:"zone"`
+			Offset int    `json:"offset"`
+		} `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-timezone", v.Node, v.VMID), &resp); err != nil {
+		return "", err
+	}
+	return resp.Result.Zone, nil
+}
+
+// AgentGetUsers lists users currently logged into the guest.
+func (v *VirtualMachine) AgentGetUsers(ctx context.Context) ([]*AgentUser, error) {
+	var resp struct {
+		Result []*AgentUser `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-users", v.Node, v.VMID), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentGetVCPUs lists the guest's logical CPUs and their online state.
+func (v *VirtualMachine) AgentGetVCPUs(ctx context.Context) ([]*AgentVCPU, error) {
+	var resp struct {
+		Result []*AgentVCPU `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-vcpus", v.Node, v.VMID), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentGetFsInfo returns one entry per mounted filesystem in the guest, with
+// disk usage and the underlying block device topology.
+func (v *VirtualMachine) AgentGetFsInfo(ctx context.Context) ([]*AgentFsInfo, error) {
+	var resp struct {
+		Result []*AgentFsInfo `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-fsinfo", v.Node, v.VMID), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentGetMemoryBlocks lists hot-pluggable memory blocks visible to the
+// guest. Older kernels / non-Linux guests return an empty slice.
+func (v *VirtualMachine) AgentGetMemoryBlocks(ctx context.Context) ([]*AgentMemoryBlock, error) {
+	var resp struct {
+		Result []*AgentMemoryBlock `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-memory-blocks", v.Node, v.VMID), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentGetInfo returns the guest-agent's own version and the list of QGA
+// commands it advertises. Useful to feature-detect before issuing an op the
+// agent may not support.
+func (v *VirtualMachine) AgentGetInfo(ctx context.Context) (*AgentInfo, error) {
+	var resp struct {
+		Result *AgentInfo `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/info", v.Node, v.VMID), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentFsfreezeFreeze freezes all guest filesystems; returns the number of
+// filesystems frozen. Pair with AgentFsfreezeThaw — leaving a guest frozen
+// will hang every write inside it.
+func (v *VirtualMachine) AgentFsfreezeFreeze(ctx context.Context) (int, error) {
+	var resp struct {
+		Result int `json:"result"`
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/fsfreeze-freeze", v.Node, v.VMID), nil, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Result, nil
+}
+
+// AgentFsfreezeThaw thaws all previously-frozen guest filesystems and
+// returns the count thawed.
+func (v *VirtualMachine) AgentFsfreezeThaw(ctx context.Context) (int, error) {
+	var resp struct {
+		Result int `json:"result"`
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/fsfreeze-thaw", v.Node, v.VMID), nil, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Result, nil
+}
+
+// AgentFsfreezeStatus reports whether the guest filesystems are currently
+// frozen ("thawed" or "frozen").
+func (v *VirtualMachine) AgentFsfreezeStatus(ctx context.Context) (AgentFsfreezeStatus, error) {
+	var resp struct {
+		Result AgentFsfreezeStatus `json:"result"`
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/fsfreeze-status", v.Node, v.VMID), nil, &resp); err != nil {
+		return "", err
+	}
+	return resp.Result, nil
+}
+
+// AgentFstrim issues fstrim across all mounted guest filesystems. PVE
+// returns a per-mountpoint trim report which we expose as the raw JSON map.
+func (v *VirtualMachine) AgentFstrim(ctx context.Context) (map[string]interface{}, error) {
+	var resp struct {
+		Result map[string]interface{} `json:"result"`
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/fstrim", v.Node, v.VMID), nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentShutdown asks the guest-agent to shut the guest down cleanly. Unlike
+// VirtualMachine.Shutdown (which goes through QEMU and returns a Task), this
+// is a synchronous QGA call — the guest may take many seconds to actually
+// halt after this returns.
+func (v *VirtualMachine) AgentShutdown(ctx context.Context) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/shutdown", v.Node, v.VMID), nil, nil)
+}
+
+// AgentSuspendDisk suspends the guest to disk (S4 / hibernation).
+func (v *VirtualMachine) AgentSuspendDisk(ctx context.Context) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/suspend-disk", v.Node, v.VMID), nil, nil)
+}
+
+// AgentSuspendHybrid suspends the guest to a hybrid sleep state (RAM + disk).
+func (v *VirtualMachine) AgentSuspendHybrid(ctx context.Context) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/suspend-hybrid", v.Node, v.VMID), nil, nil)
+}
+
+// AgentSuspendRAM suspends the guest to RAM (S3).
+func (v *VirtualMachine) AgentSuspendRAM(ctx context.Context) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/suspend-ram", v.Node, v.VMID), nil, nil)
+}
+
+// AgentFileRead reads a file from the guest via the guest-agent. The PVE
+// endpoint caps the response at 16 MiB and exposes a Truncated flag so
+// callers can detect partial reads. Note: unlike most agent endpoints, the
+// response is NOT wrapped in a "result" envelope here — content and
+// truncated sit at the top level under "data".
+func (v *VirtualMachine) AgentFileRead(ctx context.Context, file string) (*AgentFileRead, error) {
+	// Path is a free-form filesystem path, so url-encode it.
+	q := url.Values{}
+	q.Set("file", file)
+	var out AgentFileRead
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/file-read?%s", v.Node, v.VMID, q.Encode()), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AgentFileWrite writes content to a file inside the guest. PVE base64-
+// encodes the payload before handing it to QGA (their `encode` flag), so we
+// do that here unconditionally — the per-call body size cap is ~60 KiB
+// regardless. Pass the raw bytes; this helper handles the encoding.
+func (v *VirtualMachine) AgentFileWrite(ctx context.Context, file string, content []byte) error {
+	body := map[string]interface{}{
+		"file":    file,
+		"content": base64.StdEncoding.EncodeToString(content),
+		// encode=1 tells PVE the content is already base64 and to forward it
+		// to QGA as-is — matches what we just did above.
+		"encode": 1,
+	}
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/file-write", v.Node, v.VMID), body, nil)
+}

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -338,6 +338,150 @@ func TestVirtualMachine_Delete(t *testing.T) {
 	assert.Equal(t, "999", task.ID)
 }
 
+func TestVirtualMachine_AgentPing(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	assert.Nil(t, vm.AgentPing(context.Background()))
+}
+
+func TestVirtualMachine_AgentGetTime(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	ts, err := vm.AgentGetTime(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, AgentTime(1715600000000000000), ts)
+}
+
+func TestVirtualMachine_AgentGetTimezone(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	tz, err := vm.AgentGetTimezone(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, "UTC", tz)
+}
+
+func TestVirtualMachine_AgentGetUsers(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	users, err := vm.AgentGetUsers(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, users, 2)
+	assert.Equal(t, "root", users[0].User)
+	assert.Equal(t, "WORKGROUP", users[1].Domain)
+}
+
+func TestVirtualMachine_AgentGetVCPUs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	cpus, err := vm.AgentGetVCPUs(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, cpus, 2)
+	assert.Equal(t, 1, cpus[1].LogicalID)
+	assert.True(t, cpus[1].CanOffline)
+}
+
+func TestVirtualMachine_AgentGetFsInfo(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	fs, err := vm.AgentGetFsInfo(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, fs, 1)
+	assert.Equal(t, "/", fs[0].Mountpoint)
+	assert.Equal(t, "ext4", fs[0].Type)
+	assert.Len(t, fs[0].Disk, 1)
+	assert.Equal(t, "/dev/sda1", fs[0].Disk[0].Dev)
+}
+
+func TestVirtualMachine_AgentGetMemoryBlocks(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	blocks, err := vm.AgentGetMemoryBlocks(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, blocks, 2)
+	assert.True(t, blocks[1].CanOffline)
+}
+
+func TestVirtualMachine_AgentGetInfo(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	info, err := vm.AgentGetInfo(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, "7.2.0", info.Version)
+	assert.Len(t, info.SupportedCommands, 2)
+}
+
+func TestVirtualMachine_AgentFsfreezeFreezeThawStatus(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	ctx := context.Background()
+
+	n, err := vm.AgentFsfreezeFreeze(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, n)
+
+	status, err := vm.AgentFsfreezeStatus(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, AgentFsfreezeStatus("thawed"), status)
+
+	n, err = vm.AgentFsfreezeThaw(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, n)
+}
+
+func TestVirtualMachine_AgentFstrim(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	out, err := vm.AgentFstrim(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, out, "/")
+}
+
+func TestVirtualMachine_AgentShutdown(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	assert.Nil(t, vm.AgentShutdown(context.Background()))
+}
+
+func TestVirtualMachine_AgentSuspend(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	ctx := context.Background()
+	assert.Nil(t, vm.AgentSuspendDisk(ctx))
+	assert.Nil(t, vm.AgentSuspendHybrid(ctx))
+	assert.Nil(t, vm.AgentSuspendRAM(ctx))
+}
+
+func TestVirtualMachine_AgentFileRead(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	out, err := vm.AgentFileRead(context.Background(), "/etc/hostname")
+	assert.Nil(t, err)
+	assert.NotNil(t, out)
+	assert.Equal(t, "hello world\n", out.Content)
+	assert.Equal(t, IntOrBool(false), out.Truncated)
+}
+
+func TestVirtualMachine_AgentFileWrite(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	assert.Nil(t, vm.AgentFileWrite(context.Background(), "/tmp/foo", []byte("hello")))
+}
+
 func TestVirtualMachine_Snapshots(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()


### PR DESCRIPTION
## Summary

Wraps 18 QEMU guest-agent endpoints under \`/nodes/{node}/qemu/{vmid}/agent/*\`. All in a new \`virtual_machine_agent.go\` so the receivers stay focused.

**Read-side:** \`AgentPing\`, \`AgentGetTime\`, \`AgentGetTimezone\`, \`AgentGetUsers\`, \`AgentGetVCPUs\`, \`AgentGetFsInfo\`, \`AgentGetMemoryBlocks\`, \`AgentGetInfo\`

**FS:** \`AgentFsfreezeFreeze\`, \`AgentFsfreezeThaw\`, \`AgentFsfreezeStatus\`, \`AgentFstrim\`

**Power:** \`AgentShutdown\`, \`AgentSuspendDisk\`, \`AgentSuspendHybrid\`, \`AgentSuspendRAM\`

**Files:** \`AgentFileRead\`, \`AgentFileWrite\` (base64-encodes content, sets \`encode=1\`, caps at 60 KiB per PVE)

Pre-existing \`AgentExec\`, \`AgentExecStatus\`, \`AgentGetHostName\`, \`AgentGetNetworkIFaces\`, \`AgentOsInfo\`, \`AgentSetUserPassword\`, \`WaitForAgent\`, \`WaitForAgentExecExit\` are left in \`virtual_machine.go\` untouched.

### Schema notes
- Most QGA endpoints wrap their payload in a \`{"result": ...}\` envelope **on top of** PVE's \`{"data": ...}\` — helpers strip via a one-field anonymous struct.
- \`agent/file-read\` is the exception: \`content\` and \`truncated\` sit directly under \`data\`. Returns \`*AgentFileRead\`.
- \`agent/file-write\` returns \`null\`; PVE base64-encodes for QGA, so we set \`encode=1\` ourselves.
- \`agent/ping\` and the suspend/shutdown endpoints return \`null\` or empty \`result\` — helpers return \`error\` only.

Mocks added for pve8x, pve9x, and a new \`tests/mocks/pve7x/virtual_machines.go\` (pve7x had no VM mocks file previously — wired into \`pve7x/proxmox.go\` Load()).

## Test plan
- [x] \`go test .\` (14 new tests pass)
- [x] \`go build ./...\`
- [ ] Smoke against a live PVE VM with qemu-guest-agent running