### PR TITLE
feat: wrap /access/tfa and /access/openid — modern TFA + OIDC login

### DIFF
--- a/access_openid.go
+++ b/access_openid.go
@@ -1,0 +1,59 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+)
+
+// OpenIDAuthURLResponse is what PVE returns from POST /access/openid/auth-url
+// — a URL the caller redirects the browser to so the user can authenticate
+// with the configured OIDC provider.
+type OpenIDAuthURLResponse string
+
+// OpenIDLoginResponse is the post-callback exchange result — same shape as
+// the regular /access/ticket login response (ticket + CSRF token + user).
+type OpenIDLoginResponse struct {
+	Ticket              string `json:"ticket,omitempty"`
+	CSRFPreventionToken string `json:"CSRFPreventionToken,omitempty"`
+	Username            string `json:"username,omitempty"`
+	Cap                 any    `json:"cap,omitempty"`
+	ClusterName         string `json:"clustername,omitempty"`
+}
+
+// OpenIDAuthURL kicks off the OIDC flow. realm names the configured PVE OIDC
+// realm; redirectURL is where the IdP will redirect after authentication
+// (must match what's registered with the IdP). Returns the URL the caller
+// should send the browser to.
+func (c *Client) OpenIDAuthURL(ctx context.Context, realm, redirectURL string) (string, error) {
+	if realm == "" || redirectURL == "" {
+		return "", errors.New("realm and redirect-url are required")
+	}
+	body := map[string]string{
+		"realm":        realm,
+		"redirect-url": redirectURL,
+	}
+	var url string
+	if err := c.Post(ctx, "/access/openid/auth-url", body, &url); err != nil {
+		return "", err
+	}
+	return url, nil
+}
+
+// OpenIDLogin completes the OIDC dance after the IdP has redirected back to
+// our redirectURL with code + state query params. PVE returns a normal
+// session ticket on success.
+func (c *Client) OpenIDLogin(ctx context.Context, code, state, redirectURL string) (*OpenIDLoginResponse, error) {
+	if code == "" || state == "" || redirectURL == "" {
+		return nil, errors.New("code, state, and redirect-url are required")
+	}
+	body := map[string]string{
+		"code":         code,
+		"state":        state,
+		"redirect-url": redirectURL,
+	}
+	resp := &OpenIDLoginResponse{}
+	if err := c.Post(ctx, "/access/openid/login", body, resp); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/access_openid_test.go
+++ b/access_openid_test.go
@@ -1,0 +1,36 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_OpenIDAuthURL(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	url, err := mockClient().OpenIDAuthURL(context.Background(), "oidc1", "https://pve.example.com/callback")
+	assert.Nil(t, err)
+	assert.Contains(t, url, "https://idp.example.com")
+
+	_, err = mockClient().OpenIDAuthURL(context.Background(), "", "https://pve.example.com/callback")
+	assert.NotNil(t, err)
+
+	_, err = mockClient().OpenIDAuthURL(context.Background(), "oidc1", "")
+	assert.NotNil(t, err)
+}
+
+func TestClient_OpenIDLogin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	resp, err := mockClient().OpenIDLogin(context.Background(), "code123", "state456", "https://pve.example.com/callback")
+	assert.Nil(t, err)
+	assert.Equal(t, "alice@pve", resp.Username)
+	assert.NotEmpty(t, resp.Ticket)
+	assert.NotEmpty(t, resp.CSRFPreventionToken)
+
+	_, err = mockClient().OpenIDLogin(context.Background(), "", "state", "url")
+	assert.NotNil(t, err)
+}

