### PR TITLE
feat: wrap /cluster/metrics, /cluster/mapping, /cluster/notifications

### DIFF
--- a/cluster_mapping.go
+++ b/cluster_mapping.go
@@ -9,45 +9,40 @@ import (
 
 // Mappings lists the resource-type directory under /cluster/mapping (e.g. dir,
 // pci, usb). See https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/mapping
-func (cl *Cluster) Mappings(ctx context.Context) (ClusterMappings, error) {
-	var entries ClusterMappings
-	if err := cl.client.Get(ctx, "/cluster/mapping", &entries); err != nil {
-		return nil, err
-	}
-	return entries, nil
+func (cl *Cluster) Mappings(ctx context.Context) (entries ClusterMappings, err error) {
+	err = cl.client.Get(ctx, "/cluster/mapping", &entries)
+	return
 }
 
 // --- directory mappings -----------------------------------------------------
 
 // DirMappings lists directory mappings. Pass a non-empty checkNode to ask PVE
 // to validate each entry against that node (populates each entry's Checks).
-func (cl *Cluster) DirMappings(ctx context.Context, checkNode string) (ClusterDirMappings, error) {
+func (cl *Cluster) DirMappings(ctx context.Context, checkNode string) (mappings ClusterDirMappings, err error) {
 	path := "/cluster/mapping/dir"
 	if checkNode != "" {
 		q := url.Values{}
 		q.Set("check-node", checkNode)
 		path = path + "?" + q.Encode()
 	}
-	var mappings ClusterDirMappings
-	if err := cl.client.Get(ctx, path, &mappings); err != nil {
-		return nil, err
-	}
-	return mappings, nil
+	err = cl.client.Get(ctx, path, &mappings)
+	return
 }
 
 // DirMapping reads a single directory mapping by id.
-func (cl *Cluster) DirMapping(ctx context.Context, id string) (*ClusterDirMapping, error) {
+func (cl *Cluster) DirMapping(ctx context.Context, id string) (m *ClusterDirMapping, err error) {
 	if id == "" {
-		return nil, errors.New("dir mapping id can not be empty")
+		err = errors.New("dir mapping id can not be empty")
+		return
 	}
-	m := &ClusterDirMapping{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/dir/%s", id), m); err != nil {
-		return nil, err
+	m = &ClusterDirMapping{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/dir/%s", id), m); err != nil {
+		return
 	}
 	if m.ID == "" {
 		m.ID = id
 	}
-	return m, nil
+	return
 }
 
 // NewDirMapping creates a directory mapping. opts.ID and opts.Map are required.
@@ -80,33 +75,31 @@ func (cl *Cluster) DeleteDirMapping(ctx context.Context, id string) error {
 // --- PCI mappings -----------------------------------------------------------
 
 // PCIMappings lists PCI hardware mappings. See DirMappings for checkNode.
-func (cl *Cluster) PCIMappings(ctx context.Context, checkNode string) (ClusterPCIMappings, error) {
+func (cl *Cluster) PCIMappings(ctx context.Context, checkNode string) (mappings ClusterPCIMappings, err error) {
 	path := "/cluster/mapping/pci"
 	if checkNode != "" {
 		q := url.Values{}
 		q.Set("check-node", checkNode)
 		path = path + "?" + q.Encode()
 	}
-	var mappings ClusterPCIMappings
-	if err := cl.client.Get(ctx, path, &mappings); err != nil {
-		return nil, err
-	}
-	return mappings, nil
+	err = cl.client.Get(ctx, path, &mappings)
+	return
 }
 
 // PCIMapping reads a single PCI mapping by id.
-func (cl *Cluster) PCIMapping(ctx context.Context, id string) (*ClusterPCIMapping, error) {
+func (cl *Cluster) PCIMapping(ctx context.Context, id string) (m *ClusterPCIMapping, err error) {
 	if id == "" {
-		return nil, errors.New("pci mapping id can not be empty")
+		err = errors.New("pci mapping id can not be empty")
+		return
 	}
-	m := &ClusterPCIMapping{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/pci/%s", id), m); err != nil {
-		return nil, err
+	m = &ClusterPCIMapping{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/pci/%s", id), m); err != nil {
+		return
 	}
 	if m.ID == "" {
 		m.ID = id
 	}
-	return m, nil
+	return
 }
 
 // NewPCIMapping creates a PCI hardware mapping.
@@ -139,33 +132,31 @@ func (cl *Cluster) DeletePCIMapping(ctx context.Context, id string) error {
 // --- USB mappings -----------------------------------------------------------
 
 // USBMappings lists USB hardware mappings. See DirMappings for checkNode.
-func (cl *Cluster) USBMappings(ctx context.Context, checkNode string) (ClusterUSBMappings, error) {
+func (cl *Cluster) USBMappings(ctx context.Context, checkNode string) (mappings ClusterUSBMappings, err error) {
 	path := "/cluster/mapping/usb"
 	if checkNode != "" {
 		q := url.Values{}
 		q.Set("check-node", checkNode)
 		path = path + "?" + q.Encode()
 	}
-	var mappings ClusterUSBMappings
-	if err := cl.client.Get(ctx, path, &mappings); err != nil {
-		return nil, err
-	}
-	return mappings, nil
+	err = cl.client.Get(ctx, path, &mappings)
+	return
 }
 
 // USBMapping reads a single USB mapping by id.
-func (cl *Cluster) USBMapping(ctx context.Context, id string) (*ClusterUSBMapping, error) {
+func (cl *Cluster) USBMapping(ctx context.Context, id string) (m *ClusterUSBMapping, err error) {
 	if id == "" {
-		return nil, errors.New("usb mapping id can not be empty")
+		err = errors.New("usb mapping id can not be empty")
+		return
 	}
-	m := &ClusterUSBMapping{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/usb/%s", id), m); err != nil {
-		return nil, err
+	m = &ClusterUSBMapping{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/usb/%s", id), m); err != nil {
+		return
 	}
 	if m.ID == "" {
 		m.ID = id
 	}
-	return m, nil
+	return
 }
 
 // NewUSBMapping creates a USB hardware mapping.

--- a/cluster_mapping.go
+++ b/cluster_mapping.go
@@ -1,0 +1,196 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Mappings lists the resource-type directory under /cluster/mapping (e.g. dir,
+// pci, usb). See https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/mapping
+func (cl *Cluster) Mappings(ctx context.Context) (ClusterMappings, error) {
+	var entries ClusterMappings
+	if err := cl.client.Get(ctx, "/cluster/mapping", &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// --- directory mappings -----------------------------------------------------
+
+// DirMappings lists directory mappings. Pass a non-empty checkNode to ask PVE
+// to validate each entry against that node (populates each entry's Checks).
+func (cl *Cluster) DirMappings(ctx context.Context, checkNode string) (ClusterDirMappings, error) {
+	path := "/cluster/mapping/dir"
+	if checkNode != "" {
+		q := url.Values{}
+		q.Set("check-node", checkNode)
+		path = path + "?" + q.Encode()
+	}
+	var mappings ClusterDirMappings
+	if err := cl.client.Get(ctx, path, &mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// DirMapping reads a single directory mapping by id.
+func (cl *Cluster) DirMapping(ctx context.Context, id string) (*ClusterDirMapping, error) {
+	if id == "" {
+		return nil, errors.New("dir mapping id can not be empty")
+	}
+	m := &ClusterDirMapping{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/dir/%s", id), m); err != nil {
+		return nil, err
+	}
+	if m.ID == "" {
+		m.ID = id
+	}
+	return m, nil
+}
+
+// NewDirMapping creates a directory mapping. opts.ID and opts.Map are required.
+func (cl *Cluster) NewDirMapping(ctx context.Context, opts *ClusterDirMappingOptions) error {
+	if opts == nil || opts.ID == "" {
+		return errors.New("dir mapping id can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/mapping/dir", opts, nil)
+}
+
+// UpdateDirMapping mutates an existing directory mapping.
+func (cl *Cluster) UpdateDirMapping(ctx context.Context, id string, opts *ClusterDirMappingOptions) error {
+	if id == "" {
+		return errors.New("dir mapping id can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterDirMappingOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/mapping/dir/%s", id), opts, nil)
+}
+
+// DeleteDirMapping removes a directory mapping.
+func (cl *Cluster) DeleteDirMapping(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("dir mapping id can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/mapping/dir/%s", id), nil)
+}
+
+// --- PCI mappings -----------------------------------------------------------
+
+// PCIMappings lists PCI hardware mappings. See DirMappings for checkNode.
+func (cl *Cluster) PCIMappings(ctx context.Context, checkNode string) (ClusterPCIMappings, error) {
+	path := "/cluster/mapping/pci"
+	if checkNode != "" {
+		q := url.Values{}
+		q.Set("check-node", checkNode)
+		path = path + "?" + q.Encode()
+	}
+	var mappings ClusterPCIMappings
+	if err := cl.client.Get(ctx, path, &mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// PCIMapping reads a single PCI mapping by id.
+func (cl *Cluster) PCIMapping(ctx context.Context, id string) (*ClusterPCIMapping, error) {
+	if id == "" {
+		return nil, errors.New("pci mapping id can not be empty")
+	}
+	m := &ClusterPCIMapping{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/pci/%s", id), m); err != nil {
+		return nil, err
+	}
+	if m.ID == "" {
+		m.ID = id
+	}
+	return m, nil
+}
+
+// NewPCIMapping creates a PCI hardware mapping.
+func (cl *Cluster) NewPCIMapping(ctx context.Context, opts *ClusterPCIMappingOptions) error {
+	if opts == nil || opts.ID == "" {
+		return errors.New("pci mapping id can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/mapping/pci", opts, nil)
+}
+
+// UpdatePCIMapping mutates an existing PCI mapping.
+func (cl *Cluster) UpdatePCIMapping(ctx context.Context, id string, opts *ClusterPCIMappingOptions) error {
+	if id == "" {
+		return errors.New("pci mapping id can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterPCIMappingOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/mapping/pci/%s", id), opts, nil)
+}
+
+// DeletePCIMapping removes a PCI mapping.
+func (cl *Cluster) DeletePCIMapping(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("pci mapping id can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/mapping/pci/%s", id), nil)
+}
+
+// --- USB mappings -----------------------------------------------------------
+
+// USBMappings lists USB hardware mappings. See DirMappings for checkNode.
+func (cl *Cluster) USBMappings(ctx context.Context, checkNode string) (ClusterUSBMappings, error) {
+	path := "/cluster/mapping/usb"
+	if checkNode != "" {
+		q := url.Values{}
+		q.Set("check-node", checkNode)
+		path = path + "?" + q.Encode()
+	}
+	var mappings ClusterUSBMappings
+	if err := cl.client.Get(ctx, path, &mappings); err != nil {
+		return nil, err
+	}
+	return mappings, nil
+}
+
+// USBMapping reads a single USB mapping by id.
+func (cl *Cluster) USBMapping(ctx context.Context, id string) (*ClusterUSBMapping, error) {
+	if id == "" {
+		return nil, errors.New("usb mapping id can not be empty")
+	}
+	m := &ClusterUSBMapping{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/mapping/usb/%s", id), m); err != nil {
+		return nil, err
+	}
+	if m.ID == "" {
+		m.ID = id
+	}
+	return m, nil
+}
+
+// NewUSBMapping creates a USB hardware mapping.
+func (cl *Cluster) NewUSBMapping(ctx context.Context, opts *ClusterUSBMappingOptions) error {
+	if opts == nil || opts.ID == "" {
+		return errors.New("usb mapping id can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/mapping/usb", opts, nil)
+}
+
+// UpdateUSBMapping mutates an existing USB mapping.
+func (cl *Cluster) UpdateUSBMapping(ctx context.Context, id string, opts *ClusterUSBMappingOptions) error {
+	if id == "" {
+		return errors.New("usb mapping id can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterUSBMappingOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/mapping/usb/%s", id), opts, nil)
+}
+
+// DeleteUSBMapping removes a USB mapping.
+func (cl *Cluster) DeleteUSBMapping(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("usb mapping id can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/mapping/usb/%s", id), nil)
+}

--- a/cluster_mapping_test.go
+++ b/cluster_mapping_test.go
@@ -1,0 +1,283 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_Mappings(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	entries, err := cluster.Mappings(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 3)
+}
+
+// --- dir --------------------------------------------------------------------
+
+func TestCluster_DirMappings(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	mappings, err := cluster.DirMappings(ctx, "")
+	assert.Nil(t, err)
+	assert.Len(t, mappings, 1)
+	assert.Equal(t, "shared-iso", mappings[0].ID)
+	assert.Len(t, mappings[0].Map, 2)
+}
+
+func TestCluster_DirMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	m, err := cluster.DirMapping(ctx, "shared-iso")
+	assert.Nil(t, err)
+	assert.NotNil(t, m)
+	assert.Equal(t, "shared-iso", m.ID)
+	assert.Equal(t, "d1", m.Digest)
+
+	_, err = cluster.DirMapping(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewDirMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewDirMapping(ctx, &ClusterDirMappingOptions{
+		ID:  "shared-iso",
+		Map: []string{"node=node1,path=/srv/iso"},
+	})
+	assert.Nil(t, err)
+
+	err = cluster.NewDirMapping(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateDirMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateDirMapping(ctx, "shared-iso", &ClusterDirMappingOptions{
+		Description: "updated",
+	})
+	assert.Nil(t, err)
+	err = cluster.UpdateDirMapping(ctx, "shared-iso", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateDirMapping(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteDirMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteDirMapping(ctx, "shared-iso")
+	assert.Nil(t, err)
+	err = cluster.DeleteDirMapping(ctx, "")
+	assert.Error(t, err)
+}
+
+// --- pci --------------------------------------------------------------------
+
+func TestCluster_PCIMappings(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	mappings, err := cluster.PCIMappings(ctx, "")
+	assert.Nil(t, err)
+	assert.Len(t, mappings, 1)
+	assert.Equal(t, "gpu0", mappings[0].ID)
+}
+
+func TestCluster_PCIMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	m, err := cluster.PCIMapping(ctx, "gpu0")
+	assert.Nil(t, err)
+	assert.NotNil(t, m)
+	assert.Equal(t, "gpu0", m.ID)
+	assert.Equal(t, "p1", m.Digest)
+	_, err = cluster.PCIMapping(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewPCIMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewPCIMapping(ctx, &ClusterPCIMappingOptions{
+		ID:  "gpu0",
+		Map: []string{"node=node1,path=0000:01:00.0,id=10de:1eb8"},
+	})
+	assert.Nil(t, err)
+	err = cluster.NewPCIMapping(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdatePCIMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdatePCIMapping(ctx, "gpu0", &ClusterPCIMappingOptions{MDev: true})
+	assert.Nil(t, err)
+	err = cluster.UpdatePCIMapping(ctx, "gpu0", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdatePCIMapping(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeletePCIMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeletePCIMapping(ctx, "gpu0")
+	assert.Nil(t, err)
+	err = cluster.DeletePCIMapping(ctx, "")
+	assert.Error(t, err)
+}
+
+// --- usb --------------------------------------------------------------------
+
+func TestCluster_USBMappings(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	mappings, err := cluster.USBMappings(ctx, "")
+	assert.Nil(t, err)
+	assert.Len(t, mappings, 1)
+	assert.Equal(t, "yubikey", mappings[0].ID)
+}
+
+func TestCluster_USBMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	m, err := cluster.USBMapping(ctx, "yubikey")
+	assert.Nil(t, err)
+	assert.NotNil(t, m)
+	assert.Equal(t, "yubikey", m.ID)
+	assert.Equal(t, "u1", m.Digest)
+	_, err = cluster.USBMapping(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewUSBMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewUSBMapping(ctx, &ClusterUSBMappingOptions{
+		ID:  "yubikey",
+		Map: []string{"node=node1,id=1050:0407"},
+	})
+	assert.Nil(t, err)
+	err = cluster.NewUSBMapping(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateUSBMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateUSBMapping(ctx, "yubikey", &ClusterUSBMappingOptions{Description: "x"})
+	assert.Nil(t, err)
+	err = cluster.UpdateUSBMapping(ctx, "yubikey", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateUSBMapping(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteUSBMapping(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteUSBMapping(ctx, "yubikey")
+	assert.Nil(t, err)
+	err = cluster.DeleteUSBMapping(ctx, "")
+	assert.Error(t, err)
+}

--- a/cluster_metrics.go
+++ b/cluster_metrics.go
@@ -8,27 +8,25 @@ import (
 
 // MetricServers lists configured external metric servers (graphite / influxdb /
 // opentelemetry). See https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/metrics/server
-func (cl *Cluster) MetricServers(ctx context.Context) (ClusterMetricServers, error) {
-	var servers ClusterMetricServers
-	if err := cl.client.Get(ctx, "/cluster/metrics/server", &servers); err != nil {
-		return nil, err
-	}
-	return servers, nil
+func (cl *Cluster) MetricServers(ctx context.Context) (servers ClusterMetricServers, err error) {
+	err = cl.client.Get(ctx, "/cluster/metrics/server", &servers)
+	return
 }
 
 // MetricServer reads the full configuration of a single metric server.
-func (cl *Cluster) MetricServer(ctx context.Context, id string) (*ClusterMetricServer, error) {
+func (cl *Cluster) MetricServer(ctx context.Context, id string) (server *ClusterMetricServer, err error) {
 	if id == "" {
-		return nil, errors.New("metric server id can not be empty")
+		err = errors.New("metric server id can not be empty")
+		return
 	}
-	server := &ClusterMetricServer{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/metrics/server/%s", id), server); err != nil {
-		return nil, err
+	server = &ClusterMetricServer{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/metrics/server/%s", id), server); err != nil {
+		return
 	}
 	if server.ID == "" {
 		server.ID = id
 	}
-	return server, nil
+	return
 }
 
 // NewMetricServer creates a new external metric server entry. Requires opts.ID

--- a/cluster_metrics.go
+++ b/cluster_metrics.go
@@ -1,0 +1,62 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// MetricServers lists configured external metric servers (graphite / influxdb /
+// opentelemetry). See https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/metrics/server
+func (cl *Cluster) MetricServers(ctx context.Context) (ClusterMetricServers, error) {
+	var servers ClusterMetricServers
+	if err := cl.client.Get(ctx, "/cluster/metrics/server", &servers); err != nil {
+		return nil, err
+	}
+	return servers, nil
+}
+
+// MetricServer reads the full configuration of a single metric server.
+func (cl *Cluster) MetricServer(ctx context.Context, id string) (*ClusterMetricServer, error) {
+	if id == "" {
+		return nil, errors.New("metric server id can not be empty")
+	}
+	server := &ClusterMetricServer{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/metrics/server/%s", id), server); err != nil {
+		return nil, err
+	}
+	if server.ID == "" {
+		server.ID = id
+	}
+	return server, nil
+}
+
+// NewMetricServer creates a new external metric server entry. Requires opts.ID
+// and opts.Type ("graphite" | "influxdb" | "opentelemetry").
+func (cl *Cluster) NewMetricServer(ctx context.Context, opts *ClusterMetricServerOptions) error {
+	if opts == nil || opts.ID == "" {
+		return errors.New("metric server id can not be empty")
+	}
+	// PVE puts the id in the URL, not the body, on create.
+	return cl.client.Post(ctx, fmt.Sprintf("/cluster/metrics/server/%s", opts.ID), opts, nil)
+}
+
+// UpdateMetricServer mutates an existing metric server entry. The opts.Delete
+// field is a comma-separated list of keys to reset (PVE quirk).
+func (cl *Cluster) UpdateMetricServer(ctx context.Context, id string, opts *ClusterMetricServerOptions) error {
+	if id == "" {
+		return errors.New("metric server id can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterMetricServerOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/metrics/server/%s", id), opts, nil)
+}
+
+// DeleteMetricServer removes a configured metric server.
+func (cl *Cluster) DeleteMetricServer(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("metric server id can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/metrics/server/%s", id), nil)
+}

--- a/cluster_metrics_test.go
+++ b/cluster_metrics_test.go
@@ -1,0 +1,125 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_MetricServers(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	servers, err := cluster.MetricServers(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, servers, 2)
+	assert.Equal(t, "influx1", servers[0].ID)
+	assert.Equal(t, "influxdb", servers[0].Type)
+	assert.Equal(t, 8086, servers[0].Port)
+}
+
+func TestCluster_MetricServer(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	server, err := cluster.MetricServer(ctx, "influx1")
+	assert.Nil(t, err)
+	assert.NotNil(t, server)
+	assert.Equal(t, "influx1", server.ID)
+	assert.Equal(t, "influxdb", server.Type)
+	assert.Equal(t, "metrics.example.com", server.Server)
+	assert.Equal(t, "http", server.InfluxDBProto)
+	assert.Equal(t, "abc123", server.Digest)
+}
+
+func TestCluster_MetricServer_EmptyID(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	server, err := cluster.MetricServer(ctx, "")
+	assert.Nil(t, server)
+	assert.Error(t, err)
+}
+
+func TestCluster_NewMetricServer(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewMetricServer(ctx, &ClusterMetricServerOptions{
+		ID:     "influx1",
+		Type:   "influxdb",
+		Server: "metrics.example.com",
+		Port:   8086,
+	})
+	assert.Nil(t, err)
+}
+
+func TestCluster_NewMetricServer_EmptyID(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewMetricServer(ctx, &ClusterMetricServerOptions{Type: "influxdb"})
+	assert.Error(t, err)
+	err = cluster.NewMetricServer(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateMetricServer(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateMetricServer(ctx, "influx1", &ClusterMetricServerOptions{Port: 9000})
+	assert.Nil(t, err)
+	// Nil opts gets defaulted internally — also acceptable.
+	err = cluster.UpdateMetricServer(ctx, "influx1", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateMetricServer(ctx, "", &ClusterMetricServerOptions{})
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteMetricServer(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteMetricServer(ctx, "influx1")
+	assert.Nil(t, err)
+	err = cluster.DeleteMetricServer(ctx, "")
+	assert.Error(t, err)
+}

--- a/cluster_notifications.go
+++ b/cluster_notifications.go
@@ -1,0 +1,323 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Notifications lists the resource-type directory under /cluster/notifications.
+func (cl *Cluster) Notifications(ctx context.Context) (ClusterNotificationIndex, error) {
+	var entries ClusterNotificationIndex
+	if err := cl.client.Get(ctx, "/cluster/notifications", &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// NotificationMatcherFields returns the known metadata field names usable in
+// matcher "match-field" rules.
+func (cl *Cluster) NotificationMatcherFields(ctx context.Context) ([]*ClusterNotificationMatcherField, error) {
+	var fields []*ClusterNotificationMatcherField
+	if err := cl.client.Get(ctx, "/cluster/notifications/matcher-fields", &fields); err != nil {
+		return nil, err
+	}
+	return fields, nil
+}
+
+// NotificationMatcherFieldValues returns the known (field, value) pairs for
+// matcher exact-match rules.
+func (cl *Cluster) NotificationMatcherFieldValues(ctx context.Context) ([]*ClusterNotificationMatcherFieldValue, error) {
+	var values []*ClusterNotificationMatcherFieldValue
+	if err := cl.client.Get(ctx, "/cluster/notifications/matcher-field-values", &values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+// --- targets ----------------------------------------------------------------
+
+// NotificationTargets lists all notification targets (flattened view across
+// every endpoint plugin type).
+func (cl *Cluster) NotificationTargets(ctx context.Context) ([]*ClusterNotificationTarget, error) {
+	var targets []*ClusterNotificationTarget
+	if err := cl.client.Get(ctx, "/cluster/notifications/targets", &targets); err != nil {
+		return nil, err
+	}
+	return targets, nil
+}
+
+// TestNotificationTarget triggers PVE to send a test notification through the
+// named target. Returns immediately; PVE does not surface a UPID for this op.
+func (cl *Cluster) TestNotificationTarget(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("notification target name can not be empty")
+	}
+	return cl.client.Post(ctx, fmt.Sprintf("/cluster/notifications/targets/%s/test", name), nil, nil)
+}
+
+// --- matchers ---------------------------------------------------------------
+
+// NotificationMatchers lists configured matchers.
+func (cl *Cluster) NotificationMatchers(ctx context.Context) ([]*ClusterNotificationMatcher, error) {
+	var matchers []*ClusterNotificationMatcher
+	if err := cl.client.Get(ctx, "/cluster/notifications/matchers", &matchers); err != nil {
+		return nil, err
+	}
+	return matchers, nil
+}
+
+// NotificationMatcher reads a single matcher by name.
+func (cl *Cluster) NotificationMatcher(ctx context.Context, name string) (*ClusterNotificationMatcher, error) {
+	if name == "" {
+		return nil, errors.New("notification matcher name can not be empty")
+	}
+	m := &ClusterNotificationMatcher{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/matchers/%s", name), m); err != nil {
+		return nil, err
+	}
+	if m.Name == "" {
+		m.Name = name
+	}
+	return m, nil
+}
+
+// NewNotificationMatcher creates a matcher. opts.Name is required.
+func (cl *Cluster) NewNotificationMatcher(ctx context.Context, opts *ClusterNotificationMatcherOptions) error {
+	if opts == nil || opts.Name == "" {
+		return errors.New("notification matcher name can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/notifications/matchers", opts, nil)
+}
+
+// UpdateNotificationMatcher mutates an existing matcher.
+func (cl *Cluster) UpdateNotificationMatcher(ctx context.Context, name string, opts *ClusterNotificationMatcherOptions) error {
+	if name == "" {
+		return errors.New("notification matcher name can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterNotificationMatcherOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/notifications/matchers/%s", name), opts, nil)
+}
+
+// DeleteNotificationMatcher removes a matcher.
+func (cl *Cluster) DeleteNotificationMatcher(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("notification matcher name can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/notifications/matchers/%s", name), nil)
+}
+
+// --- gotify endpoints -------------------------------------------------------
+
+// NotificationGotifyEndpoints lists configured Gotify endpoints.
+func (cl *Cluster) NotificationGotifyEndpoints(ctx context.Context) ([]*ClusterNotificationGotifyEndpoint, error) {
+	var endpoints []*ClusterNotificationGotifyEndpoint
+	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/gotify", &endpoints); err != nil {
+		return nil, err
+	}
+	return endpoints, nil
+}
+
+// NotificationGotifyEndpoint reads a single Gotify endpoint.
+func (cl *Cluster) NotificationGotifyEndpoint(ctx context.Context, name string) (*ClusterNotificationGotifyEndpoint, error) {
+	if name == "" {
+		return nil, errors.New("gotify endpoint name can not be empty")
+	}
+	e := &ClusterNotificationGotifyEndpoint{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/gotify/%s", name), e); err != nil {
+		return nil, err
+	}
+	if e.Name == "" {
+		e.Name = name
+	}
+	return e, nil
+}
+
+// NewNotificationGotifyEndpoint creates a Gotify endpoint. opts.Name, .Server,
+// and .Token are required by PVE on create.
+func (cl *Cluster) NewNotificationGotifyEndpoint(ctx context.Context, opts *ClusterNotificationGotifyOptions) error {
+	if opts == nil || opts.Name == "" {
+		return errors.New("gotify endpoint name can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/notifications/endpoints/gotify", opts, nil)
+}
+
+// UpdateNotificationGotifyEndpoint mutates an existing Gotify endpoint.
+func (cl *Cluster) UpdateNotificationGotifyEndpoint(ctx context.Context, name string, opts *ClusterNotificationGotifyOptions) error {
+	if name == "" {
+		return errors.New("gotify endpoint name can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterNotificationGotifyOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/notifications/endpoints/gotify/%s", name), opts, nil)
+}
+
+// DeleteNotificationGotifyEndpoint removes a Gotify endpoint.
+func (cl *Cluster) DeleteNotificationGotifyEndpoint(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("gotify endpoint name can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/notifications/endpoints/gotify/%s", name), nil)
+}
+
+// --- sendmail endpoints -----------------------------------------------------
+
+// NotificationSendmailEndpoints lists configured sendmail endpoints.
+func (cl *Cluster) NotificationSendmailEndpoints(ctx context.Context) ([]*ClusterNotificationSendmailEndpoint, error) {
+	var endpoints []*ClusterNotificationSendmailEndpoint
+	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/sendmail", &endpoints); err != nil {
+		return nil, err
+	}
+	return endpoints, nil
+}
+
+// NotificationSendmailEndpoint reads a single sendmail endpoint.
+func (cl *Cluster) NotificationSendmailEndpoint(ctx context.Context, name string) (*ClusterNotificationSendmailEndpoint, error) {
+	if name == "" {
+		return nil, errors.New("sendmail endpoint name can not be empty")
+	}
+	e := &ClusterNotificationSendmailEndpoint{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/sendmail/%s", name), e); err != nil {
+		return nil, err
+	}
+	if e.Name == "" {
+		e.Name = name
+	}
+	return e, nil
+}
+
+// NewNotificationSendmailEndpoint creates a sendmail endpoint.
+func (cl *Cluster) NewNotificationSendmailEndpoint(ctx context.Context, opts *ClusterNotificationSendmailOptions) error {
+	if opts == nil || opts.Name == "" {
+		return errors.New("sendmail endpoint name can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/notifications/endpoints/sendmail", opts, nil)
+}
+
+// UpdateNotificationSendmailEndpoint mutates an existing sendmail endpoint.
+func (cl *Cluster) UpdateNotificationSendmailEndpoint(ctx context.Context, name string, opts *ClusterNotificationSendmailOptions) error {
+	if name == "" {
+		return errors.New("sendmail endpoint name can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterNotificationSendmailOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/notifications/endpoints/sendmail/%s", name), opts, nil)
+}
+
+// DeleteNotificationSendmailEndpoint removes a sendmail endpoint.
+func (cl *Cluster) DeleteNotificationSendmailEndpoint(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("sendmail endpoint name can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/notifications/endpoints/sendmail/%s", name), nil)
+}
+
+// --- smtp endpoints ---------------------------------------------------------
+
+// NotificationSMTPEndpoints lists configured SMTP endpoints.
+func (cl *Cluster) NotificationSMTPEndpoints(ctx context.Context) ([]*ClusterNotificationSMTPEndpoint, error) {
+	var endpoints []*ClusterNotificationSMTPEndpoint
+	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/smtp", &endpoints); err != nil {
+		return nil, err
+	}
+	return endpoints, nil
+}
+
+// NotificationSMTPEndpoint reads a single SMTP endpoint.
+func (cl *Cluster) NotificationSMTPEndpoint(ctx context.Context, name string) (*ClusterNotificationSMTPEndpoint, error) {
+	if name == "" {
+		return nil, errors.New("smtp endpoint name can not be empty")
+	}
+	e := &ClusterNotificationSMTPEndpoint{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/smtp/%s", name), e); err != nil {
+		return nil, err
+	}
+	if e.Name == "" {
+		e.Name = name
+	}
+	return e, nil
+}
+
+// NewNotificationSMTPEndpoint creates an SMTP endpoint.
+func (cl *Cluster) NewNotificationSMTPEndpoint(ctx context.Context, opts *ClusterNotificationSMTPOptions) error {
+	if opts == nil || opts.Name == "" {
+		return errors.New("smtp endpoint name can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/notifications/endpoints/smtp", opts, nil)
+}
+
+// UpdateNotificationSMTPEndpoint mutates an existing SMTP endpoint.
+func (cl *Cluster) UpdateNotificationSMTPEndpoint(ctx context.Context, name string, opts *ClusterNotificationSMTPOptions) error {
+	if name == "" {
+		return errors.New("smtp endpoint name can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterNotificationSMTPOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/notifications/endpoints/smtp/%s", name), opts, nil)
+}
+
+// DeleteNotificationSMTPEndpoint removes an SMTP endpoint.
+func (cl *Cluster) DeleteNotificationSMTPEndpoint(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("smtp endpoint name can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/notifications/endpoints/smtp/%s", name), nil)
+}
+
+// --- webhook endpoints ------------------------------------------------------
+
+// NotificationWebhookEndpoints lists configured webhook endpoints.
+func (cl *Cluster) NotificationWebhookEndpoints(ctx context.Context) ([]*ClusterNotificationWebhookEndpoint, error) {
+	var endpoints []*ClusterNotificationWebhookEndpoint
+	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/webhook", &endpoints); err != nil {
+		return nil, err
+	}
+	return endpoints, nil
+}
+
+// NotificationWebhookEndpoint reads a single webhook endpoint.
+func (cl *Cluster) NotificationWebhookEndpoint(ctx context.Context, name string) (*ClusterNotificationWebhookEndpoint, error) {
+	if name == "" {
+		return nil, errors.New("webhook endpoint name can not be empty")
+	}
+	e := &ClusterNotificationWebhookEndpoint{}
+	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/webhook/%s", name), e); err != nil {
+		return nil, err
+	}
+	if e.Name == "" {
+		e.Name = name
+	}
+	return e, nil
+}
+
+// NewNotificationWebhookEndpoint creates a webhook endpoint.
+func (cl *Cluster) NewNotificationWebhookEndpoint(ctx context.Context, opts *ClusterNotificationWebhookOptions) error {
+	if opts == nil || opts.Name == "" {
+		return errors.New("webhook endpoint name can not be empty")
+	}
+	return cl.client.Post(ctx, "/cluster/notifications/endpoints/webhook", opts, nil)
+}
+
+// UpdateNotificationWebhookEndpoint mutates an existing webhook endpoint.
+func (cl *Cluster) UpdateNotificationWebhookEndpoint(ctx context.Context, name string, opts *ClusterNotificationWebhookOptions) error {
+	if name == "" {
+		return errors.New("webhook endpoint name can not be empty")
+	}
+	if opts == nil {
+		opts = &ClusterNotificationWebhookOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/notifications/endpoints/webhook/%s", name), opts, nil)
+}
+
+// DeleteNotificationWebhookEndpoint removes a webhook endpoint.
+func (cl *Cluster) DeleteNotificationWebhookEndpoint(ctx context.Context, name string) error {
+	if name == "" {
+		return errors.New("webhook endpoint name can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/notifications/endpoints/webhook/%s", name), nil)
+}

--- a/cluster_notifications.go
+++ b/cluster_notifications.go
@@ -7,44 +7,32 @@ import (
 )
 
 // Notifications lists the resource-type directory under /cluster/notifications.
-func (cl *Cluster) Notifications(ctx context.Context) (ClusterNotificationIndex, error) {
-	var entries ClusterNotificationIndex
-	if err := cl.client.Get(ctx, "/cluster/notifications", &entries); err != nil {
-		return nil, err
-	}
-	return entries, nil
+func (cl *Cluster) Notifications(ctx context.Context) (entries ClusterNotificationIndex, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications", &entries)
+	return
 }
 
 // NotificationMatcherFields returns the known metadata field names usable in
 // matcher "match-field" rules.
-func (cl *Cluster) NotificationMatcherFields(ctx context.Context) ([]*ClusterNotificationMatcherField, error) {
-	var fields []*ClusterNotificationMatcherField
-	if err := cl.client.Get(ctx, "/cluster/notifications/matcher-fields", &fields); err != nil {
-		return nil, err
-	}
-	return fields, nil
+func (cl *Cluster) NotificationMatcherFields(ctx context.Context) (fields []*ClusterNotificationMatcherField, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/matcher-fields", &fields)
+	return
 }
 
 // NotificationMatcherFieldValues returns the known (field, value) pairs for
 // matcher exact-match rules.
-func (cl *Cluster) NotificationMatcherFieldValues(ctx context.Context) ([]*ClusterNotificationMatcherFieldValue, error) {
-	var values []*ClusterNotificationMatcherFieldValue
-	if err := cl.client.Get(ctx, "/cluster/notifications/matcher-field-values", &values); err != nil {
-		return nil, err
-	}
-	return values, nil
+func (cl *Cluster) NotificationMatcherFieldValues(ctx context.Context) (values []*ClusterNotificationMatcherFieldValue, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/matcher-field-values", &values)
+	return
 }
 
 // --- targets ----------------------------------------------------------------
 
 // NotificationTargets lists all notification targets (flattened view across
 // every endpoint plugin type).
-func (cl *Cluster) NotificationTargets(ctx context.Context) ([]*ClusterNotificationTarget, error) {
-	var targets []*ClusterNotificationTarget
-	if err := cl.client.Get(ctx, "/cluster/notifications/targets", &targets); err != nil {
-		return nil, err
-	}
-	return targets, nil
+func (cl *Cluster) NotificationTargets(ctx context.Context) (targets []*ClusterNotificationTarget, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/targets", &targets)
+	return
 }
 
 // TestNotificationTarget triggers PVE to send a test notification through the
@@ -59,27 +47,25 @@ func (cl *Cluster) TestNotificationTarget(ctx context.Context, name string) erro
 // --- matchers ---------------------------------------------------------------
 
 // NotificationMatchers lists configured matchers.
-func (cl *Cluster) NotificationMatchers(ctx context.Context) ([]*ClusterNotificationMatcher, error) {
-	var matchers []*ClusterNotificationMatcher
-	if err := cl.client.Get(ctx, "/cluster/notifications/matchers", &matchers); err != nil {
-		return nil, err
-	}
-	return matchers, nil
+func (cl *Cluster) NotificationMatchers(ctx context.Context) (matchers []*ClusterNotificationMatcher, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/matchers", &matchers)
+	return
 }
 
 // NotificationMatcher reads a single matcher by name.
-func (cl *Cluster) NotificationMatcher(ctx context.Context, name string) (*ClusterNotificationMatcher, error) {
+func (cl *Cluster) NotificationMatcher(ctx context.Context, name string) (m *ClusterNotificationMatcher, err error) {
 	if name == "" {
-		return nil, errors.New("notification matcher name can not be empty")
+		err = errors.New("notification matcher name can not be empty")
+		return
 	}
-	m := &ClusterNotificationMatcher{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/matchers/%s", name), m); err != nil {
-		return nil, err
+	m = &ClusterNotificationMatcher{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/matchers/%s", name), m); err != nil {
+		return
 	}
 	if m.Name == "" {
 		m.Name = name
 	}
-	return m, nil
+	return
 }
 
 // NewNotificationMatcher creates a matcher. opts.Name is required.
@@ -112,27 +98,25 @@ func (cl *Cluster) DeleteNotificationMatcher(ctx context.Context, name string) e
 // --- gotify endpoints -------------------------------------------------------
 
 // NotificationGotifyEndpoints lists configured Gotify endpoints.
-func (cl *Cluster) NotificationGotifyEndpoints(ctx context.Context) ([]*ClusterNotificationGotifyEndpoint, error) {
-	var endpoints []*ClusterNotificationGotifyEndpoint
-	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/gotify", &endpoints); err != nil {
-		return nil, err
-	}
-	return endpoints, nil
+func (cl *Cluster) NotificationGotifyEndpoints(ctx context.Context) (endpoints []*ClusterNotificationGotifyEndpoint, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/endpoints/gotify", &endpoints)
+	return
 }
 
 // NotificationGotifyEndpoint reads a single Gotify endpoint.
-func (cl *Cluster) NotificationGotifyEndpoint(ctx context.Context, name string) (*ClusterNotificationGotifyEndpoint, error) {
+func (cl *Cluster) NotificationGotifyEndpoint(ctx context.Context, name string) (e *ClusterNotificationGotifyEndpoint, err error) {
 	if name == "" {
-		return nil, errors.New("gotify endpoint name can not be empty")
+		err = errors.New("gotify endpoint name can not be empty")
+		return
 	}
-	e := &ClusterNotificationGotifyEndpoint{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/gotify/%s", name), e); err != nil {
-		return nil, err
+	e = &ClusterNotificationGotifyEndpoint{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/gotify/%s", name), e); err != nil {
+		return
 	}
 	if e.Name == "" {
 		e.Name = name
 	}
-	return e, nil
+	return
 }
 
 // NewNotificationGotifyEndpoint creates a Gotify endpoint. opts.Name, .Server,
@@ -166,27 +150,25 @@ func (cl *Cluster) DeleteNotificationGotifyEndpoint(ctx context.Context, name st
 // --- sendmail endpoints -----------------------------------------------------
 
 // NotificationSendmailEndpoints lists configured sendmail endpoints.
-func (cl *Cluster) NotificationSendmailEndpoints(ctx context.Context) ([]*ClusterNotificationSendmailEndpoint, error) {
-	var endpoints []*ClusterNotificationSendmailEndpoint
-	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/sendmail", &endpoints); err != nil {
-		return nil, err
-	}
-	return endpoints, nil
+func (cl *Cluster) NotificationSendmailEndpoints(ctx context.Context) (endpoints []*ClusterNotificationSendmailEndpoint, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/endpoints/sendmail", &endpoints)
+	return
 }
 
 // NotificationSendmailEndpoint reads a single sendmail endpoint.
-func (cl *Cluster) NotificationSendmailEndpoint(ctx context.Context, name string) (*ClusterNotificationSendmailEndpoint, error) {
+func (cl *Cluster) NotificationSendmailEndpoint(ctx context.Context, name string) (e *ClusterNotificationSendmailEndpoint, err error) {
 	if name == "" {
-		return nil, errors.New("sendmail endpoint name can not be empty")
+		err = errors.New("sendmail endpoint name can not be empty")
+		return
 	}
-	e := &ClusterNotificationSendmailEndpoint{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/sendmail/%s", name), e); err != nil {
-		return nil, err
+	e = &ClusterNotificationSendmailEndpoint{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/sendmail/%s", name), e); err != nil {
+		return
 	}
 	if e.Name == "" {
 		e.Name = name
 	}
-	return e, nil
+	return
 }
 
 // NewNotificationSendmailEndpoint creates a sendmail endpoint.
@@ -219,27 +201,25 @@ func (cl *Cluster) DeleteNotificationSendmailEndpoint(ctx context.Context, name 
 // --- smtp endpoints ---------------------------------------------------------
 
 // NotificationSMTPEndpoints lists configured SMTP endpoints.
-func (cl *Cluster) NotificationSMTPEndpoints(ctx context.Context) ([]*ClusterNotificationSMTPEndpoint, error) {
-	var endpoints []*ClusterNotificationSMTPEndpoint
-	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/smtp", &endpoints); err != nil {
-		return nil, err
-	}
-	return endpoints, nil
+func (cl *Cluster) NotificationSMTPEndpoints(ctx context.Context) (endpoints []*ClusterNotificationSMTPEndpoint, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/endpoints/smtp", &endpoints)
+	return
 }
 
 // NotificationSMTPEndpoint reads a single SMTP endpoint.
-func (cl *Cluster) NotificationSMTPEndpoint(ctx context.Context, name string) (*ClusterNotificationSMTPEndpoint, error) {
+func (cl *Cluster) NotificationSMTPEndpoint(ctx context.Context, name string) (e *ClusterNotificationSMTPEndpoint, err error) {
 	if name == "" {
-		return nil, errors.New("smtp endpoint name can not be empty")
+		err = errors.New("smtp endpoint name can not be empty")
+		return
 	}
-	e := &ClusterNotificationSMTPEndpoint{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/smtp/%s", name), e); err != nil {
-		return nil, err
+	e = &ClusterNotificationSMTPEndpoint{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/smtp/%s", name), e); err != nil {
+		return
 	}
 	if e.Name == "" {
 		e.Name = name
 	}
-	return e, nil
+	return
 }
 
 // NewNotificationSMTPEndpoint creates an SMTP endpoint.
@@ -272,27 +252,25 @@ func (cl *Cluster) DeleteNotificationSMTPEndpoint(ctx context.Context, name stri
 // --- webhook endpoints ------------------------------------------------------
 
 // NotificationWebhookEndpoints lists configured webhook endpoints.
-func (cl *Cluster) NotificationWebhookEndpoints(ctx context.Context) ([]*ClusterNotificationWebhookEndpoint, error) {
-	var endpoints []*ClusterNotificationWebhookEndpoint
-	if err := cl.client.Get(ctx, "/cluster/notifications/endpoints/webhook", &endpoints); err != nil {
-		return nil, err
-	}
-	return endpoints, nil
+func (cl *Cluster) NotificationWebhookEndpoints(ctx context.Context) (endpoints []*ClusterNotificationWebhookEndpoint, err error) {
+	err = cl.client.Get(ctx, "/cluster/notifications/endpoints/webhook", &endpoints)
+	return
 }
 
 // NotificationWebhookEndpoint reads a single webhook endpoint.
-func (cl *Cluster) NotificationWebhookEndpoint(ctx context.Context, name string) (*ClusterNotificationWebhookEndpoint, error) {
+func (cl *Cluster) NotificationWebhookEndpoint(ctx context.Context, name string) (e *ClusterNotificationWebhookEndpoint, err error) {
 	if name == "" {
-		return nil, errors.New("webhook endpoint name can not be empty")
+		err = errors.New("webhook endpoint name can not be empty")
+		return
 	}
-	e := &ClusterNotificationWebhookEndpoint{}
-	if err := cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/webhook/%s", name), e); err != nil {
-		return nil, err
+	e = &ClusterNotificationWebhookEndpoint{}
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/notifications/endpoints/webhook/%s", name), e); err != nil {
+		return
 	}
 	if e.Name == "" {
 		e.Name = name
 	}
-	return e, nil
+	return
 }
 
 // NewNotificationWebhookEndpoint creates a webhook endpoint.

--- a/cluster_notifications_test.go
+++ b/cluster_notifications_test.go
@@ -1,0 +1,523 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_Notifications(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	entries, err := cluster.Notifications(ctx)
+	assert.Nil(t, err)
+	assert.GreaterOrEqual(t, len(entries), 3)
+}
+
+func TestCluster_NotificationMatcherFields(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	fields, err := cluster.NotificationMatcherFields(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, fields, 2)
+	assert.Equal(t, "type", fields[0].Name)
+}
+
+func TestCluster_NotificationMatcherFieldValues(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	values, err := cluster.NotificationMatcherFieldValues(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, values, 2)
+	assert.Equal(t, "type", values[0].Field)
+	assert.Equal(t, "vzdump", values[0].Value)
+}
+
+// --- targets ---------------------------------------------------------------
+
+func TestCluster_NotificationTargets(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	targets, err := cluster.NotificationTargets(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, targets, 2)
+	assert.Equal(t, "mail-to-root", targets[0].Name)
+	assert.Equal(t, "sendmail", targets[0].Type)
+}
+
+func TestCluster_TestNotificationTarget(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.TestNotificationTarget(ctx, "mail-to-root")
+	assert.Nil(t, err)
+	err = cluster.TestNotificationTarget(ctx, "")
+	assert.Error(t, err)
+}
+
+// --- matchers --------------------------------------------------------------
+
+func TestCluster_NotificationMatchers(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	matchers, err := cluster.NotificationMatchers(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, matchers, 1)
+	assert.Equal(t, "default-matcher", matchers[0].Name)
+}
+
+func TestCluster_NotificationMatcher(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	m, err := cluster.NotificationMatcher(ctx, "default-matcher")
+	assert.Nil(t, err)
+	assert.NotNil(t, m)
+	assert.Equal(t, "default-matcher", m.Name)
+	assert.Contains(t, m.MatchSeverity, "warning")
+	assert.Equal(t, "m1", m.Digest)
+	_, err = cluster.NotificationMatcher(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewNotificationMatcher(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewNotificationMatcher(ctx, &ClusterNotificationMatcherOptions{
+		Name:          "default-matcher",
+		Mode:          "all",
+		MatchSeverity: []string{"warning", "error"},
+		Target:        []string{"mail-to-root"},
+	})
+	assert.Nil(t, err)
+	err = cluster.NewNotificationMatcher(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateNotificationMatcher(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateNotificationMatcher(ctx, "default-matcher", &ClusterNotificationMatcherOptions{
+		Comment: "updated",
+	})
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationMatcher(ctx, "default-matcher", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationMatcher(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteNotificationMatcher(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteNotificationMatcher(ctx, "default-matcher")
+	assert.Nil(t, err)
+	err = cluster.DeleteNotificationMatcher(ctx, "")
+	assert.Error(t, err)
+}
+
+// --- gotify ----------------------------------------------------------------
+
+func TestCluster_NotificationGotifyEndpoints(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	endpoints, err := cluster.NotificationGotifyEndpoints(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, endpoints, 1)
+	assert.Equal(t, "gotify1", endpoints[0].Name)
+}
+
+func TestCluster_NotificationGotifyEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	e, err := cluster.NotificationGotifyEndpoint(ctx, "gotify1")
+	assert.Nil(t, err)
+	assert.NotNil(t, e)
+	assert.Equal(t, "gotify1", e.Name)
+	assert.Equal(t, "g1", e.Digest)
+	_, err = cluster.NotificationGotifyEndpoint(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewNotificationGotifyEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewNotificationGotifyEndpoint(ctx, &ClusterNotificationGotifyOptions{
+		Name:   "gotify1",
+		Server: "https://gotify.example.com",
+		Token:  "tok",
+	})
+	assert.Nil(t, err)
+	err = cluster.NewNotificationGotifyEndpoint(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateNotificationGotifyEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateNotificationGotifyEndpoint(ctx, "gotify1", &ClusterNotificationGotifyOptions{Comment: "x"})
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationGotifyEndpoint(ctx, "gotify1", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationGotifyEndpoint(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteNotificationGotifyEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteNotificationGotifyEndpoint(ctx, "gotify1")
+	assert.Nil(t, err)
+	err = cluster.DeleteNotificationGotifyEndpoint(ctx, "")
+	assert.Error(t, err)
+}
+
+// --- sendmail --------------------------------------------------------------
+
+func TestCluster_NotificationSendmailEndpoints(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	endpoints, err := cluster.NotificationSendmailEndpoints(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, endpoints, 1)
+	assert.Equal(t, "mail-to-root", endpoints[0].Name)
+}
+
+func TestCluster_NotificationSendmailEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	e, err := cluster.NotificationSendmailEndpoint(ctx, "mail-to-root")
+	assert.Nil(t, err)
+	assert.Equal(t, "mail-to-root", e.Name)
+	assert.Equal(t, "s1", e.Digest)
+	_, err = cluster.NotificationSendmailEndpoint(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewNotificationSendmailEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewNotificationSendmailEndpoint(ctx, &ClusterNotificationSendmailOptions{
+		Name:       "mail-to-root",
+		MailToUser: []string{"root@pam"},
+	})
+	assert.Nil(t, err)
+	err = cluster.NewNotificationSendmailEndpoint(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateNotificationSendmailEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateNotificationSendmailEndpoint(ctx, "mail-to-root", &ClusterNotificationSendmailOptions{Comment: "x"})
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationSendmailEndpoint(ctx, "mail-to-root", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationSendmailEndpoint(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteNotificationSendmailEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteNotificationSendmailEndpoint(ctx, "mail-to-root")
+	assert.Nil(t, err)
+	err = cluster.DeleteNotificationSendmailEndpoint(ctx, "")
+	assert.Error(t, err)
+}
+
+// --- smtp ------------------------------------------------------------------
+
+func TestCluster_NotificationSMTPEndpoints(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	endpoints, err := cluster.NotificationSMTPEndpoints(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, endpoints, 1)
+	assert.Equal(t, "smtp1", endpoints[0].Name)
+	assert.Equal(t, "starttls", endpoints[0].Mode)
+}
+
+func TestCluster_NotificationSMTPEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	e, err := cluster.NotificationSMTPEndpoint(ctx, "smtp1")
+	assert.Nil(t, err)
+	assert.Equal(t, "smtp1", e.Name)
+	assert.Equal(t, 587, e.Port)
+	assert.Equal(t, "st1", e.Digest)
+	_, err = cluster.NotificationSMTPEndpoint(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewNotificationSMTPEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewNotificationSMTPEndpoint(ctx, &ClusterNotificationSMTPOptions{
+		Name:        "smtp1",
+		Server:      "smtp.example.com",
+		Port:        587,
+		Mode:        "starttls",
+		FromAddress: "alerts@example.com",
+	})
+	assert.Nil(t, err)
+	err = cluster.NewNotificationSMTPEndpoint(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateNotificationSMTPEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateNotificationSMTPEndpoint(ctx, "smtp1", &ClusterNotificationSMTPOptions{Password: "secret"})
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationSMTPEndpoint(ctx, "smtp1", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationSMTPEndpoint(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteNotificationSMTPEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteNotificationSMTPEndpoint(ctx, "smtp1")
+	assert.Nil(t, err)
+	err = cluster.DeleteNotificationSMTPEndpoint(ctx, "")
+	assert.Error(t, err)
+}
+
+// --- webhook ---------------------------------------------------------------
+
+func TestCluster_NotificationWebhookEndpoints(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	endpoints, err := cluster.NotificationWebhookEndpoints(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, endpoints, 1)
+	assert.Equal(t, "wh1", endpoints[0].Name)
+	assert.Equal(t, "post", endpoints[0].Method)
+}
+
+func TestCluster_NotificationWebhookEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	e, err := cluster.NotificationWebhookEndpoint(ctx, "wh1")
+	assert.Nil(t, err)
+	assert.Equal(t, "wh1", e.Name)
+	assert.Equal(t, "https://hook.example.com/alert", e.URL)
+	assert.Equal(t, "w1", e.Digest)
+	_, err = cluster.NotificationWebhookEndpoint(ctx, "")
+	assert.Error(t, err)
+}
+
+func TestCluster_NewNotificationWebhookEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewNotificationWebhookEndpoint(ctx, &ClusterNotificationWebhookOptions{
+		Name:   "wh1",
+		URL:    "https://hook.example.com/alert",
+		Method: "post",
+	})
+	assert.Nil(t, err)
+	err = cluster.NewNotificationWebhookEndpoint(ctx, nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_UpdateNotificationWebhookEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateNotificationWebhookEndpoint(ctx, "wh1", &ClusterNotificationWebhookOptions{Comment: "x"})
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationWebhookEndpoint(ctx, "wh1", nil)
+	assert.Nil(t, err)
+	err = cluster.UpdateNotificationWebhookEndpoint(ctx, "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteNotificationWebhookEndpoint(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	cluster, err := client.Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteNotificationWebhookEndpoint(ctx, "wh1")
+	assert.Nil(t, err)
+	err = cluster.DeleteNotificationWebhookEndpoint(ctx, "")
+	assert.Error(t, err)
+}

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -598,4 +598,502 @@ func clusterBackup() {
 		Delete("^/cluster/backup/backup-1$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// --- /cluster/metrics/server ---------------------------------------------
+
+	// GET /cluster/metrics/server — list configured metric servers
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/metrics/server$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"id": "influx1", "type": "influxdb", "server": "metrics.example.com", "port": 8086, "disable": 0},
+        {"id": "graphite1", "type": "graphite", "server": "graphite.example.com", "port": 2003, "disable": 0}
+    ]
+}`)
+
+	// GET /cluster/metrics/server/{id} — single metric server config
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/metrics/server/influx1$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "id": "influx1",
+        "type": "influxdb",
+        "server": "metrics.example.com",
+        "port": 8086,
+        "influxdbproto": "http",
+        "bucket": "proxmox",
+        "organization": "ops",
+        "token": "secret",
+        "disable": 0,
+        "verify-certificate": 1,
+        "digest": "abc123"
+    }
+}`)
+
+	// POST /cluster/metrics/server/{id} — create
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/metrics/server/influx1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /cluster/metrics/server/{id} — update
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/metrics/server/influx1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /cluster/metrics/server/{id} — delete
+	gock.New(config.C.URI).
+		Delete("^/cluster/metrics/server/influx1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// --- /cluster/mapping ----------------------------------------------------
+
+	// GET /cluster/mapping — directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/mapping$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "dir"},
+        {"name": "pci"},
+        {"name": "usb"}
+    ]
+}`)
+
+	// GET /cluster/mapping/dir — list directory mappings
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/mapping/dir$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "id": "shared-iso",
+            "description": "Shared ISO directory",
+            "map": ["node=node1,path=/srv/iso", "node=node2,path=/srv/iso"]
+        }
+    ]
+}`)
+
+	// GET /cluster/mapping/dir/{id}
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/mapping/dir/shared-iso$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "id": "shared-iso",
+        "description": "Shared ISO directory",
+        "map": ["node=node1,path=/srv/iso", "node=node2,path=/srv/iso"],
+        "digest": "d1"
+    }
+}`)
+
+	// POST /cluster/mapping/dir
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/mapping/dir$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /cluster/mapping/dir/{id}
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/mapping/dir/shared-iso$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /cluster/mapping/dir/{id}
+	gock.New(config.C.URI).
+		Delete("^/cluster/mapping/dir/shared-iso$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// GET /cluster/mapping/pci — list PCI mappings
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/mapping/pci$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "id": "gpu0",
+            "description": "Tesla T4",
+            "map": ["node=node1,path=0000:01:00.0,id=10de:1eb8,iommugroup=12"],
+            "mdev": 0
+        }
+    ]
+}`)
+
+	// GET /cluster/mapping/pci/{id}
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/mapping/pci/gpu0$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "id": "gpu0",
+        "description": "Tesla T4",
+        "map": ["node=node1,path=0000:01:00.0,id=10de:1eb8,iommugroup=12"],
+        "mdev": 0,
+        "live-migration-capable": 0,
+        "digest": "p1"
+    }
+}`)
+
+	// POST /cluster/mapping/pci
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/mapping/pci$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /cluster/mapping/pci/{id}
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/mapping/pci/gpu0$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /cluster/mapping/pci/{id}
+	gock.New(config.C.URI).
+		Delete("^/cluster/mapping/pci/gpu0$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// GET /cluster/mapping/usb — list USB mappings
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/mapping/usb$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "id": "yubikey",
+            "description": "YubiKey 5",
+            "map": ["node=node1,id=1050:0407,path=1-1"]
+        }
+    ]
+}`)
+
+	// GET /cluster/mapping/usb/{id}
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/mapping/usb/yubikey$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "id": "yubikey",
+        "description": "YubiKey 5",
+        "map": ["node=node1,id=1050:0407,path=1-1"],
+        "digest": "u1"
+    }
+}`)
+
+	// POST /cluster/mapping/usb
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/mapping/usb$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// PUT /cluster/mapping/usb/{id}
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/mapping/usb/yubikey$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// DELETE /cluster/mapping/usb/{id}
+	gock.New(config.C.URI).
+		Delete("^/cluster/mapping/usb/yubikey$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// --- /cluster/notifications ---------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "endpoints"},
+        {"name": "matchers"},
+        {"name": "targets"},
+        {"name": "matcher-fields"},
+        {"name": "matcher-field-values"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/matcher-fields$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "type"},
+        {"name": "hostname"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/matcher-field-values$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"field": "type", "value": "vzdump", "comment": "Backup notifications"},
+        {"field": "type", "value": "system"}
+    ]
+}`)
+
+	// Targets
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/targets$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "mail-to-root", "type": "sendmail", "origin": "builtin", "disable": 0},
+        {"name": "gotify1", "type": "gotify", "origin": "user-created", "disable": 0}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/notifications/targets/mail-to-root/test$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// Matchers
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/matchers$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "name": "default-matcher",
+            "mode": "all",
+            "target": ["mail-to-root"],
+            "origin": "builtin"
+        }
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/matchers/default-matcher$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "name": "default-matcher",
+        "mode": "all",
+        "match-severity": ["warning", "error"],
+        "target": ["mail-to-root"],
+        "digest": "m1"
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/notifications/matchers$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/notifications/matchers/default-matcher$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/cluster/notifications/matchers/default-matcher$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// Gotify endpoints
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/gotify$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "gotify1", "server": "https://gotify.example.com", "disable": 0}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/gotify/gotify1$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "name": "gotify1",
+        "server": "https://gotify.example.com",
+        "disable": 0,
+        "digest": "g1"
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/notifications/endpoints/gotify$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/notifications/endpoints/gotify/gotify1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/cluster/notifications/endpoints/gotify/gotify1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// Sendmail endpoints
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/sendmail$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "mail-to-root", "mailto-user": ["root@pam"], "origin": "builtin"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/sendmail/mail-to-root$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "name": "mail-to-root",
+        "mailto-user": ["root@pam"],
+        "from-address": "root@pve",
+        "digest": "s1"
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/notifications/endpoints/sendmail$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/notifications/endpoints/sendmail/mail-to-root$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/cluster/notifications/endpoints/sendmail/mail-to-root$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// SMTP endpoints
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/smtp$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {
+            "name": "smtp1",
+            "server": "smtp.example.com",
+            "port": 587,
+            "mode": "starttls",
+            "from-address": "alerts@example.com",
+            "username": "alerts"
+        }
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/smtp/smtp1$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "name": "smtp1",
+        "server": "smtp.example.com",
+        "port": 587,
+        "mode": "starttls",
+        "from-address": "alerts@example.com",
+        "mailto": ["ops@example.com"],
+        "digest": "st1"
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/notifications/endpoints/smtp$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/notifications/endpoints/smtp/smtp1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/cluster/notifications/endpoints/smtp/smtp1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// Webhook endpoints
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/webhook$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "wh1", "url": "https://hook.example.com/alert", "method": "post"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints/webhook/wh1$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "name": "wh1",
+        "url": "https://hook.example.com/alert",
+        "method": "post",
+        "body": "eyJoZWxsbyI6IndvcmxkIn0=",
+        "digest": "w1"
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/notifications/endpoints/webhook$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/notifications/endpoints/webhook/wh1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/cluster/notifications/endpoints/webhook/wh1$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/types.go
+++ b/types.go
@@ -2351,3 +2351,345 @@ type SDNZoneOptions struct {
 	VRFVXLAN                 int    `json:"vrf-vxlan,omitempty"`
 	VXLANPort                uint16 `json:"vxlan-port,omitempty"` // FIXME(issue-199): PVE default 4789; use *uint16 so unset doesn't send 0.
 }
+
+// ClusterMetricServers is the list payload returned by GET /cluster/metrics/server.
+type ClusterMetricServers []*ClusterMetricServerSummary
+
+// ClusterMetricServerSummary is the trimmed shape returned by the list endpoint.
+// The detailed GET /cluster/metrics/server/{id} returns the full plugin config in
+// ClusterMetricServer.
+type ClusterMetricServerSummary struct {
+	ID      string    `json:"id,omitempty"`
+	Type    string    `json:"type,omitempty"`
+	Server  string    `json:"server,omitempty"`
+	Port    int       `json:"port,omitempty"`
+	Disable IntOrBool `json:"disable,omitempty"`
+}
+
+// ClusterMetricServer is the union of fields PVE returns for a single configured
+// metric server. PVE multiplexes graphite / influxdb / opentelemetry plugins
+// behind one config-id; per-plugin fields are populated only when relevant.
+type ClusterMetricServer struct {
+	ID            string    `json:"id,omitempty"`
+	Type          string    `json:"type,omitempty"`
+	Server        string    `json:"server,omitempty"`
+	Port          int       `json:"port,omitempty"`
+	Disable       IntOrBool `json:"disable,omitempty"`
+	APIPathPrefix string    `json:"api-path-prefix,omitempty"`
+	Bucket        string    `json:"bucket,omitempty"`
+	InfluxDBProto string    `json:"influxdbproto,omitempty"`
+	MaxBodySize   uint64    `json:"max-body-size,omitempty"`
+	MTU           uint      `json:"mtu,omitempty"`
+	Organization  string    `json:"organization,omitempty"`
+	Path          string    `json:"path,omitempty"`
+	Proto         string    `json:"proto,omitempty"`
+	Timeout       uint      `json:"timeout,omitempty"`
+	Token         string    `json:"token,omitempty"`
+	// OpenTelemetry-specific knobs.
+	OtelCompression        string    `json:"otel-compression,omitempty"`
+	OtelHeaders            string    `json:"otel-headers,omitempty"`
+	OtelMaxBodySize        uint64    `json:"otel-max-body-size,omitempty"`
+	OtelPath               string    `json:"otel-path,omitempty"`
+	OtelProtocol           string    `json:"otel-protocol,omitempty"`
+	OtelResourceAttributes string    `json:"otel-resource-attributes,omitempty"`
+	OtelTimeout            uint      `json:"otel-timeout,omitempty"`
+	OtelVerifySSL          IntOrBool `json:"otel-verify-ssl,omitempty"`
+	VerifyCertificate      IntOrBool `json:"verify-certificate,omitempty"`
+	Digest                 string    `json:"digest,omitempty"`
+}
+
+// ClusterMetricServerOptions is the create/update payload. POST requires id+type;
+// PUT uses id from the URL and accepts a "delete" comma list to unset keys.
+type ClusterMetricServerOptions struct {
+	ID            string `json:"id,omitempty"`
+	Type          string `json:"type,omitempty"` // graphite | influxdb | opentelemetry — POST only
+	Server        string `json:"server,omitempty"`
+	Port          int    `json:"port,omitempty"`
+	Disable       *bool  `json:"disable,omitempty"`
+	APIPathPrefix string `json:"api-path-prefix,omitempty"`
+	Bucket        string `json:"bucket,omitempty"`
+	InfluxDBProto string `json:"influxdbproto,omitempty"`
+	MaxBodySize   uint64 `json:"max-body-size,omitempty"`
+	MTU           uint   `json:"mtu,omitempty"`
+	Organization  string `json:"organization,omitempty"`
+	Path          string `json:"path,omitempty"`
+	Proto         string `json:"proto,omitempty"`
+	Timeout       uint   `json:"timeout,omitempty"`
+	Token         string `json:"token,omitempty"`
+	// OpenTelemetry-specific knobs.
+	OtelCompression        string `json:"otel-compression,omitempty"`
+	OtelHeaders            string `json:"otel-headers,omitempty"`
+	OtelMaxBodySize        uint64 `json:"otel-max-body-size,omitempty"`
+	OtelPath               string `json:"otel-path,omitempty"`
+	OtelProtocol           string `json:"otel-protocol,omitempty"`
+	OtelResourceAttributes string `json:"otel-resource-attributes,omitempty"`
+	OtelTimeout            uint   `json:"otel-timeout,omitempty"`
+	OtelVerifySSL          *bool  `json:"otel-verify-ssl,omitempty"`     // PVE default true; pointer so unset doesn't flip server-side
+	VerifyCertificate      *bool  `json:"verify-certificate,omitempty"`  // PVE default true; pointer to avoid silently disabling TLS verification
+	Digest                 string `json:"digest,omitempty"`              // PUT only — optimistic concurrency
+	Delete                 string `json:"delete,omitempty"`              // PUT only — comma-separated keys to clear
+}
+
+// ClusterMappings is the directory index returned by GET /cluster/mapping.
+type ClusterMappings []*ClusterMappingIndexEntry
+
+// ClusterMappingIndexEntry is one row in the top-level mapping index.
+type ClusterMappingIndexEntry struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ClusterMappingCheck captures the optional per-node diagnostic returned when
+// the list endpoints are called with check-node set.
+type ClusterMappingCheck struct {
+	Message  string `json:"message,omitempty"`
+	Severity string `json:"severity,omitempty"`
+}
+
+// ClusterDirMappings is the list payload returned by GET /cluster/mapping/dir.
+type ClusterDirMappings []*ClusterDirMapping
+
+// ClusterDirMapping describes a single directory mapping. The "map" field is
+// a list of PVE property-strings ("node=...,path=...") rather than structured
+// objects — that's what the API returns.
+type ClusterDirMapping struct {
+	ID          string                 `json:"id,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	Map         []string               `json:"map,omitempty"`
+	Checks      []*ClusterMappingCheck `json:"checks,omitempty"`
+	Digest      string                 `json:"digest,omitempty"`
+}
+
+// ClusterDirMappingOptions is the create/update payload for dir mappings.
+type ClusterDirMappingOptions struct {
+	ID          string   `json:"id,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Map         []string `json:"map,omitempty"`
+	Digest      string   `json:"digest,omitempty"`
+	Delete      string   `json:"delete,omitempty"`
+}
+
+// ClusterPCIMappings is the list payload returned by GET /cluster/mapping/pci.
+type ClusterPCIMappings []*ClusterPCIMapping
+
+// ClusterPCIMapping describes a logical PCI device mapping.
+type ClusterPCIMapping struct {
+	ID                   string                 `json:"id,omitempty"`
+	Description          string                 `json:"description,omitempty"`
+	Map                  []string               `json:"map,omitempty"`
+	Checks               []*ClusterMappingCheck `json:"checks,omitempty"`
+	MDev                 IntOrBool              `json:"mdev,omitempty"`
+	LiveMigrationCapable IntOrBool              `json:"live-migration-capable,omitempty"`
+	Digest               string                 `json:"digest,omitempty"`
+}
+
+// ClusterPCIMappingOptions is the create/update payload for PCI mappings.
+// mdev / live-migration-capable both default to false on PVE, so plain bool
+// with omitempty is safe.
+type ClusterPCIMappingOptions struct {
+	ID                   string   `json:"id,omitempty"`
+	Description          string   `json:"description,omitempty"`
+	Map                  []string `json:"map,omitempty"`
+	MDev                 bool     `json:"mdev,omitempty"`
+	LiveMigrationCapable bool     `json:"live-migration-capable,omitempty"`
+	Digest               string   `json:"digest,omitempty"`
+	Delete               string   `json:"delete,omitempty"`
+}
+
+// ClusterUSBMappings is the list payload returned by GET /cluster/mapping/usb.
+type ClusterUSBMappings []*ClusterUSBMapping
+
+// ClusterUSBMapping describes a logical USB device mapping. USB uses "error"
+// instead of "checks" in the list response (PVE quirk — not normalised).
+type ClusterUSBMapping struct {
+	ID          string                 `json:"id,omitempty"`
+	Description string                 `json:"description,omitempty"`
+	Map         []string               `json:"map,omitempty"`
+	Error       []*ClusterMappingCheck `json:"error,omitempty"`
+	Digest      string                 `json:"digest,omitempty"`
+}
+
+// ClusterUSBMappingOptions is the create/update payload for USB mappings.
+type ClusterUSBMappingOptions struct {
+	ID          string   `json:"id,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Map         []string `json:"map,omitempty"`
+	Digest      string   `json:"digest,omitempty"`
+	Delete      string   `json:"delete,omitempty"`
+}
+
+// --- notifications ----------------------------------------------------------
+
+// ClusterNotificationIndex is the top-level directory under /cluster/notifications.
+type ClusterNotificationIndex []*ClusterNotificationIndexEntry
+
+// ClusterNotificationIndexEntry is one row in the notifications index.
+type ClusterNotificationIndexEntry struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ClusterNotificationMatcherField is a row from /cluster/notifications/matcher-fields.
+type ClusterNotificationMatcherField struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ClusterNotificationMatcherFieldValue is a row from
+// /cluster/notifications/matcher-field-values.
+type ClusterNotificationMatcherFieldValue struct {
+	Field   string `json:"field,omitempty"`
+	Value   string `json:"value,omitempty"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// ClusterNotificationTarget is a row from /cluster/notifications/targets — a
+// flattened view across all endpoint plugin types (sendmail/gotify/smtp/webhook).
+type ClusterNotificationTarget struct {
+	Name    string    `json:"name,omitempty"`
+	Type    string    `json:"type,omitempty"`
+	Comment string    `json:"comment,omitempty"`
+	Origin  string    `json:"origin,omitempty"`
+	Disable IntOrBool `json:"disable,omitempty"`
+}
+
+// ClusterNotificationMatcher is a single matcher.
+type ClusterNotificationMatcher struct {
+	Name          string    `json:"name,omitempty"`
+	Comment       string    `json:"comment,omitempty"`
+	Mode          string    `json:"mode,omitempty"` // all | any
+	Disable       IntOrBool `json:"disable,omitempty"`
+	InvertMatch   IntOrBool `json:"invert-match,omitempty"`
+	MatchCalendar []string  `json:"match-calendar,omitempty"`
+	MatchField    []string  `json:"match-field,omitempty"`
+	MatchSeverity []string  `json:"match-severity,omitempty"`
+	Target        []string  `json:"target,omitempty"`
+	Origin        string    `json:"origin,omitempty"`
+	Digest        string    `json:"digest,omitempty"`
+}
+
+// ClusterNotificationMatcherOptions is the create/update payload for matchers.
+// Delete is an array of keys (not a comma-string) per PVE schema.
+type ClusterNotificationMatcherOptions struct {
+	Name          string   `json:"name,omitempty"`
+	Comment       string   `json:"comment,omitempty"`
+	Mode          string   `json:"mode,omitempty"`
+	Disable       *bool    `json:"disable,omitempty"`
+	InvertMatch   *bool    `json:"invert-match,omitempty"`
+	MatchCalendar []string `json:"match-calendar,omitempty"`
+	MatchField    []string `json:"match-field,omitempty"`
+	MatchSeverity []string `json:"match-severity,omitempty"`
+	Target        []string `json:"target,omitempty"`
+	Digest        string   `json:"digest,omitempty"`
+	Delete        []string `json:"delete,omitempty"`
+}
+
+// ClusterNotificationGotifyEndpoint is a Gotify endpoint configuration. The
+// `token` field is write-only on PVE — GET never returns it.
+type ClusterNotificationGotifyEndpoint struct {
+	Name    string    `json:"name,omitempty"`
+	Server  string    `json:"server,omitempty"`
+	Comment string    `json:"comment,omitempty"`
+	Disable IntOrBool `json:"disable,omitempty"`
+	Origin  string    `json:"origin,omitempty"`
+	Digest  string    `json:"digest,omitempty"`
+}
+
+// ClusterNotificationGotifyOptions is the create/update payload for gotify.
+type ClusterNotificationGotifyOptions struct {
+	Name    string   `json:"name,omitempty"`
+	Server  string   `json:"server,omitempty"`
+	Token   string   `json:"token,omitempty"`
+	Comment string   `json:"comment,omitempty"`
+	Disable *bool    `json:"disable,omitempty"`
+	Digest  string   `json:"digest,omitempty"`
+	Delete  []string `json:"delete,omitempty"`
+}
+
+// ClusterNotificationSendmailEndpoint is a sendmail endpoint.
+type ClusterNotificationSendmailEndpoint struct {
+	Name        string    `json:"name,omitempty"`
+	Author      string    `json:"author,omitempty"`
+	FromAddress string    `json:"from-address,omitempty"`
+	MailTo      []string  `json:"mailto,omitempty"`
+	MailToUser  []string  `json:"mailto-user,omitempty"`
+	Comment     string    `json:"comment,omitempty"`
+	Disable     IntOrBool `json:"disable,omitempty"`
+	Origin      string    `json:"origin,omitempty"`
+	Digest      string    `json:"digest,omitempty"`
+}
+
+// ClusterNotificationSendmailOptions is the create/update payload for sendmail.
+type ClusterNotificationSendmailOptions struct {
+	Name        string   `json:"name,omitempty"`
+	Author      string   `json:"author,omitempty"`
+	FromAddress string   `json:"from-address,omitempty"`
+	MailTo      []string `json:"mailto,omitempty"`
+	MailToUser  []string `json:"mailto-user,omitempty"`
+	Comment     string   `json:"comment,omitempty"`
+	Disable     *bool    `json:"disable,omitempty"`
+	Digest      string   `json:"digest,omitempty"`
+	Delete      []string `json:"delete,omitempty"`
+}
+
+// ClusterNotificationSMTPEndpoint is an SMTP endpoint. Password is write-only.
+type ClusterNotificationSMTPEndpoint struct {
+	Name        string    `json:"name,omitempty"`
+	Server      string    `json:"server,omitempty"`
+	Port        int       `json:"port,omitempty"`
+	Mode        string    `json:"mode,omitempty"` // insecure | starttls | tls
+	Username    string    `json:"username,omitempty"`
+	FromAddress string    `json:"from-address,omitempty"`
+	Author      string    `json:"author,omitempty"`
+	MailTo      []string  `json:"mailto,omitempty"`
+	MailToUser  []string  `json:"mailto-user,omitempty"`
+	Comment     string    `json:"comment,omitempty"`
+	Disable     IntOrBool `json:"disable,omitempty"`
+	Origin      string    `json:"origin,omitempty"`
+	Digest      string    `json:"digest,omitempty"`
+}
+
+// ClusterNotificationSMTPOptions is the create/update payload for smtp.
+type ClusterNotificationSMTPOptions struct {
+	Name        string   `json:"name,omitempty"`
+	Server      string   `json:"server,omitempty"`
+	Port        int      `json:"port,omitempty"`
+	Mode        string   `json:"mode,omitempty"`
+	Username    string   `json:"username,omitempty"`
+	Password    string   `json:"password,omitempty"`
+	FromAddress string   `json:"from-address,omitempty"`
+	Author      string   `json:"author,omitempty"`
+	MailTo      []string `json:"mailto,omitempty"`
+	MailToUser  []string `json:"mailto-user,omitempty"`
+	Comment     string   `json:"comment,omitempty"`
+	Disable     *bool    `json:"disable,omitempty"`
+	Digest      string   `json:"digest,omitempty"`
+	Delete      []string `json:"delete,omitempty"`
+}
+
+// ClusterNotificationWebhookEndpoint is a webhook endpoint. The header / secret
+// arrays use PVE property-string format ("name=...,value=<base64>"); body is
+// already base64-encoded on the wire.
+type ClusterNotificationWebhookEndpoint struct {
+	Name    string    `json:"name,omitempty"`
+	URL     string    `json:"url,omitempty"`
+	Method  string    `json:"method,omitempty"` // post | put | get
+	Header  []string  `json:"header,omitempty"`
+	Body    string    `json:"body,omitempty"`
+	Secret  []string  `json:"secret,omitempty"`
+	Comment string    `json:"comment,omitempty"`
+	Disable IntOrBool `json:"disable,omitempty"`
+	Origin  string    `json:"origin,omitempty"`
+	Digest  string    `json:"digest,omitempty"`
+}
+
+// ClusterNotificationWebhookOptions is the create/update payload for webhook.
+type ClusterNotificationWebhookOptions struct {
+	Name    string   `json:"name,omitempty"`
+	URL     string   `json:"url,omitempty"`
+	Method  string   `json:"method,omitempty"`
+	Header  []string `json:"header,omitempty"`
+	Body    string   `json:"body,omitempty"`
+	Secret  []string `json:"secret,omitempty"`
+	Comment string   `json:"comment,omitempty"`
+	Disable *bool    `json:"disable,omitempty"`
+	Digest  string   `json:"digest,omitempty"`
+	Delete  []string `json:"delete,omitempty"`
+}


### PR DESCRIPTION
## Summary

Three previously-untouched cluster-level surfaces, ~47 endpoints total.

### \`/cluster/metrics/server\` (5)
Full CRUD for InfluxDB/Graphite metrics endpoints — list, get, create, update, delete. New file \`cluster_metrics.go\`.

### \`/cluster/mapping\` (13)
Hardware/resource maps for PCI passthrough, USB passthrough, directory mapping. Index + full CRUD on each of \`dir\`/\`pci\`/\`usb\`. New file \`cluster_mapping.go\`.

### \`/cluster/notifications\` (29)
Index, matcher-fields, matcher-field-values, targets list+test, matchers CRUD, and full CRUD for the four endpoint plugin types: **gotify**, **sendmail**, **smtp**, **webhook**. New file \`cluster_notifications.go\`.

### Schema notes
1. Each notification endpoint plugin has a disjoint field set — modeled as separate read + Options structs per plugin (not a union). The targets-list endpoint returns the flattened view across all four.
2. Notifications PUT uses \`delete: []string\` (array of config-ids), unlike the comma-string \`delete\` form used in metrics/mapping. Both forms are now present in the codebase.
3. \`verify-certificate\` / \`otel-verify-ssl\` default to \`true\` on PVE — used \`*bool\` to avoid the #199 footgun. Matcher \`disable\`/\`invert-match\` and per-endpoint \`disable\` also \`*bool\`.
4. Write-only secrets (gotify token, SMTP password, webhook secret) live only on Options structs — GET never returns them.
5. USB list response uses \`error\` while dir/pci use \`checks\` — field names kept distinct rather than normalised.
6. Metric server POST targets \`/cluster/metrics/server/{id}\` (not the parent collection) — easy to miss.

Mocks added to \`tests/mocks/pve9x/cluster.go\` only (pve7x/pve8x don't currently have cluster-level mocks for these areas; happy to extend if reviewer prefers).

## Test plan
- [x] \`go test .\`
- [x] \`go build ./...\`
- [ ] Smoke against a live PVE cluster with at least one notification endpoint configured