### PR TITLE
feat(mage): endpoints — snapshot PVE API surface + coverage diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 coverage.txt
+.cache/

--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -137,6 +137,7 @@ func Coverage() error {
 	}
 
 	covered := map[string]struct{}{}
+	var unmatched []extractedCall
 	matched, missed := 0, 0
 	for _, c := range calls {
 		k := key(c.Method, c.Path)
@@ -145,8 +146,15 @@ func Coverage() error {
 			covered[k] = struct{}{}
 		} else {
 			missed++
+			unmatched = append(unmatched, c)
 		}
 	}
+	sort.Slice(unmatched, func(i, j int) bool {
+		if unmatched[i].File != unmatched[j].File {
+			return unmatched[i].File < unmatched[j].File
+		}
+		return unmatched[i].Line < unmatched[j].Line
+	})
 
 	var uncovered []string
 	for _, e := range schema {
@@ -208,6 +216,13 @@ func Coverage() error {
 		len(covered), len(schema), pct(len(covered), len(schema)))
 	fmt.Println()
 	fmt.Print(areaBuf.String())
+	if len(unmatched) > 0 {
+		fmt.Printf("\ncall sites that don't resolve to a schema endpoint (%d):\n", len(unmatched))
+		fmt.Println("  (real coverage findings — either stale Go code, or one Go call covering multiple schema endpoints)")
+		for _, c := range unmatched {
+			fmt.Printf("  %s:%d  %s %s\n", c.File, c.Line, c.Method, c.Path)
+		}
+	}
 	fmt.Printf("\nwrote:\n  %s/coverage.txt           # %d uncovered endpoints\n  %s/coverage_by_area.txt\n",
 		cacheDir, len(uncovered), cacheDir)
 	return nil
@@ -284,16 +299,23 @@ var (
 	sprintfRE = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
 	braceRE   = regexp.MustCompile(`\{[^}]+\}`)
 	fmtVerbRE = regexp.MustCompile(`%[sdvqxXt]`)
+	// PVE volume identifiers serialize as `<storage>:<type>/<filename>` and are
+	// represented as a single `{volume}` segment in the schema. Go code that
+	// builds the path via `fmt.Sprintf(...content/%s:%s/%s, ...)` normalizes to
+	// `.../content/{}:{}/{}` and must collapse to `.../content/{}` to match.
+	volidRE = regexp.MustCompile(`\{\}:\{\}/\{\}`)
 )
 
 // normalizePath canonicalizes both schema and Go forms so they can be joined:
-// {var}/%s/%d → {}; query string and trailing slash stripped.
+// {var}/%s/%d → {}; volid-style {}:{}/{}  → {}; query string and trailing
+// slash stripped.
 func normalizePath(p string) string {
 	if i := strings.IndexByte(p, '?'); i >= 0 {
 		p = p[:i]
 	}
 	p = braceRE.ReplaceAllString(p, "{}")
 	p = fmtVerbRE.ReplaceAllString(p, "{}")
+	p = volidRE.ReplaceAllString(p, "{}")
 	if len(p) > 1 {
 		p = strings.TrimRight(p, "/")
 	}

--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -1,0 +1,208 @@
+// Package endpoints provides mage targets that snapshot the upstream Proxmox VE
+// REST API surface (apidoc.js) and flatten it into a (method, path) list, so
+// the library's wrapper coverage can be diffed against the canonical schema.
+package endpoints
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	upstreamURL = "https://pve.proxmox.com/pve-docs/api-viewer/apidoc.js"
+	cacheDir    = ".cache/pve-api"
+)
+
+type methodInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type node struct {
+	Text     string                `json:"text"`
+	Info     map[string]methodInfo `json:"info"`
+	Children []node                `json:"children"`
+}
+
+type endpoint struct {
+	Method      string `json:"method"`
+	Path        string `json:"path"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// Sync fetches the upstream API schema and writes endpoints.json + endpoints.txt
+// into .cache/pve-api/. This is the normal entry point.
+func Sync() error {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return err
+	}
+	fmt.Printf("Fetching %s\n", upstreamURL)
+	if err := download(upstreamURL, filepath.Join(cacheDir, "apidoc.js")); err != nil {
+		return err
+	}
+	return Extract()
+}
+
+// Extract parses the cached apidoc.js (no network) and emits endpoints.json
+// and endpoints.txt. Useful for re-running the parser without re-downloading.
+func Extract() error {
+	cache := filepath.Join(cacheDir, "apidoc.js")
+	raw, err := os.ReadFile(cache)
+	if err != nil {
+		return fmt.Errorf("read %s: %w (run `mage endpoints:sync` first)", cache, err)
+	}
+	jsonBlob, err := extractSchemaJSON(raw)
+	if err != nil {
+		return err
+	}
+	var schema []node
+	if err := json.Unmarshal(jsonBlob, &schema); err != nil {
+		return fmt.Errorf("parse apidoc.js schema: %w", err)
+	}
+
+	out := flatten(schema)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Path != out[j].Path {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].Method < out[j].Method
+	})
+
+	jsonBytes, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "endpoints.json"), jsonBytes, 0o644); err != nil {
+		return err
+	}
+	var txt bytes.Buffer
+	for _, e := range out {
+		fmt.Fprintf(&txt, "%-7s %s\n", e.Method, e.Path)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "endpoints.txt"), txt.Bytes(), 0o644); err != nil {
+		return err
+	}
+	printSummary(out)
+	return nil
+}
+
+// extractSchemaJSON peels the `const apiSchema = [ ... ];` array out of the
+// upstream JS file. We anchor on `\n]\n;` rather than the last `]` because
+// the JS handler code below the schema contains template literals like
+// `${m2c[method]}` whose `]` would be matched first.
+func extractSchemaJSON(raw []byte) ([]byte, error) {
+	start := bytes.IndexByte(raw, '[')
+	endIdx := bytes.Index(raw, []byte("\n]\n;"))
+	if start < 0 || endIdx <= start {
+		return nil, fmt.Errorf("could not locate JSON array boundaries in apidoc.js")
+	}
+	return raw[start : endIdx+2], nil
+}
+
+func flatten(schema []node) []endpoint {
+	var out []endpoint
+	var walk func(n node, path string)
+	walk = func(n node, path string) {
+		here := path
+		if n.Text != "" {
+			here = path + "/" + n.Text
+		}
+		for method, meta := range n.Info {
+			desc := meta.Description
+			if i := strings.IndexByte(desc, '\n'); i >= 0 {
+				desc = desc[:i]
+			}
+			out = append(out, endpoint{
+				Method:      method,
+				Path:        here,
+				Name:        meta.Name,
+				Description: strings.TrimSpace(desc),
+			})
+		}
+		for _, c := range n.Children {
+			walk(c, here)
+		}
+	}
+	for _, top := range schema {
+		walk(top, "")
+	}
+	return out
+}
+
+func download(url, dst string) (err error) {
+	client := &http.Client{Timeout: 60 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close response body: %w", cerr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close %s: %w", dst, cerr)
+		}
+	}()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func printSummary(out []endpoint) {
+	uniqPaths := map[string]struct{}{}
+	areas := map[string]int{}
+	methodCounts := map[string]int{}
+	for _, e := range out {
+		uniqPaths[e.Path] = struct{}{}
+		methodCounts[e.Method]++
+		areas[topArea(e.Path)]++
+	}
+	fmt.Printf("\nProxmox VE API snapshot — %s\n", time.Now().Format("2006-01-02"))
+	fmt.Printf("  endpoints   : %d\n", len(out))
+	fmt.Printf("  unique paths: %d\n", len(uniqPaths))
+	fmt.Printf("  methods     :")
+	for _, m := range sortedKeys(methodCounts) {
+		fmt.Printf(" %s=%d", m, methodCounts[m])
+	}
+	fmt.Println()
+	fmt.Printf("  top areas   :")
+	for _, a := range sortedKeys(areas) {
+		fmt.Printf(" %s=%d", a, areas[a])
+	}
+	fmt.Println()
+	fmt.Printf("\nwrote:\n  %s/endpoints.json\n  %s/endpoints.txt\n", cacheDir, cacheDir)
+}
+
+func topArea(path string) string {
+	p := strings.TrimPrefix(path, "/")
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		return p[:i]
+	}
+	return p
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -4,6 +4,7 @@
 package endpoints
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -93,6 +95,233 @@ func Extract() error {
 	}
 	printSummary(out)
 	return nil
+}
+
+// Coverage scans the library source for HTTP call sites, normalizes their
+// path templates, and reports the fraction of the upstream PVE API surface
+// that has at least one Go wrapper. Auto-runs Sync if the cached schema is
+// missing. Writes coverage.txt (uncovered endpoints) and coverage_by_area.txt
+// into .cache/pve-api/.
+func Coverage() error {
+	endpointsFile := filepath.Join(cacheDir, "endpoints.json")
+	if _, err := os.Stat(endpointsFile); err != nil {
+		if err := Sync(); err != nil {
+			return err
+		}
+	}
+
+	raw, err := os.ReadFile(endpointsFile)
+	if err != nil {
+		return err
+	}
+	var schema []endpoint
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		return err
+	}
+
+	schemaKey := make(map[string]struct{}, len(schema))
+	schemaByArea := map[string]map[string]struct{}{}
+	for _, e := range schema {
+		k := key(e.Method, normalizePath(e.Path))
+		schemaKey[k] = struct{}{}
+		a := areaOf(normalizePath(e.Path))
+		if schemaByArea[a] == nil {
+			schemaByArea[a] = map[string]struct{}{}
+		}
+		schemaByArea[a][k] = struct{}{}
+	}
+
+	calls, err := scanCallSites(".")
+	if err != nil {
+		return err
+	}
+
+	covered := map[string]struct{}{}
+	matched, missed := 0, 0
+	for _, c := range calls {
+		k := key(c.Method, c.Path)
+		if _, ok := schemaKey[k]; ok {
+			matched++
+			covered[k] = struct{}{}
+		} else {
+			missed++
+		}
+	}
+
+	var uncovered []string
+	for _, e := range schema {
+		k := key(e.Method, normalizePath(e.Path))
+		if _, ok := covered[k]; !ok {
+			uncovered = append(uncovered, fmt.Sprintf("%-7s %s", e.Method, e.Path))
+		}
+	}
+	sort.Strings(uncovered)
+	if err := os.WriteFile(
+		filepath.Join(cacheDir, "coverage.txt"),
+		[]byte(strings.Join(uncovered, "\n")+"\n"),
+		0o644,
+	); err != nil {
+		return err
+	}
+
+	type areaRow struct {
+		area               string
+		total, cov, missed int
+	}
+	var rows []areaRow
+	for area, keys := range schemaByArea {
+		row := areaRow{area: area, total: len(keys)}
+		for k := range keys {
+			if _, ok := covered[k]; ok {
+				row.cov++
+			}
+		}
+		row.missed = row.total - row.cov
+		rows = append(rows, row)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].total != rows[j].total {
+			return rows[i].total > rows[j].total
+		}
+		return rows[i].area < rows[j].area
+	})
+
+	var areaBuf bytes.Buffer
+	fmt.Fprintf(&areaBuf, "%-25s %8s %8s %8s %8s\n", "area", "covered", "total", "missing", "pct")
+	for _, r := range rows {
+		fmt.Fprintf(&areaBuf, "%-25s %8d %8d %8d %7.1f%%\n",
+			r.area, r.cov, r.total, r.missed, pct(r.cov, r.total))
+	}
+	if err := os.WriteFile(
+		filepath.Join(cacheDir, "coverage_by_area.txt"),
+		areaBuf.Bytes(),
+		0o644,
+	); err != nil {
+		return err
+	}
+
+	fmt.Printf("\ngo-proxmox endpoint coverage — %s\n", time.Now().Format("2006-01-02"))
+	fmt.Printf("  schema endpoints   : %d\n", len(schema))
+	fmt.Printf("  call sites scanned : %d (matched=%d, no-match=%d → match rate %.1f%%)\n",
+		len(calls), matched, missed, pct(matched, len(calls)))
+	fmt.Printf("  unique covered     : %d / %d  →  %.1f%%\n",
+		len(covered), len(schema), pct(len(covered), len(schema)))
+	fmt.Println()
+	fmt.Print(areaBuf.String())
+	fmt.Printf("\nwrote:\n  %s/coverage.txt           # %d uncovered endpoints\n  %s/coverage_by_area.txt\n",
+		cacheDir, len(uncovered), cacheDir)
+	return nil
+}
+
+// scanCallSites walks .go files (skipping tests, examples, mage, .claude, .cache)
+// and extracts `c.Get|Post|Put|Delete(ctx, "/path"|fmt.Sprintf("/path", ...), ...)`
+// call sites. Returns normalized (method, path) pairs.
+func scanCallSites(root string) ([]extractedCall, error) {
+	var out []extractedCall
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".claude", ".cache", "examples", "tests", "audit", "mage":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if cerr := f.Close(); cerr != nil {
+				fmt.Fprintln(os.Stderr, "close:", cerr)
+			}
+		}()
+		s := bufio.NewScanner(f)
+		s.Buffer(make([]byte, 1<<16), 1<<20)
+		for line := 1; s.Scan(); line++ {
+			text := s.Text()
+			m := callRE.FindStringSubmatch(text)
+			if m == nil {
+				continue
+			}
+			method := m[1]
+			rest := m[2]
+			var pathLit string
+			if sm := sprintfRE.FindStringSubmatch(rest); sm != nil {
+				pathLit = sm[1]
+			} else if t := strings.TrimSpace(rest); strings.HasPrefix(t, `"`) {
+				if end := strings.Index(t[1:], `"`); end > 0 {
+					pathLit = t[1 : 1+end]
+				}
+			}
+			if pathLit == "" {
+				continue
+			}
+			out = append(out, extractedCall{
+				Method: method,
+				Path:   normalizePath(pathLit),
+				File:   filepath.ToSlash(path),
+				Line:   line,
+			})
+		}
+		return s.Err()
+	})
+	return out, err
+}
+
+type extractedCall struct {
+	Method, Path, File string
+	Line               int
+}
+
+var (
+	callRE    = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)\s*\(\s*ctx\s*,\s*(.*?)$`)
+	sprintfRE = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
+	braceRE   = regexp.MustCompile(`\{[^}]+\}`)
+	fmtVerbRE = regexp.MustCompile(`%[sdvqxXt]`)
+)
+
+// normalizePath canonicalizes both schema and Go forms so they can be joined:
+// {var}/%s/%d → {}; query string and trailing slash stripped.
+func normalizePath(p string) string {
+	if i := strings.IndexByte(p, '?'); i >= 0 {
+		p = p[:i]
+	}
+	p = braceRE.ReplaceAllString(p, "{}")
+	p = fmtVerbRE.ReplaceAllString(p, "{}")
+	if len(p) > 1 {
+		p = strings.TrimRight(p, "/")
+	}
+	return p
+}
+
+func key(method, path string) string {
+	return strings.ToLower(method) + " " + path
+}
+
+// areaOf groups endpoints for the breakdown table — top-level segment, except
+// /nodes/{}/<sub> where <sub> is the meaningful area.
+func areaOf(path string) string {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		return "(root)"
+	}
+	if parts[0] == "nodes" && len(parts) >= 3 {
+		return "nodes/" + parts[2]
+	}
+	return parts[0]
+}
+
+func pct(n, d int) float64 {
+	if d == 0 {
+		return 0
+	}
+	return float64(n) * 100 / float64(d)
 }
 
 // extractSchemaJSON peels the `const apiSchema = [ ... ];` array out of the

--- a/magefile.go
+++ b/magefile.go
@@ -11,6 +11,9 @@ import (
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 
+	//mage:import endpoints
+	"github.com/luthermonson/go-proxmox/mage/endpoints"
+
 	//mage:import install
 	"github.com/luthermonson/go-proxmox/mage/install"
 
@@ -34,8 +37,9 @@ var (
 )
 
 var Aliases = map[string]interface{}{
-	"test":    test.Unit,
-	"install": install.Dependencies,
+	"test":      test.Unit,
+	"install":   install.Dependencies,
+	"endpoints": endpoints.Sync,
 }
 
 // run everything for ci process (install deps, lint, coverage, build)


### PR DESCRIPTION
## Summary

Adds a `mage endpoints` namespace that snapshots the upstream Proxmox VE REST API surface and diffs it against this library's wrapper coverage.

- **`mage endpoints`** (alias for `endpoints:sync`) — fetches upstream `apidoc.js` and writes `endpoints.json` + `endpoints.txt` to `.cache/pve-api/`.
- **`mage endpoints:extract`** — re-parses the cached schema offline.
- **`mage endpoints:coverage`** — scans the library's `.go` files for HTTP call sites, normalizes their path templates, and reports the fraction of the upstream surface that has a Go wrapper. Auto-runs `Sync` if the cache is cold. Writes `coverage.txt` (uncovered endpoints) and `coverage_by_area.txt`.

### Current snapshot

PVE 9.2.1: **675 endpoints / 444 unique paths** (`GET 340 · POST 173 · PUT 83 · DELETE 79`)

Library coverage on `main`: **353 / 675 covered (52.3%)** with a 98.4% regex match rate.

Biggest unwrapped areas:
| area | covered | total | pct |
|---|---:|---:|---:|
| `cluster` | 94 | 259 | 36.3% |
| `nodes/ceph` | 0 | 41 | 0.0% |
| `nodes/sdn` | 0 | 12 | 0.0% |
| `nodes/storage` | 11 | 20 | 55.0% |
| `nodes/scan` | 0 | 8 | 0.0% |

At 100%: `storage`, `version`, `nodes/dns`, `nodes/time`, `nodes/certificates`, `nodes/subscription`, `nodes/aplinfo`, plus several singletons.

### Example run

```
$ mage endpoints:coverage

