### PR TITLE
feat: wrap qemu /config (PUT sync), /feature, /dbus-vmstate

### DIFF
--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -762,6 +762,33 @@ func virtualMachines() {
     "data": "UPID:node1:00000004:00000004:00000004:qmconfig:100:root@pam:"
 }`)
 
+	// PUT /nodes/{node}/qemu/{vmid}/config - synchronous VM config update
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/qemu/100/config$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/qemu/{vmid}/feature - feature availability check
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/feature$").
+		MatchParam("feature", "[a-z]+").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "hasFeature": true,
+        "nodes": ["node1", "node2"]
+    }
+}`)
+
+	// POST /nodes/{node}/qemu/{vmid}/dbus-vmstate - control dbus-vmstate helper
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/100/dbus-vmstate$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
 	// POST /nodes/{node}/qemu/{vmid}/status/start - Start VM
 	gock.New(config.C.URI).
 		Post("^/nodes/node1/qemu/100/status/start$").

--- a/types.go
+++ b/types.go
@@ -1076,6 +1076,15 @@ func indexedDeviceKey(k string) (prefix string, ok bool) {
 	return "", false
 }
 
+// VirtualMachineFeature is the response payload of
+// GET /nodes/{node}/qemu/{vmid}/feature. HasFeature reports whether the
+// requested feature is available for the VM (and optional snapshot); Nodes
+// lists the cluster nodes on which the feature is available.
+type VirtualMachineFeature struct {
+	HasFeature bool     `json:"hasFeature"`
+	Nodes      []string `json:"nodes,omitempty"`
+}
+
 type VirtualMachineMigrateOptions struct {
 	Target           string    `json:"target"`
 	BWLimit          uint64    `json:"bwlimit,omitempty"` // FIXME(issue-199): PVE default = datacenter/storage migrate limit; use *uint64 so unset doesn't impose 0.

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -54,6 +54,44 @@ func (v *VirtualMachine) Config(ctx context.Context, options ...VirtualMachineOp
 	return NewTask(upid, v.client), err
 }
 
+// ConfigSync sets virtual machine options using the synchronous API
+// (PUT /nodes/{node}/qemu/{vmid}/config). It blocks until the change is
+// applied and does not return a task. Per the upstream docs, prefer the
+// asynchronous variant (Config) for any actions involving hotplug or storage
+// allocation.
+func (v *VirtualMachine) ConfigSync(ctx context.Context, options ...VirtualMachineOption) error {
+	data := make(map[string]interface{})
+	for _, opt := range options {
+		data[opt.Name] = opt.Value
+	}
+	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", v.Node, v.VMID), data, nil)
+}
+
+// Feature checks whether a given feature (for example "snapshot", "clone",
+// or "copy") is available for this VM. When snapname is non-empty the check
+// is performed against that specific snapshot. The returned VirtualMachineFeature
+// also lists which cluster nodes the feature is available on.
+func (v *VirtualMachine) Feature(ctx context.Context, feature, snapname string) (VirtualMachineFeature, error) {
+	var result VirtualMachineFeature
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/feature", v.Node, v.VMID)}
+	params := url.Values{}
+	params.Set("feature", feature)
+	if snapname != "" {
+		params.Set("snapname", snapname)
+	}
+	u.RawQuery = params.Encode()
+	err := v.client.Get(ctx, u.String(), &result)
+	return result, err
+}
+
+// DBusVMState controls the dbus-vmstate helper for a running VM. Valid
+// actions are "start" and "stop". This is a niche endpoint used to migrate
+// additional VM state via the dbus-vmstate helper.
+func (v *VirtualMachine) DBusVMState(ctx context.Context, action string) error {
+	data := map[string]interface{}{"action": action}
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/dbus-vmstate", v.Node, v.VMID), data, nil)
+}
+
 func (v *VirtualMachine) Monitor(ctx context.Context, command string) (s string, err error) {
 	data := make(map[string]interface{})
 	data["command"] = command

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -186,6 +186,60 @@ func TestVirtualMachine_Config(t *testing.T) {
 	assert.Equal(t, "100", task.ID)
 }
 
+func TestVirtualMachine_ConfigSync(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   100,
+		Node:   "node1",
+	}
+
+	// ConfigSync blocks until the change is applied and returns no task.
+	err := vm.ConfigSync(ctx, VirtualMachineOption{Name: "description", Value: "synchronous update"})
+	assert.Nil(t, err)
+}
+
+func TestVirtualMachine_Feature(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   100,
+		Node:   "node1",
+	}
+
+	// Feature without a snapshot.
+	feature, err := vm.Feature(ctx, "snapshot", "")
+	assert.Nil(t, err)
+	assert.True(t, feature.HasFeature)
+	assert.Equal(t, []string{"node1", "node2"}, feature.Nodes)
+
+	// Feature against a specific snapshot.
+	feature, err = vm.Feature(ctx, "clone", "snap1")
+	assert.Nil(t, err)
+	assert.True(t, feature.HasFeature)
+}
+
+func TestVirtualMachine_DBusVMState(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   100,
+		Node:   "node1",
+	}
+
+	assert.Nil(t, vm.DBusVMState(ctx, "start"))
+	assert.Nil(t, vm.DBusVMState(ctx, "stop"))
+}
+
 func TestVirtualMachine_Start(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()


### PR DESCRIPTION
## Summary

Adds three previously-uncovered `/nodes/{node}/qemu/{vmid}` wrappers:

- `VirtualMachine.ConfigSync` — `PUT /config`, the synchronous variant of the existing async `POST /config`. Reuses `VirtualMachineOption` and blocks until the change is applied rather than returning a UPID/Task. Per the upstream docs, prefer the async `Config` for hotplug or storage allocation.
- `VirtualMachine.Feature` — `GET /feature`, checks if a feature (`clone`/`snapshot`/`copy`) is available for the VM, optionally against a specific snapshot. Returns `hasFeature` + `nodes` via a new `VirtualMachineFeature` type.
- `VirtualMachine.DBusVMState` — `POST /dbus-vmstate`, controls the dbus-vmstate helper for live-migrating additional VM state (`start`/`stop`).

Includes gock mocks under `tests/mocks/pve9x/virtual_machines.go` and matching unit tests in `virtual_machine_test.go`. The `nodes/qemu` coverage moves from 79/97 to 82/97 (~84.5%) — all three target endpoints disappear from `.cache/pve-api/coverage.txt`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `mage test:unit` — passes
- [x] `mage endpoints:coverage` — confirms `PUT /nodes/{node}/qemu/{vmid}/config`, `GET /nodes/{node}/qemu/{vmid}/feature`, and `POST /nodes/{node}/qemu/{vmid}/dbus-vmstate` are no longer in the uncovered list