### PR TITLE
fix(mage): endpoints:coverage recognizes url.URL{Path:...}.String() pattern

### DIFF
--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -230,7 +230,14 @@ func Coverage() error {
 
 // scanCallSites walks .go files (skipping tests, examples, mage, .claude, .cache)
 // and extracts `c.Get|Post|Put|Delete(ctx, "/path"|fmt.Sprintf("/path", ...), ...)`
-// call sites. Returns normalized (method, path) pairs.
+// call sites. Also recognizes the `url.URL{Path: ...}.String()` indirection
+// used by call sites that need to attach query parameters, e.g.
+//
+//	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/rrddata", v.Node, v.VMID)}
+//	u.RawQuery = params.Encode()
+//	err := v.client.Get(ctx, u.String(), &out)
+//
+// Returns normalized (method, path) pairs.
 func scanCallSites(root string) ([]extractedCall, error) {
 	var out []extractedCall
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -258,20 +265,31 @@ func scanCallSites(root string) ([]extractedCall, error) {
 		}()
 		s := bufio.NewScanner(f)
 		s.Buffer(make([]byte, 1<<16), 1<<20)
+		// Per-file map of `<var>` → path for `<var> := url.URL{Path: ...}`
+		// declarations. Reset per file so that vars in different files don't
+		// bleed. Reused vars within a file simply track the most recent binding,
+		// which is correct because the corresponding Get/Post call always
+		// follows the assignment in the same function.
+		urlVars := map[string]string{}
 		for line := 1; s.Scan(); line++ {
 			text := s.Text()
+
+			if am := urlAssignRE.FindStringSubmatch(text); am != nil {
+				if p := extractPathExpr(am[2]); p != "" {
+					urlVars[am[1]] = p
+				}
+			}
+
 			m := callRE.FindStringSubmatch(text)
 			if m == nil {
 				continue
 			}
 			method := m[1]
 			rest := m[2]
-			var pathLit string
-			if sm := sprintfRE.FindStringSubmatch(rest); sm != nil {
-				pathLit = sm[1]
-			} else if t := strings.TrimSpace(rest); strings.HasPrefix(t, `"`) {
-				if end := strings.Index(t[1:], `"`); end > 0 {
-					pathLit = t[1 : 1+end]
+			pathLit := extractPathExpr(rest)
+			if pathLit == "" {
+				if um := urlStringRE.FindStringSubmatch(strings.TrimSpace(rest)); um != nil {
+					pathLit = urlVars[um[1]]
 				}
 			}
 			if pathLit == "" {
@@ -289,16 +307,36 @@ func scanCallSites(root string) ([]extractedCall, error) {
 	return out, err
 }
 
+// extractPathExpr pulls the path literal out of an expression like:
+//
+//	"/some/path"
+//	fmt.Sprintf("/some/path", args...)
+//
+// Returns "" if neither form is present.
+func extractPathExpr(expr string) string {
+	if sm := sprintfRE.FindStringSubmatch(expr); sm != nil {
+		return sm[1]
+	}
+	if t := strings.TrimSpace(expr); strings.HasPrefix(t, `"`) {
+		if end := strings.Index(t[1:], `"`); end > 0 {
+			return t[1 : 1+end]
+		}
+	}
+	return ""
+}
+
 type extractedCall struct {
 	Method, Path, File string
 	Line               int
 }
 
 var (
-	callRE    = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)\s*\(\s*ctx\s*,\s*(.*?)$`)
-	sprintfRE = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
-	braceRE   = regexp.MustCompile(`\{[^}]+\}`)
-	fmtVerbRE = regexp.MustCompile(`%[sdvqxXt]`)
+	callRE      = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)\s*\(\s*ctx\s*,\s*(.*?)$`)
+	sprintfRE   = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
+	urlAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*url\.URL\{\s*Path:\s*(.+)\}`)
+	urlStringRE = regexp.MustCompile(`^(\w+)\.String\(\)`)
+	braceRE     = regexp.MustCompile(`\{[^}]+\}`)
+	fmtVerbRE   = regexp.MustCompile(`%[sdvqxXt]`)
 	// PVE volume identifiers serialize as `<storage>:<type>/<filename>` and are
 	// represented as a single `{volume}` segment in the schema. Go code that
 	// builds the path via `fmt.Sprintf(...content/%s:%s/%s, ...)` normalizes to


### PR DESCRIPTION
## Summary

`mage endpoints:coverage` was silently dropping any HTTP call site that builds its path via a `url.URL` value, because the regex extractor only understands `fmt.Sprintf("...")` and quoted-literal forms as the path argument.

The pattern is used wherever a call needs to attach query parameters:

```go
u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/rrddata", v.Node, v.VMID)}
u.RawQuery = params.Encode()
err := v.client.Get(ctx, u.String(), &out)
```

The `v.client.Get(...)` line matched the call regex, but the path argument was `u.String()` rather than a literal — so `extractPath` returned `""` and the call was discarded. The endpoint then showed up as uncovered even though it was wrapped.

## Fix

- Maintain a per-file map of `<var>` → path for `url.URL{Path: ...}` assignments.
- When the call argument is `<var>.String()`, look up the path from that map.
- Factored out `extractPathExpr` so the literal/`fmt.Sprintf` extraction is shared between call sites and url.URL declarations.

The per-file scope is sufficient because every `<var> := url.URL{Path: ...}` is followed by the corresponding Get/Post in the same function, so the most-recent binding for `<var>` is always the right one when the call is read.

## Impact

| metric | before | after |
|---|---:|---:|
| call sites scanned | 368 | 378 |
| matched | 367 | 377 |
| no-match | 1 | 1 (same `serviceAction` outlier) |
| match rate | 99.7% | 99.7% |
| unique covered | 354 / 675 (**52.4%**) | 363 / 675 (**53.8%**) |

10 newly-counted sites → 9 unique additional covered endpoints (`pools.go:28 /pools/` and `pools.go:77 /pools` normalize to the same path).

### Area shifts

| area | before | after |
|---|---:|---:|
| `nodes/qemu` | 78 | 79 (RRDData) |
| `nodes/lxc` | 53 | 55 (RRD + RRDData) |
| `access` | 39 | 40 (Permissions) |
| `cluster` | 94 | 96 (Resources + SDN zones) |
| `pools` | 5 | **7 / 7 — 100%** |

`pools` is now fully covered — the 2 "missing" entries were already wrapped, just hidden by the tool.

### Why it matters now

We were about to dispatch sub-agents to write wrappers for the qemu coverage gaps. Without this fix we'd have written a duplicate wrapper for `RRDData` and possibly others. Fixing the tool first ensures the gap list reflects what's actually missing.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `mage -l` still lists `endpoints:sync`, `endpoints:extract`, `endpoints:coverage`
- [x] `mage endpoints:coverage` runs successfully, prints the new numbers above
- [x] Match rate stable at 99.7% — fix didn't regress any previously-resolved call sites