### PR TITLE
feat: wrap /nodes/{node}/disks/* — list, SMART, GPT/wipe, directory/LVM/LVM-thin/ZFS CRUD

### DIFF
--- a/nodes_disks.go
+++ b/nodes_disks.go
@@ -1,0 +1,266 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Disks wraps the /nodes/{node}/disks/* family — physical disk discovery,
+// SMART, GPT init/wipe, and CRUD for directory / LVM / LVM-thin / ZFS
+// storages backed by raw block devices. All write ops return a Task since
+// PVE runs them via the task queue (mkfs, zpool create, etc.).
+
+// --- discovery / SMART / GPT / wipe ----------------------------------------
+
+// Disks lists every block device PVE sees on the node. Pass includePartitions
+// to also surface partition entries, skipSMART to avoid the per-disk SMART
+// probe, and diskType ("unused"|"journal_disks"|"") to filter.
+func (n *Node) Disks(ctx context.Context, includePartitions, skipSMART bool, diskType string) (disks []*Disk, err error) {
+	q := url.Values{}
+	if includePartitions {
+		q.Set("include-partitions", "1")
+	}
+	if skipSMART {
+		q.Set("skipsmart", "1")
+	}
+	if diskType != "" {
+		q.Set("type", diskType)
+	}
+	path := fmt.Sprintf("/nodes/%s/disks/list", n.Name)
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	return disks, n.client.Get(ctx, path, &disks)
+}
+
+// DiskSMART returns SMART data for one disk. Pass healthOnly=true for just
+// the "PASS"/"FAIL" string (faster — skips the full attribute dump).
+func (n *Node) DiskSMART(ctx context.Context, disk string, healthOnly bool) (smart *DiskSMART, err error) {
+	if disk == "" {
+		return nil, errors.New("disk path is required")
+	}
+	q := url.Values{}
+	q.Set("disk", disk)
+	if healthOnly {
+		q.Set("healthonly", "1")
+	}
+	return smart, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/disks/smart?%s", n.Name, q.Encode()), &smart)
+}
+
+// DiskInitGPT writes a fresh GPT partition table to disk. uuid is optional;
+// pass "" to let the kernel assign one. Returns a Task.
+func (n *Node) DiskInitGPT(ctx context.Context, disk, uuid string) (*Task, error) {
+	if disk == "" {
+		return nil, errors.New("disk path is required")
+	}
+	body := map[string]any{"disk": disk}
+	if uuid != "" {
+		body["uuid"] = uuid
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/disks/initgpt", n.Name), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// DiskWipe zeroes the first and last megabytes of disk and clears the
+// partition table — destructive. Returns a Task.
+func (n *Node) DiskWipe(ctx context.Context, disk string) (*Task, error) {
+	if disk == "" {
+		return nil, errors.New("disk path is required")
+	}
+	body := map[string]any{"disk": disk}
+	var upid UPID
+	if err := n.client.Put(ctx, fmt.Sprintf("/nodes/%s/disks/wipedisk", n.Name), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// --- directory-mount storages ----------------------------------------------
+
+// Directories lists per-node directory-mount storages backed by raw devices.
+func (n *Node) Directories(ctx context.Context) (dirs []*NodeDirectory, err error) {
+	return dirs, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/disks/directory", n.Name), &dirs)
+}
+
+// NewDirectory formats a block device and mounts it as a per-node directory
+// storage. opts.Name and opts.Device are required. opts.Filesystem defaults
+// to ext4 server-side.
+func (n *Node) NewDirectory(ctx context.Context, opts *NodeDirectoryOptions) (*Task, error) {
+	if opts == nil || opts.Name == "" || opts.Device == "" {
+		return nil, errors.New("directory name and device are required")
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/disks/directory", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// DeleteDirectory tears down a directory-mount storage. cleanupConfig also
+// removes the storage.cfg entry; cleanupDisks wipes the underlying disk so
+// it can be repurposed.
+func (n *Node) DeleteDirectory(ctx context.Context, name string, cleanupConfig, cleanupDisks bool) (*Task, error) {
+	if name == "" {
+		return nil, errors.New("directory name is required")
+	}
+	q := url.Values{}
+	if cleanupConfig {
+		q.Set("cleanup-config", "1")
+	}
+	if cleanupDisks {
+		q.Set("cleanup-disks", "1")
+	}
+	path := fmt.Sprintf("/nodes/%s/disks/directory/%s", n.Name, name)
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	var upid UPID
+	if err := n.client.Delete(ctx, path, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// --- LVM volume groups -----------------------------------------------------
+
+// LVMs returns the nested LVM tree (volume groups → physical volumes).
+func (n *Node) LVMs(ctx context.Context) (lvm *NodeLVMTree, err error) {
+	return lvm, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/disks/lvm", n.Name), &lvm)
+}
+
+// NewLVM creates an LVM volume group on a block device. opts.Name and
+// opts.Device are required.
+func (n *Node) NewLVM(ctx context.Context, opts *NodeLVMOptions) (*Task, error) {
+	if opts == nil || opts.Name == "" || opts.Device == "" {
+		return nil, errors.New("lvm name and device are required")
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/disks/lvm", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// DeleteLVM removes an LVM volume group. See DeleteDirectory for cleanup
+// semantics.
+func (n *Node) DeleteLVM(ctx context.Context, name string, cleanupConfig, cleanupDisks bool) (*Task, error) {
+	if name == "" {
+		return nil, errors.New("lvm name is required")
+	}
+	q := url.Values{}
+	if cleanupConfig {
+		q.Set("cleanup-config", "1")
+	}
+	if cleanupDisks {
+		q.Set("cleanup-disks", "1")
+	}
+	path := fmt.Sprintf("/nodes/%s/disks/lvm/%s", n.Name, name)
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	var upid UPID
+	if err := n.client.Delete(ctx, path, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// --- LVM-thin pools --------------------------------------------------------
+
+// LVMThins lists LVM-thin pools.
+func (n *Node) LVMThins(ctx context.Context) (thins []*NodeLVMThin, err error) {
+	return thins, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/disks/lvmthin", n.Name), &thins)
+}
+
+// NewLVMThin creates an LVM-thin pool on a block device.
+func (n *Node) NewLVMThin(ctx context.Context, opts *NodeLVMThinOptions) (*Task, error) {
+	if opts == nil || opts.Name == "" || opts.Device == "" {
+		return nil, errors.New("lvmthin name and device are required")
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/disks/lvmthin", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// DeleteLVMThin removes an LVM-thin pool. Unlike directory / LVM / ZFS,
+// this endpoint *requires* the parent volume-group name to disambiguate
+// when a node has multiple VGs containing thin pools by the same name.
+func (n *Node) DeleteLVMThin(ctx context.Context, name, volumeGroup string, cleanupConfig, cleanupDisks bool) (*Task, error) {
+	if name == "" || volumeGroup == "" {
+		return nil, errors.New("lvmthin name and volume-group are required")
+	}
+	q := url.Values{}
+	q.Set("volume-group", volumeGroup)
+	if cleanupConfig {
+		q.Set("cleanup-config", "1")
+	}
+	if cleanupDisks {
+		q.Set("cleanup-disks", "1")
+	}
+	path := fmt.Sprintf("/nodes/%s/disks/lvmthin/%s?%s", n.Name, name, q.Encode())
+	var upid UPID
+	if err := n.client.Delete(ctx, path, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// --- ZFS pools -------------------------------------------------------------
+
+// ZFSPools lists ZFS pools visible to PVE on the node.
+func (n *Node) ZFSPools(ctx context.Context) (pools []*NodeZFSPoolSummary, err error) {
+	return pools, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/disks/zfs", n.Name), &pools)
+}
+
+// ZFSPool returns the detailed status of a single pool, including the
+// underlying vdev/device tree and any failure-action recommendation.
+func (n *Node) ZFSPool(ctx context.Context, name string) (pool *NodeZFSPool, err error) {
+	if name == "" {
+		return nil, errors.New("zfs pool name is required")
+	}
+	return pool, n.client.Get(ctx, fmt.Sprintf("/nodes/%s/disks/zfs/%s", n.Name, name), &pool)
+}
+
+// NewZFSPool creates a ZFS pool. opts.Name, opts.Devices (space-separated),
+// and opts.RaidLevel are required.
+func (n *Node) NewZFSPool(ctx context.Context, opts *NodeZFSPoolOptions) (*Task, error) {
+	if opts == nil || opts.Name == "" || opts.Devices == "" || opts.RaidLevel == "" {
+		return nil, errors.New("zfs pool name, devices, and raidlevel are required")
+	}
+	var upid UPID
+	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/disks/zfs", n.Name), opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}
+
+// DeleteZFSPool destroys a ZFS pool. cleanupConfig/cleanupDisks semantics
+// match DeleteDirectory.
+func (n *Node) DeleteZFSPool(ctx context.Context, name string, cleanupConfig, cleanupDisks bool) (*Task, error) {
+	if name == "" {
+		return nil, errors.New("zfs pool name is required")
+	}
+	q := url.Values{}
+	if cleanupConfig {
+		q.Set("cleanup-config", "1")
+	}
+	if cleanupDisks {
+		q.Set("cleanup-disks", "1")
+	}
+	path := fmt.Sprintf("/nodes/%s/disks/zfs/%s", n.Name, name)
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	var upid UPID
+	if err := n.client.Delete(ctx, path, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, n.client), nil
+}

--- a/nodes_disks_test.go
+++ b/nodes_disks_test.go
@@ -1,0 +1,175 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func diskNode() *Node {
+	return &Node{client: mockClient(), Name: "node1"}
+}
+
+func TestNode_Disks(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	disks, err := diskNode().Disks(context.Background(), false, false, "")
+	assert.Nil(t, err)
+	assert.Len(t, disks, 2)
+	assert.Equal(t, "/dev/sda", disks[0].DevPath)
+	assert.Equal(t, "ssd", disks[0].Type)
+}
+
+func TestNode_DiskSMART(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	smart, err := diskNode().DiskSMART(context.Background(), "/dev/sda", false)
+	assert.Nil(t, err)
+	assert.Equal(t, "PASSED", smart.Health)
+
+	_, err = diskNode().DiskSMART(context.Background(), "", false)
+	assert.NotNil(t, err)
+}
+
+func TestNode_DiskInitGPT(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().DiskInitGPT(context.Background(), "/dev/sda", "")
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "diskinit", task.Type)
+
+	_, err = diskNode().DiskInitGPT(context.Background(), "", "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_DiskWipe(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().DiskWipe(context.Background(), "/dev/sda")
+	assert.Nil(t, err)
+	assert.Equal(t, "wipedisk", task.Type)
+}
+
+func TestNode_Directories(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	dirs, err := diskNode().Directories(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, dirs, 1)
+	assert.Equal(t, "/mnt/pve/iso", dirs[0].Path)
+}
+
+func TestNode_NewDirectory(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().NewDirectory(context.Background(), &NodeDirectoryOptions{Name: "iso", Device: "/dev/sda1"})
+	assert.Nil(t, err)
+	assert.Equal(t, "mkdir", task.Type)
+
+	_, err = diskNode().NewDirectory(context.Background(), nil)
+	assert.NotNil(t, err)
+}
+
+func TestNode_DeleteDirectory(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().DeleteDirectory(context.Background(), "iso", true, true)
+	assert.Nil(t, err)
+	assert.Equal(t, "rmdir", task.Type)
+
+	_, err = diskNode().DeleteDirectory(context.Background(), "", false, false)
+	assert.NotNil(t, err)
+}
+
+func TestNode_LVMs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	lvm, err := diskNode().LVMs(context.Background())
+	assert.Nil(t, err)
+	assert.NotEmpty(t, lvm.Children)
+	assert.Equal(t, "pve", lvm.Children[0].Name)
+}
+
+func TestNode_NewLVM(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().NewLVM(context.Background(), &NodeLVMOptions{Name: "pve", Device: "/dev/sda"})
+	assert.Nil(t, err)
+	assert.Equal(t, "mklvm", task.Type)
+}
+
+func TestNode_DeleteLVM(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().DeleteLVM(context.Background(), "pve", false, false)
+	assert.Nil(t, err)
+	assert.Equal(t, "rmlvm", task.Type)
+}
+
+func TestNode_LVMThins(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	thins, err := diskNode().LVMThins(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, thins, 1)
+	assert.Equal(t, "data", thins[0].LV)
+}
+
+func TestNode_NewLVMThin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().NewLVMThin(context.Background(), &NodeLVMThinOptions{Name: "data", Device: "/dev/sdb"})
+	assert.Nil(t, err)
+	assert.Equal(t, "mklvmthin", task.Type)
+}
+
+func TestNode_DeleteLVMThin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().DeleteLVMThin(context.Background(), "data", "pve", true, false)
+	assert.Nil(t, err)
+	assert.Equal(t, "rmlvmthin", task.Type)
+
+	_, err = diskNode().DeleteLVMThin(context.Background(), "data", "", false, false)
+	assert.NotNil(t, err)
+}
+
+func TestNode_ZFSPools(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	pools, err := diskNode().ZFSPools(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, pools, 1)
+	assert.Equal(t, "rpool", pools[0].Name)
+}
+
+func TestNode_ZFSPool(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	pool, err := diskNode().ZFSPool(context.Background(), "rpool")
+	assert.Nil(t, err)
+	assert.Equal(t, "ONLINE", pool.State)
+	assert.NotEmpty(t, pool.Children)
+}
+
+func TestNode_NewZFSPool(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().NewZFSPool(context.Background(), &NodeZFSPoolOptions{Name: "rpool", Devices: "/dev/sda /dev/sdb", RaidLevel: "mirror"})
+	assert.Nil(t, err)
+	assert.Equal(t, "mkzfs", task.Type)
+
+	_, err = diskNode().NewZFSPool(context.Background(), nil)
+	assert.NotNil(t, err)
+}
+
+func TestNode_DeleteZFSPool(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := diskNode().DeleteZFSPool(context.Background(), "rpool", true, true)
+	assert.Nil(t, err)
+	assert.Equal(t, "rmzfs", task.Type)
+}

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -954,4 +954,136 @@ func nodes() {
 			{"Package": "pve-manager", "Title": "Proxmox VE Management", "Description": "PVE manager", "Version": "9.1-1", "Origin": "Proxmox", "Arch": "amd64", "Section": "admin", "Priority": "optional", "CurrentState": "Installed", "ManagerVersion": "9.1-1"},
 			{"Package": "proxmox-ve", "Title": "Proxmox VE", "Description": "Proxmox VE metapackage", "Version": "9.1-1", "Origin": "Proxmox", "Arch": "all", "Section": "admin", "Priority": "optional", "CurrentState": "Installed", "RunningKernel": "6.8.12-1-pve"}
 		]}`)
+
+	// --- /nodes/{node}/disks -------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks/list").
+		Reply(200).
+		JSON(`{"data": [
+			{"devpath": "/dev/sda", "size": 512000000000, "model": "Samsung SSD 870 EVO", "type": "ssd", "health": "PASSED", "gpt": 1, "used": "LVM"},
+			{"devpath": "/dev/sdb", "size": 2000000000000, "model": "Seagate ST2000DM008", "type": "hdd", "health": "PASSED", "gpt": 0}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks/smart").
+		Reply(200).
+		JSON(`{"data": {"health": "PASSED", "type": "ata", "attributes": []}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/disks/initgpt$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:diskinit:/dev/sda:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/disks/wipedisk$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:wipedisk:/dev/sda:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks/directory$").
+		Reply(200).
+		JSON(`{"data": [
+			{"path": "/mnt/pve/iso", "device": "/dev/sda1", "type": "ext4", "options": "defaults"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/disks/directory$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:mkdir:iso:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/disks/directory/iso").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:rmdir:iso:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks/lvm$").
+		Reply(200).
+		JSON(`{"data": {
+			"leaf": 0,
+			"children": [
+				{"name": "pve", "size": 500000000000, "free": 100000000000, "leaf": 0, "children": [
+					{"name": "/dev/sda", "size": 500000000000, "free": 100000000000, "leaf": 1}
+				]}
+			]
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/disks/lvm$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:mklvm:pve:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/disks/lvm/pve").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:rmlvm:pve:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks/lvmthin$").
+		Reply(200).
+		JSON(`{"data": [
+			{"lv": "data", "lv_size": 400000000000, "metadata_size": 100000000, "metadata_used": 1000000, "used": 50000000000}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/disks/lvmthin$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:mklvmthin:data:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/disks/lvmthin/data").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:rmlvmthin:data:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks/zfs$").
+		Reply(200).
+		JSON(`{"data": [
+			{"name": "rpool", "health": "ONLINE", "size": 1000000000000, "alloc": 200000000000, "free": 800000000000, "frag": 5, "dedup": 1.0}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks/zfs/rpool$").
+		Reply(200).
+		JSON(`{"data": {
+			"name": "rpool",
+			"state": "ONLINE",
+			"status": "healthy",
+			"scan": "scrub repaired 0B in 00:12:34 with 0 errors on Sun Apr 14 00:24:35 2024",
+			"errors": "No known data errors",
+			"children": [
+				{"name": "raidz2-0", "state": "ONLINE", "leaf": 0, "children": [
+					{"name": "/dev/sda", "state": "ONLINE", "leaf": 1, "read": 0, "write": 0, "cksum": 0},
+					{"name": "/dev/sdb", "state": "ONLINE", "leaf": 1, "read": 0, "write": 0, "cksum": 0}
+				]}
+			]
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/disks/zfs$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:mkzfs:rpool:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/disks/zfs/rpool").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:rmzfs:rpool:root@pam:"}`)
 }

--- a/types.go
+++ b/types.go
@@ -2825,6 +2825,147 @@ type ClusterMetricServerOptions struct {
 	Delete                 string `json:"delete,omitempty"`              // PUT only — comma-separated keys to clear
 }
 
+// --- /nodes/{node}/disks ---------------------------------------------------
+
+// Disk is one row returned by GET /nodes/{node}/disks/list. Fields are
+// best-effort optional — PVE omits keys that don't apply to a given device.
+type Disk struct {
+	DevPath     string    `json:"devpath,omitempty"`
+	Used        string    `json:"used,omitempty"`
+	GPT         IntOrBool `json:"gpt,omitempty"`
+	Size        uint64    `json:"size,omitempty"`
+	Health      string    `json:"health,omitempty"`
+	Model       string    `json:"model,omitempty"`
+	Serial      string    `json:"serial,omitempty"`
+	Type        string    `json:"type,omitempty"`
+	Vendor      string    `json:"vendor,omitempty"`
+	WWN         string    `json:"wwn,omitempty"`
+	ByIDLink    string    `json:"by_id_link,omitempty"`
+	Wearout     string    `json:"wearout,omitempty"`
+	OSDID       int       `json:"osdid,omitempty"`
+	OSDEncrypted IntOrBool `json:"osdencrypted,omitempty"`
+	Parent      string    `json:"parent,omitempty"`
+	RPM         int       `json:"rpm,omitempty"`
+	BLKSize     int       `json:"blocksize,omitempty"`
+	MountPoint  string    `json:"mounted,omitempty"`
+	Vendor2     string    `json:"vendor2,omitempty"`
+}
+
+// DiskSMART is the response from GET /nodes/{node}/disks/smart.
+type DiskSMART struct {
+	Health     string                 `json:"health,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	Text       string                 `json:"text,omitempty"`
+	Attributes []map[string]any       `json:"attributes,omitempty"`
+}
+
+// NodeDirectory is one row returned by GET /nodes/{node}/disks/directory.
+type NodeDirectory struct {
+	Device  string `json:"device,omitempty"`
+	Options string `json:"options,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Type    string `json:"type,omitempty"`
+	UUID    string `json:"unitfile,omitempty"`
+}
+
+// NodeDirectoryOptions is the POST body for /nodes/{node}/disks/directory.
+type NodeDirectoryOptions struct {
+	Name       string `json:"name"`
+	Device     string `json:"device"`
+	Filesystem string `json:"filesystem,omitempty"` // PVE default ext4
+	AddStorage IntOrBool `json:"add_storage,omitempty"`
+}
+
+// NodeLVMTree is the nested response from GET /nodes/{node}/disks/lvm. Each
+// child is a volume group whose own children are the constituent physical
+// volumes.
+type NodeLVMTree struct {
+	Children []NodeLVMVolumeGroup `json:"children,omitempty"`
+	Leaf     IntOrBool            `json:"leaf,omitempty"`
+}
+
+type NodeLVMVolumeGroup struct {
+	Name     string             `json:"name,omitempty"`
+	Size     uint64             `json:"size,omitempty"`
+	Free     uint64             `json:"free,omitempty"`
+	Leaf     IntOrBool          `json:"leaf,omitempty"`
+	Children []NodeLVMPhysical  `json:"children,omitempty"`
+}
+
+type NodeLVMPhysical struct {
+	Name string `json:"name,omitempty"`
+	Size uint64 `json:"size,omitempty"`
+	Free uint64 `json:"free,omitempty"`
+	Leaf IntOrBool `json:"leaf,omitempty"`
+}
+
+// NodeLVMOptions is the POST body for /nodes/{node}/disks/lvm.
+type NodeLVMOptions struct {
+	Name       string    `json:"name"`
+	Device     string    `json:"device"`
+	AddStorage IntOrBool `json:"add_storage,omitempty"`
+}
+
+// NodeLVMThin is one row from GET /nodes/{node}/disks/lvmthin.
+type NodeLVMThin struct {
+	LV           string `json:"lv,omitempty"`
+	LVSize       uint64 `json:"lv_size,omitempty"`
+	MetadataSize uint64 `json:"metadata_size,omitempty"`
+	MetadataUsed uint64 `json:"metadata_used,omitempty"`
+	Used         uint64 `json:"used,omitempty"`
+}
+
+// NodeLVMThinOptions is the POST body for /nodes/{node}/disks/lvmthin.
+type NodeLVMThinOptions struct {
+	Name       string    `json:"name"`
+	Device     string    `json:"device"`
+	AddStorage IntOrBool `json:"add_storage,omitempty"`
+}
+
+// NodeZFSPoolSummary is one row from GET /nodes/{node}/disks/zfs.
+type NodeZFSPoolSummary struct {
+	Name    string  `json:"name,omitempty"`
+	Health  string  `json:"health,omitempty"`
+	Size    uint64  `json:"size,omitempty"`
+	Alloc   uint64  `json:"alloc,omitempty"`
+	Free    uint64  `json:"free,omitempty"`
+	Frag    int     `json:"frag,omitempty"`
+	Dedup   float64 `json:"dedup,omitempty"`
+}
+
+// NodeZFSPool is the detailed pool status from GET /nodes/{node}/disks/zfs/{name}.
+type NodeZFSPool struct {
+	Name     string           `json:"name,omitempty"`
+	State    string           `json:"state,omitempty"`
+	Status   string           `json:"status,omitempty"`
+	Action   string           `json:"action,omitempty"`
+	Scan     string           `json:"scan,omitempty"`
+	Errors   string           `json:"errors,omitempty"`
+	Children []NodeZFSVdev    `json:"children,omitempty"`
+}
+
+type NodeZFSVdev struct {
+	Name     string        `json:"name,omitempty"`
+	State    string        `json:"state,omitempty"`
+	Read     uint64        `json:"read,omitempty"`
+	Write    uint64        `json:"write,omitempty"`
+	Cksum    uint64        `json:"cksum,omitempty"`
+	Msg      string        `json:"msg,omitempty"`
+	Children []NodeZFSVdev `json:"children,omitempty"`
+	Leaf     IntOrBool     `json:"leaf,omitempty"`
+}
+
+// NodeZFSPoolOptions is the POST body for /nodes/{node}/disks/zfs.
+type NodeZFSPoolOptions struct {
+	Name        string    `json:"name"`
+	Devices     string    `json:"devices"` // space-separated device list per PVE
+	RaidLevel   string    `json:"raidlevel"`
+	Ashift      int       `json:"ashift,omitempty"`
+	Compression string    `json:"compression,omitempty"`
+	DraidConfig string    `json:"draid-config,omitempty"`
+	AddStorage  IntOrBool `json:"add_storage,omitempty"`
+}
+
 // ClusterMappings is the directory index returned by GET /cluster/mapping.
 type ClusterMappings []*ClusterMappingIndexEntry
 


### PR DESCRIPTION
## Summary

Closes the \`/nodes/{node}/disks\` coverage gap (0/18 → 18/18). Bare-metal
provisioning workflows have been a recurring gap; this lands the full surface
in one PR.

All write operations return \`*Task\` since PVE runs disk-level operations
via its task queue (mkfs, zpool create, etc. are not instant).

### Discovery / single-disk
- \`Disks\` — list block devices (with optional partition / SMART skip / type filter)
- \`DiskSMART\` — SMART data (with \`healthOnly\` fast path)
- \`DiskInitGPT\` — write a fresh GPT partition table
- \`DiskWipe\` — zero first/last MB + clear partition table

### Directory-mount storages
- \`Directories\`, \`NewDirectory\`, \`DeleteDirectory\`

### LVM
- \`LVMs\`, \`NewLVM\`, \`DeleteLVM\`

### LVM-thin
- \`LVMThins\`, \`NewLVMThin\`, \`DeleteLVMThin\` *(requires volume-group param)*

### ZFS
- \`ZFSPools\`, \`ZFSPool\` (single-pool detail), \`NewZFSPool\`, \`DeleteZFSPool\`

### Schema notes
- \`DeleteLVMThin\` is the odd one — PVE requires the parent VG name as a query param to disambiguate thin pools that share names across VGs.
- \`NodeLVMTree\` is nested (VG → PV); typed accordingly.
- \`NodeZFSPool.Children\` recurses (vdev → device) — typed as \`NodeZFSVdev\` with self-reference.
- All \`cleanup-config\` / \`cleanup-disks\` params on DELETE endpoints are exposed as Go bools.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test .\` (17 new tests, all green)
- [ ] Smoke against a live PVE node with spare disks