### PR TITLE
feat: wrap remaining /nodes/{node}/qemu/{vmid} — firewall, cloudinit, snapshot config

### DIFF
--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -878,6 +878,132 @@ func virtualMachines() {
     "data": "UPID:node1:0000000F:0000000F:0000000F:qmdelsnapshot:100:root@pam:"
 }`)
 
+	// GET /nodes/{node}/qemu/{vmid}/snapshot/{snapname}/config
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/snapshot/snap1/config$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "description": "Before upgrade",
+        "parent": "snap0",
+        "cores": 4,
+        "memory": 8192,
+        "name": "snap1"
+    }
+}`)
+
+	// PUT /nodes/{node}/qemu/{vmid}/snapshot/{snapname}/config
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/qemu/100/snapshot/snap1/config$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// ----- Per-VM firewall (vmid 100) -----
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/firewall$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "rules": [{"pos": 0, "action": "ACCEPT", "type": "in"}],
+        "aliases": [{"name": "internal", "cidr": "10.0.0.0/8"}],
+        "ipset": [{"name": "blocked", "comment": "blocked clients"}]
+    }
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/firewall/rules/0$").
+		Reply(200).
+		JSON(`{
+    "data": {"pos": 0, "action": "ACCEPT", "type": "in", "enable": 1, "comment": "allow http"}
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/firewall/log").
+		Reply(200).
+		JSON(`{
+    "data": [
+        [0, "block: IN=eth0 SRC=1.2.3.4"],
+        [1, "block: IN=eth0 SRC=5.6.7.8"]
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/firewall/refs").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"type": "alias", "name": "internal", "comment": "vm-local"},
+        {"type": "ipset", "name": "blocked"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/firewall/aliases$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"name": "internal", "cidr": "10.0.0.0/8", "comment": "RFC1918"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/100/firewall/aliases$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/firewall/aliases/internal$").
+		Reply(200).
+		JSON(`{
+    "data": {"name": "internal", "cidr": "10.0.0.0/8", "comment": "RFC1918"}
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/qemu/100/firewall/aliases/internal$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/nodes/node1/qemu/100/firewall/aliases/internal$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// ----- Cloud-init (vmid 100) -----
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/cloudinit$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"key": "ipconfig0", "value": "ip=10.0.0.10/24,gw=10.0.0.1", "pending": "ip=10.0.0.11/24,gw=10.0.0.1"},
+        {"key": "sshkeys", "value": "ssh-rsa AAAA...old", "pending": "ssh-rsa AAAA...new"}
+    ]
+}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/qemu/100/cloudinit$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/cloudinit/dump").
+		Reply(200).
+		JSON(`{"data": "#cloud-config\nhostname: node1\n"}`)
+
 	// ----- QEMU guest-agent endpoints (vmid 101) -----
 	// All synchronous QGA wrappers return {"data": {"result": ...}} except
 	// file-read (top-level data) and file-write (null).

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -785,6 +785,29 @@ func (v *VirtualMachine) DeleteSnapshot(ctx context.Context, snapshot string) (t
 	return NewTask(upid, v.client), nil
 }
 
+// GetSnapshotConfig reads a snapshot's metadata (description, parent, etc.).
+// PVE returns a free-form map since snapshot configs include arbitrary
+// device keys snapshotted at the time of creation.
+func (v *VirtualMachine) GetSnapshotConfig(ctx context.Context, snapshot string) (config map[string]interface{}, err error) {
+	return config, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", v.Node, v.VMID, snapshot), &config)
+}
+
+// VirtualMachineSnapshotUpdateOptions is the body for PUT
+// /qemu/{vmid}/snapshot/{name}/config. PVE only lets you change the
+// description through this endpoint.
+type VirtualMachineSnapshotUpdateOptions struct {
+	Description string `json:"description,omitempty"`
+}
+
+// UpdateSnapshot updates a VM snapshot's metadata. PVE only allows changing
+// the description on this endpoint; pass nil options to clear it.
+func (v *VirtualMachine) UpdateSnapshot(ctx context.Context, snapshot string, options *VirtualMachineSnapshotUpdateOptions) error {
+	if options == nil {
+		options = &VirtualMachineSnapshotUpdateOptions{}
+	}
+	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", v.Node, v.VMID, snapshot), options, nil)
+}
+
 // RRDData takes a timeframe enum and an optional consolidation function
 // usage: vm.RRDData(HOURLY) or vm.RRDData(HOURLY, AVERAGE)
 func (v *VirtualMachine) RRDData(ctx context.Context, timeframe Timeframe, consolidationFunction ...ConsolidationFunction) (rrddata []*RRDData, err error) {

--- a/virtual_machine_cloudinit.go
+++ b/virtual_machine_cloudinit.go
@@ -1,0 +1,44 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// VirtualMachineCloudInitPending is one row from GET /qemu/{vmid}/cloudinit —
+// a single config key with its currently-applied value and a pending value if
+// a regenerate is needed. Delete=1 means the key is pending removal.
+type VirtualMachineCloudInitPending struct {
+	Delete  IntOrBool `json:"delete,omitempty"`
+	Key     string    `json:"key,omitempty"`
+	Pending string    `json:"pending,omitempty"`
+	Value   string    `json:"value,omitempty"`
+}
+
+// CloudInitPending lists per-VM cloud-init config differences between the
+// applied image and the current VM config. Empty list means the image is in
+// sync with the config.
+func (v *VirtualMachine) CloudInitPending(ctx context.Context) (pending []*VirtualMachineCloudInitPending, err error) {
+	return pending, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/cloudinit", v.Node, v.VMID), &pending)
+}
+
+// CloudInitRegenerate rewrites the cloud-init ISO/cd-rom so the next guest
+// boot picks up pending changes. Synchronous — PVE returns null on success.
+func (v *VirtualMachine) CloudInitRegenerate(ctx context.Context) error {
+	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/cloudinit", v.Node, v.VMID), nil, nil)
+}
+
+// CloudInitDump returns the rendered cloud-init configuration document of a
+// given kind. kind must be one of "user", "meta", "network".
+func (v *VirtualMachine) CloudInitDump(ctx context.Context, kind string) (string, error) {
+	if kind == "" {
+		return "", errors.New("cloudinit dump type is required (user|meta|network)")
+	}
+	q := url.Values{}
+	q.Set("type", kind)
+	var out string
+	err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/cloudinit/dump?%s", v.Node, v.VMID, q.Encode()), &out)
+	return out, err
+}

--- a/virtual_machine_cloudinit_test.go
+++ b/virtual_machine_cloudinit_test.go
@@ -1,0 +1,36 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVirtualMachine_CloudInitPending(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	pending, err := vm100().CloudInitPending(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, pending, 2)
+	assert.Equal(t, "ipconfig0", pending[0].Key)
+	assert.NotEqual(t, pending[0].Value, pending[0].Pending)
+}
+
+func TestVirtualMachine_CloudInitRegenerate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	assert.Nil(t, vm100().CloudInitRegenerate(context.Background()))
+}
+
+func TestVirtualMachine_CloudInitDump(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	out, err := vm100().CloudInitDump(context.Background(), "user")
+	assert.Nil(t, err)
+	assert.Contains(t, out, "cloud-config")
+
+	_, err = vm100().CloudInitDump(context.Background(), "")
+	assert.NotNil(t, err)
+}

--- a/virtual_machine_firewall.go
+++ b/virtual_machine_firewall.go
@@ -1,0 +1,85 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// This file closes the per-VM firewall coverage gaps under
+// /nodes/{node}/qemu/{vmid}/firewall/*. Existing rules/ipset/options helpers
+// remain in virtual_machine.go.
+
+// Firewall fetches the directory-rooted firewall record (aliases + ipset +
+// rules + options) for the VM in one call. Cheaper than four round-trips
+// when you just need a snapshot.
+func (v *VirtualMachine) Firewall(ctx context.Context) (firewall *Firewall, err error) {
+	return firewall, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall", v.Node, v.VMID), &firewall)
+}
+
+// FirewallGetRule reads a single firewall rule by position.
+func (v *VirtualMachine) FirewallGetRule(ctx context.Context, pos int) (rule *FirewallRule, err error) {
+	return rule, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/rules/%d", v.Node, v.VMID, pos), &rule)
+}
+
+// FirewallLog returns the per-VM firewall log entries. start/limit page the
+// result; since/until filter by UNIX epoch — pass 0 to omit.
+func (v *VirtualMachine) FirewallLog(ctx context.Context, start, limit, since, until int) (entries []*FirewallLogEntry, err error) {
+	path := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/log", v.Node, v.VMID)
+	q := url.Values{}
+	if start > 0 {
+		q.Set("start", strconv.Itoa(start))
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	if since > 0 {
+		q.Set("since", strconv.Itoa(since))
+	}
+	if until > 0 {
+		q.Set("until", strconv.Itoa(until))
+	}
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	return entries, v.client.Get(ctx, path, &entries)
+}
+
+// FirewallRefs lists IPSets and aliases reachable from this VM's scope —
+// useful when authoring rules that reference cluster/node-level objects
+// alongside VM-local ones. Pass refType ("alias"|"ipset"|"") to filter.
+func (v *VirtualMachine) FirewallRefs(ctx context.Context, refType string) (refs []*FirewallRef, err error) {
+	path := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/refs", v.Node, v.VMID)
+	if refType != "" {
+		q := url.Values{}
+		q.Set("type", refType)
+		path = path + "?" + q.Encode()
+	}
+	return refs, v.client.Get(ctx, path, &refs)
+}
+
+// GetFirewallAliases lists per-VM firewall aliases.
+func (v *VirtualMachine) GetFirewallAliases(ctx context.Context) (aliases []*FirewallAlias, err error) {
+	return aliases, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/aliases", v.Node, v.VMID), &aliases)
+}
+
+// NewFirewallAlias creates a per-VM firewall alias.
+func (v *VirtualMachine) NewFirewallAlias(ctx context.Context, alias *FirewallAlias) error {
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/aliases", v.Node, v.VMID), alias, nil)
+}
+
+// GetFirewallAlias reads a single per-VM firewall alias.
+func (v *VirtualMachine) GetFirewallAlias(ctx context.Context, name string) (alias *FirewallAlias, err error) {
+	return alias, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/aliases/%s", v.Node, v.VMID, name), &alias)
+}
+
+// UpdateFirewallAlias mutates an existing per-VM alias.
+func (v *VirtualMachine) UpdateFirewallAlias(ctx context.Context, name string, alias *FirewallAlias) error {
+	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/aliases/%s", v.Node, v.VMID, name), alias, nil)
+}
+
+// DeleteFirewallAlias removes a per-VM firewall alias.
+func (v *VirtualMachine) DeleteFirewallAlias(ctx context.Context, name string) error {
+	return v.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/aliases/%s", v.Node, v.VMID, name), nil)
+}

--- a/virtual_machine_firewall_test.go
+++ b/virtual_machine_firewall_test.go
@@ -1,0 +1,70 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func vm100() *VirtualMachine {
+	return &VirtualMachine{client: mockClient(), Node: "node1", VMID: 100}
+}
+
+func TestVirtualMachine_Firewall(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	fw, err := vm100().Firewall(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, fw)
+	assert.NotEmpty(t, fw.Rules)
+	assert.NotEmpty(t, fw.Aliases)
+}
+
+func TestVirtualMachine_FirewallGetRule(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	rule, err := vm100().FirewallGetRule(context.Background(), 0)
+	assert.Nil(t, err)
+	assert.NotNil(t, rule)
+	assert.Equal(t, "ACCEPT", rule.Action)
+}
+
+func TestVirtualMachine_FirewallLog(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := vm100().FirewallLog(context.Background(), 0, 50, 0, 0)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, 0, entries[0].LineNum)
+	assert.Contains(t, entries[0].Text, "block")
+}
+
+func TestVirtualMachine_FirewallRefs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	refs, err := vm100().FirewallRefs(context.Background(), "")
+	assert.Nil(t, err)
+	assert.Len(t, refs, 2)
+}
+
+func TestVirtualMachine_FirewallAliases(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := vm100()
+	ctx := context.Background()
+
+	aliases, err := vm.GetFirewallAliases(ctx)
+	assert.Nil(t, err)
+	assert.Len(t, aliases, 1)
+	assert.Equal(t, "internal", aliases[0].Name)
+
+	alias, err := vm.GetFirewallAlias(ctx, "internal")
+	assert.Nil(t, err)
+	assert.Equal(t, "10.0.0.0/8", alias.Cidr)
+
+	assert.Nil(t, vm.NewFirewallAlias(ctx, &FirewallAlias{Name: "internal", Cidr: "10.0.0.0/8"}))
+	assert.Nil(t, vm.UpdateFirewallAlias(ctx, "internal", &FirewallAlias{Cidr: "10.0.0.0/16"}))
+	assert.Nil(t, vm.DeleteFirewallAlias(ctx, "internal"))
+}

--- a/virtual_machine_snapshot_config_test.go
+++ b/virtual_machine_snapshot_config_test.go
@@ -1,0 +1,27 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVirtualMachine_GetSnapshotConfig(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cfg, err := vm100().GetSnapshotConfig(context.Background(), "snap1")
+	assert.Nil(t, err)
+	assert.Equal(t, "Before upgrade", cfg["description"])
+	assert.Equal(t, "snap0", cfg["parent"])
+}
+
+func TestVirtualMachine_UpdateSnapshot(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	err := vm100().UpdateSnapshot(context.Background(), "snap1", &VirtualMachineSnapshotUpdateOptions{Description: "renamed"})
+	assert.Nil(t, err)
+	// nil options path
+	assert.Nil(t, vm100().UpdateSnapshot(context.Background(), "snap1", nil))
+}


### PR DESCRIPTION
## Summary

Mop-up of the remaining \`/nodes/{node}/qemu/{vmid}\` gaps that are cheaply
reachable. Mirrors the LXC firewall surface that PR #277 landed plus the
cloudinit and snapshot config endpoints.

**Per-VM firewall** (new file \`virtual_machine_firewall.go\`):
- \`Firewall\`, \`FirewallGetRule\`, \`FirewallLog\`, \`FirewallRefs\`
- \`GetFirewallAliases\`, \`NewFirewallAlias\`, \`GetFirewallAlias\`, \`UpdateFirewallAlias\`, \`DeleteFirewallAlias\`

**Cloud-init** (new file \`virtual_machine_cloudinit.go\`):
- \`CloudInitPending\` — list pending cloudinit diffs
- \`CloudInitRegenerate\` — rewrite the cloudinit cd-rom
- \`CloudInitDump\` — fetch the rendered cloudinit doc (user/meta/network)

**Snapshot config** (\`virtual_machine.go\`, near existing snapshot methods):
- \`GetSnapshotConfig\` (map[string]interface{} — snapshot keys are free-form)
- \`UpdateSnapshot\` (PVE only lets you change \`description\`, mirroring LXC)

### Types added
- \`VirtualMachineCloudInitPending\` — one row of the cloudinit diff list
- \`VirtualMachineSnapshotUpdateOptions\` — PUT body for snapshot config

### Notes
- Pre-existing \`Firewall\` struct shape is shared with Container; intentionally not duplicated.
- \`Firewall.Options\` is typed as \`*FirewallNodeOption\` (per-VM should use \`*FirewallVirtualMachineOption\`) — pre-existing inconsistency, not changed here. Mock omits the options key to avoid the int-vs-bool unmarshal issue tracked by #178.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test .\` (10 new tests, all green)
- [ ] Smoke against a live PVE VM