### PR TITLE
feat: wrap /cluster/jobs — realm-sync CRUD + schedule-analyze

### DIFF
--- a/cluster_jobs.go
+++ b/cluster_jobs.go
@@ -1,0 +1,86 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// Jobs lists the resource-type directory under /cluster/jobs (just
+// "realm-sync" today, but PVE may grow other recurring job kinds).
+func (cl *Cluster) Jobs(ctx context.Context) (entries []*ClusterJobIndexEntry, err error) {
+	err = cl.client.Get(ctx, "/cluster/jobs", &entries)
+	return
+}
+
+// ScheduleAnalyze simulates a systemd-style calendar event and returns the
+// next iterations firings. iterations defaults to 10 server-side when 0;
+// startTime in UNIX seconds (0 = "now").
+func (cl *Cluster) ScheduleAnalyze(ctx context.Context, schedule string, iterations, startTime int) (preview []*ClusterScheduleEvent, err error) {
+	if schedule == "" {
+		err = errors.New("schedule is required")
+		return
+	}
+	q := url.Values{}
+	q.Set("schedule", schedule)
+	if iterations > 0 {
+		q.Set("iterations", strconv.Itoa(iterations))
+	}
+	if startTime > 0 {
+		q.Set("starttime", strconv.Itoa(startTime))
+	}
+	err = cl.client.Get(ctx, "/cluster/jobs/schedule-analyze?"+q.Encode(), &preview)
+	return
+}
+
+// --- realm-sync jobs --------------------------------------------------------
+
+// RealmSyncJobs lists configured realm-sync (LDAP/AD/OIDC) jobs.
+func (cl *Cluster) RealmSyncJobs(ctx context.Context) (jobs []*ClusterRealmSyncJob, err error) {
+	err = cl.client.Get(ctx, "/cluster/jobs/realm-sync", &jobs)
+	return
+}
+
+// RealmSyncJob reads a single realm-sync job by id.
+func (cl *Cluster) RealmSyncJob(ctx context.Context, id string) (job *ClusterRealmSyncJob, err error) {
+	if id == "" {
+		err = errors.New("realm-sync job id is required")
+		return
+	}
+	err = cl.client.Get(ctx, fmt.Sprintf("/cluster/jobs/realm-sync/%s", id), &job)
+	return
+}
+
+// NewRealmSyncJob creates a realm-sync job. PVE puts the id in the URL (not
+// the body) and requires opts.Schedule.
+func (cl *Cluster) NewRealmSyncJob(ctx context.Context, id string, opts *ClusterRealmSyncJobOptions) error {
+	if id == "" {
+		return errors.New("realm-sync job id is required")
+	}
+	if opts == nil || opts.Schedule == "" {
+		return errors.New("realm-sync job schedule is required")
+	}
+	return cl.client.Post(ctx, fmt.Sprintf("/cluster/jobs/realm-sync/%s", id), opts, nil)
+}
+
+// UpdateRealmSyncJob mutates an existing job. Pass opts.Delete (comma list)
+// to reset specific keys back to PVE defaults.
+func (cl *Cluster) UpdateRealmSyncJob(ctx context.Context, id string, opts *ClusterRealmSyncJobOptions) error {
+	if id == "" {
+		return errors.New("realm-sync job id is required")
+	}
+	if opts == nil {
+		opts = &ClusterRealmSyncJobOptions{}
+	}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/jobs/realm-sync/%s", id), opts, nil)
+}
+
+// DeleteRealmSyncJob removes a realm-sync job.
+func (cl *Cluster) DeleteRealmSyncJob(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("realm-sync job id is required")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/jobs/realm-sync/%s", id), nil)
+}