go-proxmox endpoint coverage — 2026-05-24
  schema endpoints   : 675
  call sites scanned : 368 (matched=362, no-match=6 → match rate 98.4%)
  unique covered     : 353 / 675  →  52.3%

area                       covered    total  missing      pct
cluster                         94      259      165    36.3%
nodes/qemu                      78       97       19    80.4%
nodes/lxc                       53       62        9    85.5%
access                          39       45        6    86.7%
nodes/ceph                       0       41       41     0.0%
...
```

### Implementation notes

- New package `mage/endpoints` — stdlib only (`net/http`, `encoding/json`, `regexp`), no new deps.
- Wired in via `//mage:import endpoints` + an `endpoints: endpoints.Sync` alias, matching the existing `test`/`install` namespace pattern.
- `.cache/` added to `.gitignore` — outputs are derivable, not checked in.
- **Schema-extraction gotcha:** `apidoc.js` ends with `]\n;` followed by JS handler code containing template literals like `${m2c[method]}` whose `]` would defeat a naive `LastIndexByte(']')` anchor. The parser anchors on the literal `\n]\n;` instead.
- **Coverage heuristic:** regex matches `c.Get|Post|Put|Delete(ctx, "/path", ...)` and the `fmt.Sprintf("...")` variant. Normalization collapses `{var}`/`%s`/`%d` to `{}` and strips query strings + trailing slashes. Considered an AST-based approach but the regex hits 98.4% on the current codebase — the remaining 1.6% are all real call sites in benign forms (no false positives).

## Test plan

- [x] `go build ./...` clean in the worktree
- [x] `go vet ./...` clean
- [x] `mage -l` lists `endpoints:sync`, `endpoints:extract`, `endpoints:coverage`
- [x] `mage endpoints` (alias) downloads upstream and writes `endpoints.{json,txt}`
- [x] `mage endpoints:extract` re-runs offline against the cache
- [x] `mage endpoints:coverage` produces summary + per-area table + `coverage.txt`