--- a/access_tfa.go
+++ b/access_tfa.go
@@ -1,0 +1,137 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// This file wraps /access/tfa/* — the modern TFA endpoint family that
+// supports listing, adding, updating, and removing individual TFA entries
+// per user. The older /access/users/{userid}/tfa surface (which returns the
+// summary `TFA` struct) is wrapped in access.go as User.GetTFA and is
+// retained for backward compatibility.
+
+// TFAUserEntry is one row in GET /access/tfa — a user that has at least one
+// TFA entry configured.
+type TFAUserEntry struct {
+	UserID  string         `json:"userid,omitempty"`
+	Entries []TFAEntryInfo `json:"entries,omitempty"`
+	TOTP    bool           `json:"totp,omitempty"`
+	YubicoOTP bool         `json:"yubico,omitempty"`
+	U2F     bool           `json:"u2f,omitempty"`
+	Webauthn bool          `json:"webauthn,omitempty"`
+	Recovery []int         `json:"recovery,omitempty"`
+}
+
+// TFAEntryInfo is the read shape of a single TFA entry.
+type TFAEntryInfo struct {
+	ID          string    `json:"id,omitempty"`
+	Type        string    `json:"type,omitempty"` // totp | webauthn | u2f | yubico | recovery
+	Description string    `json:"description,omitempty"`
+	Created     int64     `json:"created,omitempty"`
+	Enable      IntOrBool `json:"enable,omitempty"`
+}
+
+// TFAEntryOptions is the POST body for adding a TFA entry.
+//   - Type is required ("totp" | "webauthn" | "u2f" | "yubico" | "recovery").
+//   - For TOTP: set TOTP (the otpauth:// URI) and Value (the current OTP to prove enrollment).
+//   - For Webauthn/U2F: set Challenge / Value with the client's signed assertion.
+//   - Password is the requesting user's current password (required when changing another user's TFA).
+type TFAEntryOptions struct {
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+	TOTP        string `json:"totp,omitempty"`
+	Value       string `json:"value,omitempty"`
+	Challenge   string `json:"challenge,omitempty"`
+	Password    string `json:"password,omitempty"`
+}
+
+// TFAEntryUpdateOptions is the PUT body for updating an existing entry.
+// Only Enable / Description are settable.
+type TFAEntryUpdateOptions struct {
+	Enable      *bool  `json:"enable,omitempty"`
+	Description string `json:"description,omitempty"`
+	Password    string `json:"password,omitempty"`
+}
+
+// TFAUsers lists every user with at least one TFA entry configured.
+func (c *Client) TFAUsers(ctx context.Context) (users []*TFAUserEntry, err error) {
+	err = c.Get(ctx, "/access/tfa", &users)
+	return
+}
+
+// TFAEntries lists all TFA entries for a given user.
+func (c *Client) TFAEntries(ctx context.Context, userid string) (entries []*TFAEntryInfo, err error) {
+	if userid == "" {
+		err = errors.New("userid is required")
+		return
+	}
+	err = c.Get(ctx, fmt.Sprintf("/access/tfa/%s", userid), &entries)
+	return
+}
+
+// TFAEntry reads a single TFA entry by id.
+func (c *Client) TFAEntry(ctx context.Context, userid, id string) (entry *TFAEntryInfo, err error) {
+	if userid == "" || id == "" {
+		err = errors.New("userid and entry id are required")
+		return
+	}
+	err = c.Get(ctx, fmt.Sprintf("/access/tfa/%s/%s", userid, id), &entry)
+	return
+}
+
+// NewTFAEntry adds a TFA entry for a user. Returns the new entry id on
+// success — PVE wraps it in a {"id": "..."} envelope inside data.
+func (c *Client) NewTFAEntry(ctx context.Context, userid string, opts *TFAEntryOptions) (id string, err error) {
+	if userid == "" {
+		return "", errors.New("userid is required")
+	}
+	if opts == nil || opts.Type == "" {
+		return "", errors.New("tfa entry type is required")
+	}
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err = c.Post(ctx, fmt.Sprintf("/access/tfa/%s", userid), opts, &resp); err != nil {
+		return "", err
+	}
+	return resp.ID, nil
+}
+
+// UpdateTFAEntry mutates an existing entry (enable/disable, description).
+func (c *Client) UpdateTFAEntry(ctx context.Context, userid, id string, opts *TFAEntryUpdateOptions) error {
+	if userid == "" || id == "" {
+		return errors.New("userid and entry id are required")
+	}
+	if opts == nil {
+		opts = &TFAEntryUpdateOptions{}
+	}
+	return c.Put(ctx, fmt.Sprintf("/access/tfa/%s/%s", userid, id), opts, nil)
+}
+
+// DeleteTFAEntry removes a single TFA entry. password is the caller's current
+// password when changing another user's TFA (PVE may require it server-side).
+// Pass "" to omit.
+func (c *Client) DeleteTFAEntry(ctx context.Context, userid, id, password string) error {
+	if userid == "" || id == "" {
+		return errors.New("userid and entry id are required")
+	}
+	path := fmt.Sprintf("/access/tfa/%s/%s", userid, id)
+	if password != "" {
+		// PVE accepts password via body on DELETE; we pass it as a body map.
+		return c.Delete(ctx, path, map[string]string{"password": password})
+	}
+	return c.Delete(ctx, path, nil)
+}
+
+// UnlockUserTFA clears the TFA lockout flag set after too many failed attempts
+// for the given user. Unlike User.UnlockTFA (which actually removes the user's
+// TFA configuration via the legacy endpoint), this leaves the entries intact —
+// it just resets the failure counter. PUT /access/users/{userid}/unlock-tfa.
+func (c *Client) UnlockUserTFA(ctx context.Context, userid string) error {
+	if userid == "" {
+		return errors.New("userid is required")
+	}
+	return c.Put(ctx, fmt.Sprintf("/access/users/%s/unlock-tfa", userid), nil, nil)
+}

