### PR TITLE
refactor(qga): use typed result envelope in agent helpers

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -569,35 +569,33 @@ func (v *VirtualMachine) AgentGetHostName(ctx context.Context) (hostname string,
 		return
 	}
 
-	results := map[string]*AgentHostName{}
-	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-host-name", node.Name, v.VMID), &results)
-	if err != nil {
+	var resp struct {
+		Result *AgentHostName `json:"result"`
+	}
+	if err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-host-name", node.Name, v.VMID), &resp); err != nil {
 		return
 	}
-	result, ok := results["result"]
-	if !ok {
+	if resp.Result == nil {
 		err = fmt.Errorf("result is empty")
 		return
 	}
-	hostname = result.HostName
+	hostname = resp.Result.HostName
 	return
 }
 
 func (v *VirtualMachine) AgentGetNetworkIFaces(ctx context.Context) (iFaces []*AgentNetworkIface, err error) {
-	networks := map[string][]*AgentNetworkIface{}
-	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/network-get-interfaces", v.Node, v.VMID), &networks)
-	if err != nil {
+	var resp struct {
+		Result []*AgentNetworkIface `json:"result"`
+	}
+	if err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/network-get-interfaces", v.Node, v.VMID), &resp); err != nil {
 		return
 	}
-	if result, ok := networks["result"]; ok {
-		for _, iface := range result {
-			if iface.Name == "lo" {
-				continue
-			}
-			iFaces = append(iFaces, iface)
+	for _, iface := range resp.Result {
+		if iface.Name == "lo" {
+			continue
 		}
+		iFaces = append(iFaces, iface)
 	}
-
 	return
 }
 
@@ -672,18 +670,17 @@ func (v *VirtualMachine) WaitForAgentExecExit(ctx context.Context, pid, seconds 
 }
 
 func (v *VirtualMachine) AgentOsInfo(ctx context.Context) (info *AgentOsInfo, err error) {
-	results := map[string]*AgentOsInfo{}
-	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-osinfo", v.Node, v.VMID), &results)
-	if err != nil {
+	var resp struct {
+		Result *AgentOsInfo `json:"result"`
+	}
+	if err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-osinfo", v.Node, v.VMID), &resp); err != nil {
 		return
 	}
-
-	var ok bool
-	info, ok = results["result"]
-	if !ok {
+	if resp.Result == nil {
 		err = fmt.Errorf("result is empty")
+		return
 	}
-
+	info = resp.Result
 	return
 }
 


### PR DESCRIPTION
## Summary

Three pre-existing QGA helpers in \`virtual_machine.go\` unwrap PVE's \`{\"result\": ...}\` envelope via \`map[string]T{}\` + \`m[\"result\"]\` lookups. The new agent helpers added in #286 use the typed anonymous-struct pattern instead. This PR retrofits the old three to match.

### Why the struct is better
- **Type-safe.** \`resp.Result\` is a struct field; \`m[\"result\"]\` is a stringly-typed lookup that compiles fine if you typo the key and silently returns the zero value.
- **No allocation.** The struct is a stack-allocated value; the map allocates a header for a single key.
- **Self-documenting.** The envelope shape is declared at the top of the function.

### Behavior preservation
- \`AgentGetHostName\` and \`AgentOsInfo\` still return \`fmt.Errorf(\"result is empty\")\` when QGA produced no envelope (now triggered via \`resp.Result == nil\` instead of map-key-not-present).
- \`AgentGetNetworkIFaces\` still filters out \`lo\` and silently tolerates a missing/empty envelope (returns an empty slice).

### Out of scope
\`AgentGetHostName\` still does an unnecessary \`v.client.Node(ctx, v.Node)\` round-trip at the top — every other agent method uses \`v.Node\` directly. Left alone to keep this PR tightly scoped; happy to fix as a follow-up.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test .\`
- [ ] Smoke against a live PVE VM with qemu-guest-agent running