### PR TITLE
feat: wrap /cluster/acme — accounts, plugins, directories, meta, ToS

### DIFF
--- a/cluster_acme.go
+++ b/cluster_acme.go
@@ -1,0 +1,174 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// --- ACME directory / metadata (read-only discovery) -----------------------
+
+// ACMEDirectories returns the list of ACME CA directories PVE knows about
+// (Let's Encrypt prod, staging, etc.).
+func (cl *Cluster) ACMEDirectories(ctx context.Context) (dirs []*ACMEDirectory, err error) {
+	err = cl.client.Get(ctx, "/cluster/acme/directories", &dirs)
+	return
+}
+
+// ACMEChallengeSchema returns the catalog of supported challenge plugin
+// schemas (DNS providers etc.) PVE can configure.
+func (cl *Cluster) ACMEChallengeSchema(ctx context.Context) (schemas []*ACMEChallengeSchema, err error) {
+	err = cl.client.Get(ctx, "/cluster/acme/challenge-schema", &schemas)
+	return
+}
+
+// ACMETermsOfService returns the URL of the CA's ToS document for a given
+// directory URL. directory is optional — PVE defaults to Let's Encrypt prod.
+func (cl *Cluster) ACMETermsOfService(ctx context.Context, directory string) (tosURL string, err error) {
+	path := "/cluster/acme/tos"
+	if directory != "" {
+		q := url.Values{}
+		q.Set("directory", directory)
+		path = path + "?" + q.Encode()
+	}
+	err = cl.client.Get(ctx, path, &tosURL)
+	return
+}
+
+// ACMEMeta returns the metadata document of an ACME CA directory (caa
+// identities, EAB requirement, ToS URL, website). directory is optional.
+func (cl *Cluster) ACMEMeta(ctx context.Context, directory string) (meta *ACMEMeta, err error) {
+	path := "/cluster/acme/meta"
+	if directory != "" {
+		q := url.Values{}
+		q.Set("directory", directory)
+		path = path + "?" + q.Encode()
+	}
+	meta = &ACMEMeta{}
+	err = cl.client.Get(ctx, path, meta)
+	return
+}
+
+// --- ACME accounts ---------------------------------------------------------
+
+// ACMEAccounts lists configured ACME accounts on the cluster.
+func (cl *Cluster) ACMEAccounts(ctx context.Context) (accounts []*ACMEAccountIndex, err error) {
+	err = cl.client.Get(ctx, "/cluster/acme/account", &accounts)
+	return
+}
+
+// ACMEAccount returns the full account record (contact, directory URL, EAB
+// settings, account JSON from the CA). Pass "" to read the "default" account.
+func (cl *Cluster) ACMEAccount(ctx context.Context, name string) (account *ACMEAccount, err error) {
+	if name == "" {
+		name = "default"
+	}
+	account = &ACMEAccount{}
+	err = cl.client.Get(ctx, fmt.Sprintf("/cluster/acme/account/%s", name), account)
+	return
+}
+
+// NewACMEAccount registers a new ACME account with the CA. PVE runs this as
+// a task because it does a real HTTP round-trip to the CA. opts.Contact is
+// required; everything else (including Name) defaults sensibly.
+func (cl *Cluster) NewACMEAccount(ctx context.Context, opts *ACMEAccountOptions) (*Task, error) {
+	if opts == nil || opts.Contact == "" {
+		return nil, errors.New("acme account contact is required")
+	}
+	var upid UPID
+	if err := cl.client.Post(ctx, "/cluster/acme/account", opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}
+
+// UpdateACMEAccount mutates an existing account. Only `contact` is mutable
+// per the PVE schema; the rest is set at creation. Pass "" for name to
+// target the "default" account.
+func (cl *Cluster) UpdateACMEAccount(ctx context.Context, name, contact string) (*Task, error) {
+	if name == "" {
+		name = "default"
+	}
+	body := map[string]any{}
+	if contact != "" {
+		body["contact"] = contact
+	}
+	var upid UPID
+	if err := cl.client.Put(ctx, fmt.Sprintf("/cluster/acme/account/%s", name), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}
+
+// DeleteACMEAccount deactivates an ACME account with the CA and removes it
+// from PVE. Async because PVE calls the CA's deactivate endpoint.
+func (cl *Cluster) DeleteACMEAccount(ctx context.Context, name string) (*Task, error) {
+	if name == "" {
+		name = "default"
+	}
+	var upid UPID
+	if err := cl.client.Delete(ctx, fmt.Sprintf("/cluster/acme/account/%s", name), &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}
+
+// --- ACME plugins (DNS challenge providers) --------------------------------
+
+// ACMEPlugins lists configured ACME challenge plugins (DNS providers,
+// standalone, etc.). Pass a non-empty pluginType to filter by challenge
+// type (e.g. "dns", "standalone").
+func (cl *Cluster) ACMEPlugins(ctx context.Context, pluginType string) (plugins []*ACMEPlugin, err error) {
+	path := "/cluster/acme/plugins"
+	if pluginType != "" {
+		q := url.Values{}
+		q.Set("type", pluginType)
+		path = path + "?" + q.Encode()
+	}
+	err = cl.client.Get(ctx, path, &plugins)
+	return
+}
+
+// ACMEPlugin reads a single plugin's configuration.
+func (cl *Cluster) ACMEPlugin(ctx context.Context, id string) (plugin *ACMEPlugin, err error) {
+	if id == "" {
+		err = errors.New("acme plugin id can not be empty")
+		return
+	}
+	plugin = &ACMEPlugin{}
+	err = cl.client.Get(ctx, fmt.Sprintf("/cluster/acme/plugins/%s", id), plugin)
+	return
+}
+
+// NewACMEPlugin creates a new ACME challenge plugin. opts.ID and opts.Type
+// ("dns" | "standalone") are required by PVE.
+func (cl *Cluster) NewACMEPlugin(ctx context.Context, opts *ACMEPluginOptions) error {
+	if opts == nil || opts.ID == "" {
+		return errors.New("acme plugin id can not be empty")
+	}
+	if opts.Type == "" {
+		return errors.New("acme plugin type is required")
+	}
+	return cl.client.Post(ctx, "/cluster/acme/plugins", opts, nil)
+}
+
+// UpdateACMEPlugin mutates an existing plugin. Pass opts.Delete to reset a
+// comma-separated list of keys back to their PVE defaults.
+func (cl *Cluster) UpdateACMEPlugin(ctx context.Context, id string, opts *ACMEPluginOptions) error {
+	if id == "" {
+		return errors.New("acme plugin id can not be empty")
+	}
+	if opts == nil {
+		opts = &ACMEPluginOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/acme/plugins/%s", id), opts, nil)
+}
+
+// DeleteACMEPlugin removes an ACME challenge plugin.
+func (cl *Cluster) DeleteACMEPlugin(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("acme plugin id can not be empty")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/acme/plugins/%s", id), nil)
+}

--- a/cluster_acme_test.go
+++ b/cluster_acme_test.go
@@ -1,0 +1,203 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_ACMEDirectories(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	dirs, err := cluster.ACMEDirectories(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, dirs, 2)
+	assert.Equal(t, "Let's Encrypt V2", dirs[0].Name)
+	assert.Contains(t, dirs[0].URL, "acme-v02.api.letsencrypt.org")
+}
+
+func TestCluster_ACMEChallengeSchema(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	schemas, err := cluster.ACMEChallengeSchema(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, schemas, 2)
+	assert.Equal(t, "dns-01", schemas[0].ID)
+}
+
+func TestCluster_ACMETermsOfService(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	tosURL, err := cluster.ACMETermsOfService(ctx, "")
+	assert.Nil(t, err)
+	assert.Contains(t, tosURL, "letsencrypt.org")
+}
+
+func TestCluster_ACMEMeta(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	meta, err := cluster.ACMEMeta(ctx, "https://acme-v02.api.letsencrypt.org/directory")
+	assert.Nil(t, err)
+	assert.NotNil(t, meta)
+	assert.Contains(t, meta.CAAIdentities, "letsencrypt.org")
+	assert.Contains(t, meta.Website, "letsencrypt.org")
+}
+
+func TestCluster_ACMEAccounts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	accounts, err := cluster.ACMEAccounts(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, accounts, 1)
+	assert.Equal(t, "default", accounts[0].Name)
+}
+
+func TestCluster_ACMEAccount(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	account, err := cluster.ACMEAccount(ctx, "")
+	assert.Nil(t, err)
+	assert.NotNil(t, account)
+	assert.Contains(t, account.Directory, "letsencrypt.org")
+}
+
+func TestCluster_NewACMEAccount(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	task, err := cluster.NewACMEAccount(ctx, &ACMEAccountOptions{Contact: "mailto:admin@example.com"})
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "acme-register", task.Type)
+
+	_, err = cluster.NewACMEAccount(ctx, nil)
+	assert.NotNil(t, err)
+}
+
+func TestCluster_UpdateACMEAccount(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	task, err := cluster.UpdateACMEAccount(ctx, "", "mailto:newadmin@example.com")
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "acme-update", task.Type)
+}
+
+func TestCluster_DeleteACMEAccount(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	task, err := cluster.DeleteACMEAccount(ctx, "")
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "acme-deactivate", task.Type)
+}
+
+func TestCluster_ACMEPlugins(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	plugins, err := cluster.ACMEPlugins(ctx, "")
+	assert.Nil(t, err)
+	assert.Len(t, plugins, 1)
+	assert.Equal(t, "cloudflare", plugins[0].ID)
+	assert.Equal(t, "dns", plugins[0].Type)
+}
+
+func TestCluster_ACMEPlugin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	plugin, err := cluster.ACMEPlugin(ctx, "cloudflare")
+	assert.Nil(t, err)
+	assert.NotNil(t, plugin)
+	assert.Equal(t, "cloudflare", plugin.ID)
+	assert.Equal(t, "cf", plugin.API)
+}
+
+func TestCluster_NewACMEPlugin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.NewACMEPlugin(ctx, &ACMEPluginOptions{ID: "cloudflare", Type: "dns", API: "cf"})
+	assert.Nil(t, err)
+
+	err = cluster.NewACMEPlugin(ctx, nil)
+	assert.NotNil(t, err)
+
+	err = cluster.NewACMEPlugin(ctx, &ACMEPluginOptions{ID: "no-type"})
+	assert.NotNil(t, err)
+}
+
+func TestCluster_UpdateACMEPlugin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.UpdateACMEPlugin(ctx, "cloudflare", &ACMEPluginOptions{API: "cf"})
+	assert.Nil(t, err)
+
+	err = cluster.UpdateACMEPlugin(ctx, "", nil)
+	assert.NotNil(t, err)
+}
+
+func TestCluster_DeleteACMEPlugin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ctx := context.Background()
+	cluster, err := mockClient().Cluster(ctx)
+	assert.Nil(t, err)
+
+	err = cluster.DeleteACMEPlugin(ctx, "cloudflare")
+	assert.Nil(t, err)
+
+	err = cluster.DeleteACMEPlugin(ctx, "")
+	assert.NotNil(t, err)
+}

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -654,6 +654,129 @@ func clusterBackup() {
 		Reply(200).
 		JSON(`{"data": null}`)
 
+	// --- /cluster/acme -------------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/directories$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "Let's Encrypt V2", "url": "https://acme-v02.api.letsencrypt.org/directory"},
+        {"name": "Let's Encrypt V2 Staging", "url": "https://acme-staging-v02.api.letsencrypt.org/directory"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/challenge-schema$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"id": "dns-01", "name": "dns-01 challenge", "type": "dns", "schema": {}},
+        {"id": "http-01", "name": "http-01 challenge", "type": "standalone", "schema": {}}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/tos").
+		Reply(200).
+		JSON(`{"data": "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/meta").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "caaIdentities": ["letsencrypt.org"],
+        "externalAccountRequired": 0,
+        "termsOfService": "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf",
+        "website": "https://letsencrypt.org"
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/account$").
+		Reply(200).
+		JSON(`{"data": [{"name": "default"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/account/default$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "directory": "https://acme-v02.api.letsencrypt.org/directory",
+        "location": "https://acme-v02.api.letsencrypt.org/acme/acct/123456",
+        "tos": "https://letsencrypt.org/documents/LE-SA-v1.4-April-3-2024.pdf",
+        "account": {"status": "valid", "contact": ["mailto:admin@example.com"]}
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/acme/account$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:acme-register:default:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/acme/account/default$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:acme-update:default:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/acme/account/default$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:acme-deactivate:default:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/plugins$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"plugin": "cloudflare", "type": "dns", "api": "cf", "data": "Y2YtdG9rZW49c2VjcmV0", "disable": 0, "validation-delay": 30}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme/plugins/cloudflare$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "plugin": "cloudflare",
+        "type": "dns",
+        "api": "cf",
+        "data": "Y2YtdG9rZW49c2VjcmV0",
+        "disable": 0,
+        "validation-delay": 30,
+        "digest": "abc123"
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/acme/plugins$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/acme/plugins/cloudflare$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/cluster/acme/plugins/cloudflare$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
 	// --- /cluster/mapping ----------------------------------------------------
 
 	// GET /cluster/mapping — directory index

--- a/types.go
+++ b/types.go
@@ -2825,6 +2825,88 @@ type ClusterMetricServerOptions struct {
 	Delete                 string `json:"delete,omitempty"`              // PUT only — comma-separated keys to clear
 }
 
+// --- ACME (Let's Encrypt-style automated certificate issuance) -------------
+
+// ACMEDirectory is one row in GET /cluster/acme/directories — a friendly name
+// + URL for a known ACME CA endpoint.
+type ACMEDirectory struct {
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// ACMEMeta is the metadata document returned by GET /cluster/acme/meta — what
+// the CA itself advertises about its capabilities and policies.
+type ACMEMeta struct {
+	CAAIdentities           []string `json:"caaIdentities,omitempty"`
+	ExternalAccountRequired IntOrBool `json:"externalAccountRequired,omitempty"`
+	TermsOfService          string   `json:"termsOfService,omitempty"`
+	Website                 string   `json:"website,omitempty"`
+}
+
+// ACMEChallengeSchema is one entry in GET /cluster/acme/challenge-schema —
+// the catalog of DNS plugin types PVE understands. Schema is the per-plugin
+// parameter spec (left as raw map since each plugin defines its own).
+type ACMEChallengeSchema struct {
+	ID     string                 `json:"id,omitempty"`
+	Name   string                 `json:"name,omitempty"`
+	Type   string                 `json:"type,omitempty"`
+	Schema map[string]interface{} `json:"schema,omitempty"`
+}
+
+// ACMEAccountIndex is one row in GET /cluster/acme/account — just the name.
+type ACMEAccountIndex struct {
+	Name string `json:"name,omitempty"`
+}
+
+// ACMEAccount is the full account record from GET /cluster/acme/account/{name}.
+// `Account` is the raw CA-returned JSON (status, contacts, etc.) — left
+// untyped because RFC 8555 leaves the shape extensible.
+type ACMEAccount struct {
+	Account   map[string]interface{} `json:"account,omitempty"`
+	Directory string                 `json:"directory,omitempty"`
+	Location  string                 `json:"location,omitempty"`
+	TOS       string                 `json:"tos,omitempty"`
+}
+
+// ACMEAccountOptions is the POST body for creating an account. Contact is the
+// only required field; PVE defaults Name to "default" and Directory to LE prod.
+// EABKid + EABHMACKey are for External Account Binding (e.g. ZeroSSL).
+type ACMEAccountOptions struct {
+	Contact     string `json:"contact"`
+	Directory   string `json:"directory,omitempty"`
+	EABKid      string `json:"eab-kid,omitempty"`
+	EABHMACKey  string `json:"eab-hmac-key,omitempty"`
+	Name        string `json:"name,omitempty"`
+	TOSURL      string `json:"tos_url,omitempty"`
+}
+
+// ACMEPlugin is the read shape from GET /cluster/acme/plugins[/{id}]. The
+// per-provider parameters live in Data (a base64-encoded blob per PVE).
+type ACMEPlugin struct {
+	ID              string    `json:"plugin,omitempty"`
+	Type            string    `json:"type,omitempty"`
+	API             string    `json:"api,omitempty"`
+	Data            string    `json:"data,omitempty"`
+	Disable         IntOrBool `json:"disable,omitempty"`
+	Nodes           string    `json:"nodes,omitempty"`
+	ValidationDelay int       `json:"validation-delay,omitempty"`
+	Digest          string    `json:"digest,omitempty"`
+}
+
+// ACMEPluginOptions is the create/update payload. POST requires ID + Type;
+// PUT identifies the plugin by URL and accepts Delete to clear keys.
+type ACMEPluginOptions struct {
+	ID              string `json:"id,omitempty"`
+	Type            string `json:"type,omitempty"` // "dns" | "standalone" — POST only
+	API             string `json:"api,omitempty"`
+	Data            string `json:"data,omitempty"`
+	Disable         *bool  `json:"disable,omitempty"`
+	Nodes           string `json:"nodes,omitempty"`
+	ValidationDelay *int   `json:"validation-delay,omitempty"` // PVE default 30; pointer so unset doesn't reset to 0
+	Digest          string `json:"digest,omitempty"`           // PUT only
+	Delete          string `json:"delete,omitempty"`           // PUT only
+}
+
 // ClusterMappings is the directory index returned by GET /cluster/mapping.
 type ClusterMappings []*ClusterMappingIndexEntry
 


### PR DESCRIPTION
## Summary

Closes the \`/cluster/acme\` coverage gap (0/15 → 15/15).

**Discovery** (synchronous reads):
- \`ACMEDirectories\` — list known CA directory URLs
- \`ACMEChallengeSchema\` — catalog of supported DNS plugin types
- \`ACMETermsOfService\` — ToS URL for a given CA
- \`ACMEMeta\` — CA metadata (caaIdentities, EAB requirement, website, ToS)

**Accounts** (POST/PUT/DELETE return \`*Task\` since PVE round-trips to the CA):
- \`ACMEAccounts\`, \`ACMEAccount\`, \`NewACMEAccount\`, \`UpdateACMEAccount\`, \`DeleteACMEAccount\`

**Plugins** (DNS challenge providers etc., synchronous CRUD):
- \`ACMEPlugins\`, \`ACMEPlugin\`, \`NewACMEPlugin\`, \`UpdateACMEPlugin\`, \`DeleteACMEPlugin\`

### Schema notes
- \`ACMEPlugin.Data\` is base64-encoded per-provider config (PVE wraps the underlying DNS plugin's parameters). Pass the already-encoded blob; we don't try to interpret it.
- Account name defaults to \`"default"\` for read/update/delete (matches PVE convention).
- \`ValidationDelay\` is \`*int\` on options (PVE default 30) so unset doesn't silently reset to 0.
- \`Disable\` is \`*bool\` for the same reason.
- \`UpdateACMEAccount\` only sends \`contact\` per the schema — that's the only mutable field on existing accounts.

Mocks added to pve9x cluster.go. Existing pve7x/pve8x cluster mocks don't cover the recent cluster surfaces; happy to extend on request.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test .\` (14 new tests, all green)
- [ ] Smoke against a live PVE cluster with a real LE account configured