--- a/access_tfa_test.go
+++ b/access_tfa_test.go
@@ -1,0 +1,92 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_TFAUsers(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	users, err := mockClient().TFAUsers(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, users, 1)
+	assert.Equal(t, "alice@pve", users[0].UserID)
+	assert.True(t, users[0].TOTP)
+}
+
+func TestClient_TFAEntries(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := mockClient().TFAEntries(context.Background(), "alice@pve")
+	assert.Nil(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "totp-1", entries[0].ID)
+
+	_, err = mockClient().TFAEntries(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestClient_TFAEntry(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entry, err := mockClient().TFAEntry(context.Background(), "alice@pve", "totp-1")
+	assert.Nil(t, err)
+	assert.Equal(t, "phone", entry.Description)
+
+	_, err = mockClient().TFAEntry(context.Background(), "", "totp-1")
+	assert.NotNil(t, err)
+}
+
+func TestClient_NewTFAEntry(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	id, err := mockClient().NewTFAEntry(context.Background(), "alice@pve", &TFAEntryOptions{
+		Type:        "totp",
+		Description: "phone",
+		TOTP:        "otpauth://totp/Proxmox:alice?secret=ABCD&issuer=Proxmox",
+		Value:       "123456",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "totp-2", id)
+
+	_, err = mockClient().NewTFAEntry(context.Background(), "alice@pve", &TFAEntryOptions{})
+	assert.NotNil(t, err)
+
+	_, err = mockClient().NewTFAEntry(context.Background(), "", nil)
+	assert.NotNil(t, err)
+}
+
+func TestClient_UpdateTFAEntry(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	enable := false
+	err := mockClient().UpdateTFAEntry(context.Background(), "alice@pve", "totp-1", &TFAEntryUpdateOptions{Enable: &enable})
+	assert.Nil(t, err)
+
+	err = mockClient().UpdateTFAEntry(context.Background(), "", "totp-1", nil)
+	assert.NotNil(t, err)
+}
+
+func TestClient_DeleteTFAEntry(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	err := mockClient().DeleteTFAEntry(context.Background(), "alice@pve", "totp-1", "currentpw")
+	assert.Nil(t, err)
+
+	err = mockClient().DeleteTFAEntry(context.Background(), "alice@pve", "totp-1", "")
+	assert.Nil(t, err)
+}
+
+func TestClient_UnlockUserTFA(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	err := mockClient().UnlockUserTFA(context.Background(), "alice@pve")
+	assert.Nil(t, err)
+
+	err = mockClient().UnlockUserTFA(context.Background(), "")
+	assert.NotNil(t, err)
+}

--- a/tests/mocks/pve9x/access.go
+++ b/tests/mocks/pve9x/access.go
@@ -952,4 +952,69 @@ func access() {
     }
 }`)
 
+	// --- /access/tfa ---------------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/access/tfa$").
+		Reply(200).
+		JSON(`{"data": [
+			{"userid": "alice@pve", "totp": true, "webauthn": false, "u2f": false}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/access/tfa/alice@pve$").
+		Reply(200).
+		JSON(`{"data": [
+			{"id": "totp-1", "type": "totp", "description": "phone", "created": 1715000000, "enable": 1}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/access/tfa/alice@pve/totp-1$").
+		Reply(200).
+		JSON(`{"data": {"id": "totp-1", "type": "totp", "description": "phone", "enable": 1}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/access/tfa/alice@pve$").
+		Reply(200).
+		JSON(`{"data": {"id": "totp-2"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/access/tfa/alice@pve/totp-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/access/tfa/alice@pve/totp-1$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/access/users/alice@pve/unlock-tfa$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// --- /access/openid ------------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/access/openid/auth-url$").
+		Reply(200).
+		JSON(`{"data": "https://idp.example.com/authorize?response_type=code&client_id=pve&state=xyz"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/access/openid/login$").
+		Reply(200).
+		JSON(`{"data": {
+			"ticket": "PVE:alice@pve:abc123",
+			"CSRFPreventionToken": "csrf123",
+			"username": "alice@pve"
+		}}`)
 }


### PR DESCRIPTION
## Summary

Adds 9 new wrappers covering the modern \`/access/tfa\` family and the OIDC
login dance under \`/access/openid\`.

**TFA** (per-entry CRUD, supersedes the legacy summary endpoint):
- \`TFAUsers\` — list users with TFA configured
- \`TFAEntries\` — list a user's entries
- \`TFAEntry\` — read one
- \`NewTFAEntry\` — add one (returns the new id)
- \`UpdateTFAEntry\` — enable/disable, description
- \`DeleteTFAEntry\` — remove one (with optional password arg for cross-user changes)
- \`UnlockUserTFA\` — reset the lockout counter (PUT \`/access/users/{userid}/unlock-tfa\`)

**OpenID Connect**:
- \`OpenIDAuthURL\` — start the OIDC dance, returns the IdP redirect URL
- \`OpenIDLogin\` — complete the callback, returns a ticket like \`/access/ticket\`

### Notes
- \`NewTFAEntry\` returns just the new id — PVE wraps it as \`{\"id\": \"...\"}\` inside data; helper unwraps to a plain string.
- \`TFAEntryUpdateOptions.Enable\` is \`*bool\` so unset doesn't silently flip a user's TFA off when the caller only wanted to update the description.
- \`UnlockUserTFA\` is the **modern** unlock endpoint (resets the lockout counter, leaves entries intact). The pre-existing \`User.UnlockTFA\` wraps the legacy \`DELETE /access/users/{userid}/tfa\` that nukes all entries — different semantics, kept for backward compat.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test .\` (9 new tests, all green)
- [ ] Smoke against a live PVE realm with OIDC + TFA configured