--- a/cluster_jobs_test.go
+++ b/cluster_jobs_test.go
@@ -1,0 +1,96 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_Jobs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.Jobs(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+}
+
+func TestCluster_ScheduleAnalyze(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	preview, err := cluster.ScheduleAnalyze(context.Background(), "daily", 5, 0)
+	assert.Nil(t, err)
+	assert.Len(t, preview, 2)
+	assert.NotZero(t, preview[0].Timestamp)
+
+	_, err = cluster.ScheduleAnalyze(context.Background(), "", 0, 0)
+	assert.NotNil(t, err)
+}
+
+func TestCluster_RealmSyncJobs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	jobs, err := cluster.RealmSyncJobs(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, jobs, 1)
+	assert.Equal(t, "ldap-sync", jobs[0].ID)
+}
+
+func TestCluster_RealmSyncJob(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	job, err := cluster.RealmSyncJob(context.Background(), "ldap-sync")
+	assert.Nil(t, err)
+	assert.Equal(t, "ldap1", job.Realm)
+
+	_, err = cluster.RealmSyncJob(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestCluster_NewRealmSyncJob(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewRealmSyncJob(context.Background(), "ldap-sync", &ClusterRealmSyncJobOptions{Schedule: "daily", Realm: "ldap1"})
+	assert.Nil(t, err)
+
+	err = cluster.NewRealmSyncJob(context.Background(), "", nil)
+	assert.NotNil(t, err)
+
+	err = cluster.NewRealmSyncJob(context.Background(), "ldap-sync", &ClusterRealmSyncJobOptions{})
+	assert.NotNil(t, err)
+}
+
+func TestCluster_UpdateRealmSyncJob(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.UpdateRealmSyncJob(context.Background(), "ldap-sync", &ClusterRealmSyncJobOptions{Comment: "updated"})
+	assert.Nil(t, err)
+
+	err = cluster.UpdateRealmSyncJob(context.Background(), "", nil)
+	assert.NotNil(t, err)
+}
+
+func TestCluster_DeleteRealmSyncJob(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.DeleteRealmSyncJob(context.Background(), "ldap-sync")
+	assert.Nil(t, err)
+
+	err = cluster.DeleteRealmSyncJob(context.Background(), "")
+	assert.NotNil(t, err)
+}

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -1096,4 +1096,61 @@ func clusterBackup() {
 		Delete("^/cluster/notifications/endpoints/webhook/wh1$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// --- /cluster/jobs -------------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/jobs$").
+		Reply(200).
+		JSON(`{"data": [{"subdir": "realm-sync"}, {"subdir": "schedule-analyze"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/jobs/schedule-analyze").
+		Reply(200).
+		JSON(`{"data": [
+			{"timestamp": 1715731200, "utc": "2026-05-15 00:00:00"},
+			{"timestamp": 1715817600, "utc": "2026-05-16 00:00:00"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/jobs/realm-sync$").
+		Reply(200).
+		JSON(`{"data": [
+			{"id": "ldap-sync", "realm": "ldap1", "schedule": "daily", "enabled": 1, "enable-new": 1, "scope": "both"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/jobs/realm-sync/ldap-sync$").
+		Reply(200).
+		JSON(`{"data": {
+			"id": "ldap-sync",
+			"realm": "ldap1",
+			"schedule": "daily",
+			"enabled": 1,
+			"enable-new": 1,
+			"scope": "both",
+			"remove-vanished": "none",
+			"comment": "daily LDAP sync"
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/jobs/realm-sync/ldap-sync$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/jobs/realm-sync/ldap-sync$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Delete("^/cluster/jobs/realm-sync/ldap-sync$").
+		Reply(200).
+		JSON(`{"data": null}`)
 }

--- a/types.go
+++ b/types.go
@@ -2825,6 +2825,48 @@ type ClusterMetricServerOptions struct {
 	Delete                 string `json:"delete,omitempty"`              // PUT only — comma-separated keys to clear
 }
 
+// --- /cluster/jobs ---------------------------------------------------------
+
+// ClusterJobIndexEntry is one row in the /cluster/jobs directory index.
+type ClusterJobIndexEntry struct {
+	SubDir string `json:"subdir,omitempty"`
+}
+
+// ClusterScheduleEvent is one firing in the schedule-analyze preview — a
+// human-readable UTC timestamp + UNIX epoch.
+type ClusterScheduleEvent struct {
+	Timestamp int64  `json:"timestamp,omitempty"`
+	UTC       string `json:"utc,omitempty"`
+}
+
+// ClusterRealmSyncJob is the GET shape for a realm-sync job. PVE returns
+// Enabled / EnableNew as integers; using IntOrBool to stay safe.
+type ClusterRealmSyncJob struct {
+	ID             string    `json:"id,omitempty"`
+	Comment        string    `json:"comment,omitempty"`
+	EnableNew      IntOrBool `json:"enable-new,omitempty"`
+	Enabled        IntOrBool `json:"enabled,omitempty"`
+	LastRun        int64     `json:"last-run,omitempty"`
+	NextRun        int64     `json:"next-run,omitempty"`
+	Realm          string    `json:"realm,omitempty"`
+	RemoveVanished string    `json:"remove-vanished,omitempty"`
+	Schedule       string    `json:"schedule,omitempty"`
+	Scope          string    `json:"scope,omitempty"`
+}
+
+// ClusterRealmSyncJobOptions is the body for both POST (create) and PUT
+// (update). Pointer fields preserve PVE's defaults when unset.
+type ClusterRealmSyncJobOptions struct {
+	Comment        string `json:"comment,omitempty"`
+	EnableNew      *bool  `json:"enable-new,omitempty"` // PVE default true; pointer so unset doesn't flip
+	Enabled        *bool  `json:"enabled,omitempty"`    // PVE default true; pointer so unset doesn't flip
+	Realm          string `json:"realm,omitempty"`      // POST only — identifies the auth realm
+	RemoveVanished string `json:"remove-vanished,omitempty"`
+	Schedule       string `json:"schedule,omitempty"` // required on create
+	Scope          string `json:"scope,omitempty"`
+	Delete         string `json:"delete,omitempty"` // PUT only — comma-separated keys to clear
+}
+
 // ClusterMappings is the directory index returned by GET /cluster/mapping.
 type ClusterMappings []*ClusterMappingIndexEntry
 


### PR DESCRIPTION
## Summary

Closes the `/cluster/jobs` gap (0/7 → 7/7).

- `Jobs` — directory index
- `ScheduleAnalyze` — preview next N firings of a systemd-style calendar expression
- `RealmSyncJobs` / `RealmSyncJob` — list / read
- `NewRealmSyncJob` / `UpdateRealmSyncJob` / `DeleteRealmSyncJob` — write

### Notes
- The realm-sync POST endpoint is at `/cluster/jobs/realm-sync/{id}` (the id is in the path, not the body), unlike most PVE create endpoints. `NewRealmSyncJob` takes `id` as a separate parameter.
- `Enabled` / `EnableNew` are `*bool` on the options struct (PVE defaults true) so unset doesn't silently flip the job off.

## Test plan
- [x] `go build ./...`
- [x] `go test .` (7 new tests, all green)