### PR TITLE
feat: wrap remaining qemu /agent endpoints — index, generic exec, get-memory-block-info

### DIFF
--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -1010,6 +1010,28 @@ func virtualMachines() {
 
 	gock.New(config.C.URI).
 		Persist().
+		Get("^/nodes/node1/qemu/101/agent$").
+		Reply(200).
+		JSON(`{"data": [
+			{"name": "exec"},
+			{"name": "ping"},
+			{"name": "fsfreeze-status"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent$").
+		Reply(200).
+		JSON(`{"data": {"result": {"echoed": "ping"}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-memory-block-info$").
+		Reply(200).
+		JSON(`{"data": {"result": {"size": 134217728}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
 		Post("^/nodes/node1/qemu/101/agent/ping$").
 		Reply(200).
 		JSON(`{"data": {"result": {}}}`)

--- a/types.go
+++ b/types.go
@@ -1997,6 +1997,19 @@ type AgentMemoryBlock struct {
 	CanOffline  bool `json:"can-offline,omitempty"`
 }
 
+// AgentMemoryBlockInfo is the response payload from qga's
+// guest-get-memory-block-info — currently just the per-block size in bytes.
+type AgentMemoryBlockInfo struct {
+	Size uint64 `json:"size"`
+}
+
+// AgentCommandIndexEntry is one entry in the GET /agent command index. PVE
+// only documents `{}` items, but exposes the subroute as the link's "name",
+// so we accept it as an open struct and surface the name when present.
+type AgentCommandIndexEntry struct {
+	Name string `json:"name,omitempty"`
+}
+
 // AgentFsfreezeStatus is the freeze state string ("thawed" or "frozen")
 // returned by qga's guest-fsfreeze-status.
 type AgentFsfreezeStatus string

--- a/virtual_machine_agent.go
+++ b/virtual_machine_agent.go
@@ -17,6 +17,38 @@ import (
 // the standard {"data": ...} envelope the client already strips. The helpers
 // below unwrap that inner "result" before returning a typed value.
 
+// AgentCommandIndex lists the QEMU guest-agent sub-commands the PVE node
+// exposes for this VM. This is the index served at GET /agent — it surfaces
+// the routing table the proxy itself knows about and is independent of what
+// the in-guest agent actually advertises (see AgentGetInfo for that).
+func (v *VirtualMachine) AgentCommandIndex(ctx context.Context) ([]*AgentCommandIndexEntry, error) {
+	var out []*AgentCommandIndexEntry
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent", v.Node, v.VMID), &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// AgentCommand is the low-level POST /agent helper that runs any QGA command
+// by name. The specific helpers (AgentPing, AgentGetTime, …) are preferable
+// for known commands because they return typed values; this exists for the
+// rare command not otherwise wrapped (or for forward-compat with new QGA
+// verbs PVE adds). PVE constrains the accepted names — see the enum on the
+// API endpoint — but we don't gate that here so callers stay forward-compat.
+// The raw {"result": ...} envelope payload is returned as a JSON map.
+func (v *VirtualMachine) AgentCommand(ctx context.Context, command string) (map[string]interface{}, error) {
+	body := map[string]interface{}{
+		"command": command,
+	}
+	var resp struct {
+		Result map[string]interface{} `json:"result"`
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent", v.Node, v.VMID), body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
 // AgentPing is a cheap probe that the guest-agent socket is reachable. PVE
 // returns an empty result on success; any non-nil error means the agent is
 // unreachable or the VM is off.
@@ -93,6 +125,19 @@ func (v *VirtualMachine) AgentGetMemoryBlocks(ctx context.Context) ([]*AgentMemo
 		Result []*AgentMemoryBlock `json:"result"`
 	}
 	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-memory-blocks", v.Node, v.VMID), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentGetMemoryBlockInfo returns hot-pluggable memory-block sizing for the
+// guest — the per-block byte size that AgentGetMemoryBlocks's phys-index
+// references. Returns zero on guests without memory-hotplug support.
+func (v *VirtualMachine) AgentGetMemoryBlockInfo(ctx context.Context) (*AgentMemoryBlockInfo, error) {
+	var resp struct {
+		Result *AgentMemoryBlockInfo `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-memory-block-info", v.Node, v.VMID), &resp); err != nil {
 		return nil, err
 	}
 	return resp.Result, nil

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -482,6 +482,36 @@ func TestVirtualMachine_AgentFileWrite(t *testing.T) {
 	assert.Nil(t, vm.AgentFileWrite(context.Background(), "/tmp/foo", []byte("hello")))
 }
 
+func TestVirtualMachine_AgentCommandIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	cmds, err := vm.AgentCommandIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, cmds, 3)
+	assert.Equal(t, "exec", cmds[0].Name)
+	assert.Equal(t, "ping", cmds[1].Name)
+}
+
+func TestVirtualMachine_AgentCommand(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	out, err := vm.AgentCommand(context.Background(), "ping")
+	assert.Nil(t, err)
+	assert.Equal(t, "ping", out["echoed"])
+}
+
+func TestVirtualMachine_AgentGetMemoryBlockInfo(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	info, err := vm.AgentGetMemoryBlockInfo(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, uint64(134217728), info.Size)
+}
+
 func TestVirtualMachine_Snapshots(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()


### PR DESCRIPTION
## Summary

Closes 3 coverage gaps under `/nodes/{node}/qemu/{vmid}/agent` left over from PR #286 / #288. All exposed on `*VirtualMachine`, follow the existing `result`-envelope pattern.

- **`AgentCommandIndex`** — `GET /agent`: lists the QGA sub-commands the PVE node exposes (proxy routing table, distinct from the guest-advertised set already returned by `AgentGetInfo`).
- **`AgentCommand`** — `POST /agent`: low-level generic executor that runs any QGA command by name. Returns the raw `{"result": ...}` map so callers can hit commands not specifically wrapped (and stay forward-compat as PVE adds new QGA verbs). PVE enforces the command enum server-side; we don't gate it client-side.
- **`AgentGetMemoryBlockInfo`** — `GET /agent/get-memory-block-info`: per-block byte size that `AgentGetMemoryBlocks`'s `phys-index` references.

New types in `types.go`: `AgentCommandIndexEntry`, `AgentMemoryBlockInfo`.

### Coverage delta

| area | before | after |
|---|---:|---:|
| `nodes/qemu` | 79 / 97 (81.4%) | **82 / 97 (84.5%)** |

All three endpoints disappear from `.cache/pve-api/coverage.txt`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `mage test:unit` — all green, new tests `TestVirtualMachine_AgentCommandIndex`, `TestVirtualMachine_AgentCommand`, `TestVirtualMachine_AgentGetMemoryBlockInfo` pass against pve9x mocks
- [x] `mage endpoints:coverage` — `nodes/qemu` jumps from 81.4% → 84.5%, the three target endpoints no longer in uncovered list