### PR TITLE
feat: wrap remaining /nodes/{node}/storage/{storage}/* — content alloc/update/copy, OCI pull, file-restore, RRD

### DIFF
--- a/storage_content.go
+++ b/storage_content.go
@@ -1,0 +1,130 @@
+package proxmox
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// This file fills the remaining /nodes/{node}/storage/{storage}/* gaps —
+// content allocation/update/copy, OCI registry pull, file-restore listing,
+// and RRD data. Upload, GetContent, DeleteContent, prunebackups, and
+// import-metadata are wrapped in storage.go.
+
+// StorageContentAllocOptions is the body for POST /content — allocate a new
+// disk image on the storage. Filename and Size are required; PVE picks
+// Format based on the storage type when unset.
+type StorageContentAllocOptions struct {
+	Filename string `json:"filename"`
+	Size     string `json:"size"` // e.g. "1024" (KB) or "4G"
+	VMID     uint64 `json:"vmid"`
+	Format   string `json:"format,omitempty"`
+}
+
+// AllocContent creates a new image volume on the storage. Returns the new
+// volid (e.g. "local-lvm:vm-100-disk-1"). Synchronous — most LVM/ZFS-backed
+// allocations finish quickly enough that PVE returns the volid directly.
+func (s *Storage) AllocContent(ctx context.Context, opts *StorageContentAllocOptions) (volid string, err error) {
+	if opts == nil || opts.Filename == "" || opts.Size == "" || opts.VMID == 0 {
+		return "", errors.New("filename, size, and vmid are required")
+	}
+	err = s.client.Post(ctx, fmt.Sprintf("/nodes/%s/storage/%s/content", s.Node, s.Name), opts, &volid)
+	return
+}
+
+// StorageContentUpdateOptions is the PUT body for /content/{volume}.
+// Protected currently only applies to backup volumes.
+type StorageContentUpdateOptions struct {
+	Notes     string `json:"notes,omitempty"`
+	Protected *bool  `json:"protected,omitempty"`
+}
+
+// UpdateContent mutates a volume's metadata (currently: notes + protected
+// flag on backups). Pass volume as the full PVE volid (e.g.
+// "local:backup/vzdump-qemu-100-2026_01_01-12_00_00.vma.zst").
+func (s *Storage) UpdateContent(ctx context.Context, volume string, opts *StorageContentUpdateOptions) error {
+	if volume == "" {
+		return errors.New("volume is required")
+	}
+	if opts == nil {
+		opts = &StorageContentUpdateOptions{}
+	}
+	return s.client.Put(ctx, fmt.Sprintf("/nodes/%s/storage/%s/content/%s", s.Node, s.Name, volume), opts, nil)
+}
+
+// CopyContent clones a source volume to a target volid, optionally on a
+// different node. Returns a Task — copying multi-GB images takes a while.
+func (s *Storage) CopyContent(ctx context.Context, sourceVolume, targetVolume, targetNode string) (*Task, error) {
+	if sourceVolume == "" || targetVolume == "" {
+		return nil, errors.New("source and target volumes are required")
+	}
+	body := map[string]string{"target": targetVolume}
+	if targetNode != "" {
+		body["target_node"] = targetNode
+	}
+	var upid UPID
+	if err := s.client.Post(ctx, fmt.Sprintf("/nodes/%s/storage/%s/content/%s", s.Node, s.Name, sourceVolume), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
+}
+
+// OCIRegistryPull downloads an OCI image from a registry into the storage.
+// reference is the OCI image ref (e.g. "docker.io/library/alpine:latest").
+// filename is optional — PVE will derive one from the reference when unset.
+// Returns a Task.
+func (s *Storage) OCIRegistryPull(ctx context.Context, reference, filename string) (*Task, error) {
+	if reference == "" {
+		return nil, errors.New("oci reference is required")
+	}
+	body := map[string]string{"reference": reference}
+	if filename != "" {
+		body["filename"] = filename
+	}
+	var upid UPID
+	if err := s.client.Post(ctx, fmt.Sprintf("/nodes/%s/storage/%s/oci-registry-pull", s.Node, s.Name), body, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
+}
+
+// StorageFileRestoreEntry is one row from GET /file-restore/list.
+type StorageFileRestoreEntry struct {
+	Filepath string `json:"filepath,omitempty"`
+	Type     string `json:"type,omitempty"` // "f" (file), "d" (directory), "l" (link)
+	Text     string `json:"text,omitempty"`
+	Size     uint64 `json:"size,omitempty"`
+	Mtime    int64  `json:"mtime,omitempty"`
+	Leaf     IntOrBool `json:"leaf,omitempty"`
+}
+
+// FileRestoreList lists entries inside a PBS-backed backup volume at the
+// given filesystem path. Pass filepath="/" for the root. PVE only supports
+// this on PBS storages.
+func (s *Storage) FileRestoreList(ctx context.Context, volume, filepath string) (entries []*StorageFileRestoreEntry, err error) {
+	if volume == "" || filepath == "" {
+		return nil, errors.New("volume and filepath are required")
+	}
+	// PVE requires filepath base64-encoded — applies to both directories
+	// (which list children) and individual files (which download content).
+	q := url.Values{}
+	q.Set("volume", volume)
+	q.Set("filepath", base64.StdEncoding.EncodeToString([]byte(filepath)))
+	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/storage/%s/file-restore/list?%s", s.Node, s.Name, q.Encode()), &entries)
+	return
+}
+
+// RRDData returns the storage's historical IO/usage timeseries. timeframe
+// is one of hour/day/week/month/year; cf is the consolidation function
+// (AVERAGE | MAX) — empty defaults to AVERAGE server-side.
+func (s *Storage) RRDData(ctx context.Context, timeframe Timeframe, cf ConsolidationFunction) (data []*RRDData, err error) {
+	q := url.Values{}
+	q.Set("timeframe", string(timeframe))
+	if cf != "" {
+		q.Set("cf", string(cf))
+	}
+	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/storage/%s/rrddata?%s", s.Node, s.Name, q.Encode()), &data)
+	return
+}

--- a/storage_content_test.go
+++ b/storage_content_test.go
@@ -1,0 +1,84 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func storageRef(name string) *Storage {
+	return &Storage{client: mockClient(), Node: "node1", Name: name}
+}
+
+func TestStorage_AllocContent(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	volid, err := storageRef("local-lvm").AllocContent(context.Background(), &StorageContentAllocOptions{
+		Filename: "vm-100-disk-1",
+		Size:     "4G",
+		VMID:     100,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "local-lvm:vm-100-disk-1", volid)
+
+	_, err = storageRef("local-lvm").AllocContent(context.Background(), nil)
+	assert.NotNil(t, err)
+}
+
+func TestStorage_UpdateContent(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	protected := true
+	err := storageRef("local").UpdateContent(context.Background(),
+		"local:backup/vzdump-qemu-100-2026_01_01-12_00_00.vma.zst",
+		&StorageContentUpdateOptions{Notes: "keep — golden image", Protected: &protected})
+	assert.Nil(t, err)
+
+	err = storageRef("local").UpdateContent(context.Background(), "", nil)
+	assert.NotNil(t, err)
+}
+
+func TestStorage_CopyContent(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := storageRef("local-lvm").CopyContent(context.Background(),
+		"local-lvm:vm-100-disk-0", "local-lvm:vm-200-disk-0", "")
+	assert.Nil(t, err)
+	assert.Equal(t, "imgcopy", task.Type)
+
+	_, err = storageRef("local-lvm").CopyContent(context.Background(), "", "x", "")
+	assert.NotNil(t, err)
+}
+
+func TestStorage_OCIRegistryPull(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task, err := storageRef("local").OCIRegistryPull(context.Background(), "docker.io/library/alpine:latest", "")
+	assert.Nil(t, err)
+	assert.Equal(t, "ocipull", task.Type)
+
+	_, err = storageRef("local").OCIRegistryPull(context.Background(), "", "")
+	assert.NotNil(t, err)
+}
+
+func TestStorage_FileRestoreList(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := storageRef("pbs").FileRestoreList(context.Background(), "pbs:backup/vm/100/2026-05-13T22:00:00Z", "/")
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "f", entries[0].Type)
+
+	_, err = storageRef("pbs").FileRestoreList(context.Background(), "", "/")
+	assert.NotNil(t, err)
+}
+
+func TestStorage_RRDData(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	data, err := storageRef("local").RRDData(context.Background(), TimeframeHour, "")
+	assert.Nil(t, err)
+	assert.Len(t, data, 2)
+}

--- a/tests/mocks/pve9x/storage.go
+++ b/tests/mocks/pve9x/storage.go
@@ -238,4 +238,54 @@ func storage() {
         ]
     }
 }`)
+
+	// --- /nodes/{node}/storage/{storage}/content extras ---------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/storage/local-lvm/content$").
+		Reply(200).
+		JSON(`{"data": "local-lvm:vm-100-disk-1"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/storage/local/content/local:backup/").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/storage/local-lvm/content/local-lvm:vm-100-disk-0$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00000006:00000006:00000006:imgcopy:vm-100-disk-0:root@pam:"}`)
+
+	// --- OCI registry pull --------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/storage/local/oci-registry-pull$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00000007:00000007:00000007:ocipull:alpine:root@pam:"}`)
+
+	// --- file-restore -------------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/pbs/file-restore/list").
+		Reply(200).
+		JSON(`{"data": [
+			{"filepath": "/etc/hostname", "type": "f", "size": 12, "mtime": 1715000000},
+			{"filepath": "/etc/network", "type": "d", "leaf": 0}
+		]}`)
+
+	// --- rrddata ------------------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/local/rrddata").
+		Reply(200).
+		JSON(`{"data": [
+			{"time": 1715000000, "used": 1000000, "total": 2000000},
+			{"time": 1715000060, "used": 1100000, "total": 2000000}
+		]}`)
 }


### PR DESCRIPTION
## Summary

Closes the remaining \`/nodes/{node}/storage/{storage}/*\` gaps (Upload,
download-url, prunebackups, import-metadata were already wrapped; this PR
fills in the rest of the day-to-day surface).

- \`AllocContent\` — POST \`/content\` — allocate a new disk image, returns the volid PVE picks
- \`UpdateContent\` — PUT \`/content/{volume}\` — update notes / protected flag
- \`CopyContent\` — POST \`/content/{volume}\` — copy a volume to a target volid (returns Task)
- \`OCIRegistryPull\` — POST \`/oci-registry-pull\` — pull OCI image into storage (returns Task)
- \`FileRestoreList\` — GET \`/file-restore/list\` — list files in a PBS-backed backup
- \`RRDData\` — GET \`/rrddata\` — storage IO/usage timeseries

### Schema notes
- File-restore filepaths are base64-encoded on the wire (PVE quirk). Helper handles it; callers pass plain UTF-8 paths.
- \`UpdateContent.Protected\` is \`*bool\` (only valid on backup volumes) so unset doesn't silently unprotect a backup.
- \`CopyContent.targetNode\` defaults to local; pass non-empty to copy cross-node.

### Out of scope
- \`/file-restore/download\` — streams binary content; needs a different transport API than our JSON-unmarshaling client. Best wrapped separately when someone needs it.
- Storage RRD chart image (\`/rrd\`) — returns a PNG, same transport issue.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test .\` (6 new tests, all green)
- [ ] Smoke against a PVE node with a real PBS-backed storage for file-restore