### PR TITLE
fix: UnlockTFA calls PUT /access/users/{userid}/unlock-tfa

### DIFF
--- a/access.go
+++ b/access.go
@@ -268,7 +268,7 @@ func (u *User) GetTFA(ctx context.Context) (tfa TFA, err error) {
 }
 
 func (u *User) UnlockTFA(ctx context.Context) error {
-	return u.client.Delete(ctx, fmt.Sprintf("/access/users/%s/tfa", u.UserID), nil)
+	return u.client.Put(ctx, fmt.Sprintf("/access/users/%s/unlock-tfa", u.UserID), nil, nil)
 }
 
 func (c *Client) Role(ctx context.Context, roleid string) (role Permission, err error) {

--- a/tests/mocks/pve9x/access.go
+++ b/tests/mocks/pve9x/access.go
@@ -937,7 +937,7 @@ func access() {
 }`)
 
 	gock.New(config.C.URI).
-		Delete("^/access/users/userid/tfa").
+		Put("^/access/users/userid/unlock-tfa").
 		Reply(200).
 		JSON(``)
 


### PR DESCRIPTION
## Summary

`User.UnlockTFA` has been broken since it was introduced in #125. It calls:

```go
u.client.Delete(ctx, fmt.Sprintf("/access/users/%s/tfa", u.UserID), nil)
```

…but that's not a real PVE endpoint. The schema for `/access/users/{userid}/tfa` only exposes **GET** (used by `GetTFA`). The actual unlock endpoint, present in PVE for years and documented in the current 9.2.1 API schema, is:

```
PUT /access/users/{userid}/unlock-tfa
```

So any caller invoking `UnlockTFA` against a real PVE cluster would get `501 Method not implemented` / `404`, never actually unlocking the user.

### Why the existing test didn't catch it

`TestUnlockTFA` passed because `tests/mocks/pve9x/access.go` registered a gock mock for the same wrong `(DELETE, /access/users/userid/tfa)` pair. The test confirmed the Go code matched the mock; nothing verified the mock matched PVE. Updated the mock to `PUT /access/users/userid/unlock-tfa`; test still green.

### How it was found

The `mage endpoints:coverage` target added in #298 lists call sites that don't resolve to any schema endpoint. The fixed-up final report flagged exactly two — this was one of them. (The other is `serviceAction`, a generic internal helper, which is acceptable.)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `mage test:unit` passes — including `TestUnlockTFA` against the corrected mock
- [ ] Live PVE verification — `UnlockTFA(ctx)` against a 9.x cluster returns nil and actually clears the TFA-lock on the user (reviewer with a test cluster, please confirm)

## Related

- Discovered via #298 (`mage endpoints:coverage` diagnostics)
- Introduced in #125