### PR TITLE
feat: wrap qemu /rrd (PNG), /migrate (preconditions), /remote_migrate

### DIFF
--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -715,6 +715,48 @@ func virtualMachines() {
     ]
 }`)
 
+	// GET /nodes/{node}/qemu/{vmid}/rrd - render single-DS PNG, returns filename
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/rrd$").
+		Reply(200).
+		JSON(`{"data": {"filename": "/var/lib/rrdcached/db/pve2-vm/101.png"}}`)
+
+	// GET /nodes/{node}/qemu/{vmid}/migrate - migration preconditions
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/migrate$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "running": true,
+        "has-dbus-vmstate": true,
+        "allowed_nodes": ["node2", "node3"],
+        "not_allowed_nodes": {
+            "node4": {
+                "unavailable_storages": ["local-lvm"],
+                "blocking-ha-resources": [
+                    {"sid": "vm:101", "cause": "node-affinity"}
+                ]
+            }
+        },
+        "local_disks": [
+            {"volid": "local-lvm:vm-101-disk-0", "size": 34359738368, "cdrom": false, "is_unused": false}
+        ],
+        "local_resources": [],
+        "mapped-resources": [],
+        "mapped-resource-info": {},
+        "dependent-ha-resources": []
+    }
+}`)
+
+	// POST /nodes/{node}/qemu/{vmid}/remote_migrate - cross-cluster migration
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/remote_migrate$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00009ABC:0000DEAD:5A3B7C8D:qmremote-migrate:101:root@pam:"}`)
+
 	// POST /nodes/{node}/qemu/{vmid}/clone - Clone VM
 	gock.New(config.C.URI).
 		Post("^/nodes/node1/qemu/101/clone").

--- a/types.go
+++ b/types.go
@@ -1142,6 +1142,71 @@ type ContainerRRD struct {
 	Filename string `json:"filename"`
 }
 
+// VirtualMachineRRD is the response from GET /nodes/{node}/qemu/{vmid}/rrd.
+// PVE renders a single PNG on the server (one datasource per call) and
+// returns its on-disk filename; callers typically want RRDData instead for
+// usable numeric series.
+type VirtualMachineRRD struct {
+	Filename string `json:"filename"`
+}
+
+// VirtualMachineRemoteMigrateOptions configures POST
+// /nodes/{node}/qemu/{vmid}/remote_migrate (cross-cluster VM migration —
+// flagged EXPERIMENTAL upstream). TargetEndpoint is the API-token bundle
+// string PVE accepts ("apitoken=PVEAPIToken=... host=... fingerprint=...");
+// see the pvesh docs for the exact shape. TargetBridge and TargetStorage are
+// "src=tgt,src2=tgt2" pair-list maps; the special value "1" maps each source
+// to itself.
+type VirtualMachineRemoteMigrateOptions struct {
+	TargetEndpoint string    `json:"target-endpoint"`
+	TargetBridge   string    `json:"target-bridge"`
+	TargetStorage  string    `json:"target-storage"`
+	TargetVMID     int       `json:"target-vmid,omitempty"`
+	BWLimit        uint64    `json:"bwlimit,omitempty"`
+	Delete         IntOrBool `json:"delete,omitempty"`
+	Online         IntOrBool `json:"online,omitempty"`
+}
+
+// VirtualMachineMigratePreconditionsLocalDisk describes one local disk
+// surfaced by GET /nodes/{node}/qemu/{vmid}/migrate. Local disks block
+// live migration unless WithLocalDisks is enabled on Migrate.
+type VirtualMachineMigratePreconditionsLocalDisk struct {
+	VolID    string `json:"volid"`
+	Size     uint64 `json:"size,omitempty"`
+	CDROM    bool   `json:"cdrom,omitempty"`
+	IsUnused bool   `json:"is_unused,omitempty"`
+}
+
+// VirtualMachineMigratePreconditionsBlockingHAResource identifies a HA
+// resource preventing the VM from migrating to a particular node.
+type VirtualMachineMigratePreconditionsBlockingHAResource struct {
+	SID   string `json:"sid"`
+	Cause string `json:"cause"` // "node-affinity" or "resource-affinity"
+}
+
+// VirtualMachineMigratePreconditionsNotAllowedNodes carries the per-node
+// reasons a target node is rejected for migration.
+type VirtualMachineMigratePreconditionsNotAllowedNodes struct {
+	UnavailableStorages  []string                                                `json:"unavailable_storages,omitempty"`
+	BlockingHAResources  []*VirtualMachineMigratePreconditionsBlockingHAResource `json:"blocking-ha-resources,omitempty"`
+}
+
+// VirtualMachineMigratePreconditions is the response from
+// GET /nodes/{node}/qemu/{vmid}/migrate — a dry-run summary of whether the
+// VM can be migrated, which nodes accept it, and what local state would
+// have to be moved along with it. Pre-flight only; no task is created.
+type VirtualMachineMigratePreconditions struct {
+	Running             bool                                                          `json:"running"`
+	HasDBusVMState      bool                                                          `json:"has-dbus-vmstate"`
+	AllowedNodes        []string                                                      `json:"allowed_nodes,omitempty"`
+	NotAllowedNodes     map[string]*VirtualMachineMigratePreconditionsNotAllowedNodes `json:"not_allowed_nodes,omitempty"`
+	LocalDisks          []*VirtualMachineMigratePreconditionsLocalDisk                `json:"local_disks,omitempty"`
+	LocalResources      []string                                                      `json:"local_resources,omitempty"`
+	MappedResources     []string                                                      `json:"mapped-resources,omitempty"`
+	MappedResourceInfo  map[string]interface{}                                        `json:"mapped-resource-info,omitempty"`
+	DependentHAResources []string                                                     `json:"dependent-ha-resources,omitempty"`
+}
+
 // SpiceProxy carries the SPICE connection info returned by /spiceproxy.
 // The field names match the keys remote-viewer expects in its .vv config.
 type SpiceProxy struct {

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -470,6 +470,23 @@ func (v *VirtualMachine) deleteCloudInitISO(ctx context.Context) (ok bool, err e
 	return true, nil
 }
 
+// MigratePreconditions is the pre-flight sibling of Migrate: it returns
+// whether the VM is movable, which target nodes accept it, and what local
+// state (disks, PCI/USB resources, HA dependencies) would have to be moved
+// along with it. target is optional — pass "" to query against every node
+// in the cluster; pass a node name to scope the answer to just that target.
+// No task is created.
+func (v *VirtualMachine) MigratePreconditions(ctx context.Context, target string) (preconditions *VirtualMachineMigratePreconditions, err error) {
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/migrate", v.Node, v.VMID)}
+	if target != "" {
+		params := url.Values{}
+		params.Add("target", target)
+		u.RawQuery = params.Encode()
+	}
+	err = v.client.Get(ctx, u.String(), &preconditions)
+	return
+}
+
 func (v *VirtualMachine) Migrate(
 	ctx context.Context,
 	params *VirtualMachineMigrateOptions,
@@ -484,6 +501,22 @@ func (v *VirtualMachine) Migrate(
 		return nil, err
 	}
 
+	return NewTask(upid, v.client), nil
+}
+
+// RemoteMigrate triggers a cross-cluster migration of this VM. The target
+// endpoint is an API-token bundle string per PVE's pvesh docs (e.g.
+// "apitoken=PVEAPIToken=user@pam!tok=secret host=target.example.com
+// fingerprint=AA:BB:..."). EXPERIMENTAL upstream — the schema and behavior
+// may change between PVE versions.
+func (v *VirtualMachine) RemoteMigrate(ctx context.Context, params *VirtualMachineRemoteMigrateOptions) (task *Task, err error) {
+	var upid UPID
+	if params == nil {
+		params = &VirtualMachineRemoteMigrateOptions{}
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/remote_migrate", v.Node, v.VMID), params, &upid); err != nil {
+		return nil, err
+	}
 	return NewTask(upid, v.client), nil
 }
 
@@ -806,6 +839,26 @@ func (v *VirtualMachine) UpdateSnapshot(ctx context.Context, snapshot string, op
 		options = &VirtualMachineSnapshotUpdateOptions{}
 	}
 	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", v.Node, v.VMID, snapshot), options, nil)
+}
+
+// RRD asks PVE to render a single-datasource PNG on the server and returns
+// its on-disk filename (the file lives in PVE's rrdcached directory). Most
+// callers want RRDData instead for numeric series; this exists for API
+// parity with the web UI's graph rendering.
+func (v *VirtualMachine) RRD(ctx context.Context, ds string, timeframe Timeframe, consolidationFunction ...ConsolidationFunction) (rrd *VirtualMachineRRD, err error) {
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/rrd", v.Node, v.VMID)}
+	params := url.Values{}
+	if len(consolidationFunction) > 0 {
+		if len(consolidationFunction) != 1 {
+			return nil, fmt.Errorf("only one consolidation function allowed")
+		}
+		params.Add("cf", string(consolidationFunction[0]))
+	}
+	params.Add("ds", ds)
+	params.Add("timeframe", string(timeframe))
+	u.RawQuery = params.Encode()
+	err = v.client.Get(ctx, u.String(), &rrd)
+	return
 }
 
 // RRDData takes a timeframe enum and an optional consolidation function

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -49,6 +49,73 @@ func TestVirtualMachine_RRDData(t *testing.T) {
 	assert.Len(t, rdddata, 70)
 }
 
+func TestVirtualMachine_RRD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   101,
+		Node:   "node1",
+	}
+
+	rrd, err := vm.RRD(ctx, "cpu", TimeframeHour)
+	assert.Nil(t, err)
+	require.NotNil(t, rrd)
+	assert.Contains(t, rrd.Filename, "101.png")
+}
+
+func TestVirtualMachine_MigratePreconditions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   101,
+		Node:   "node1",
+	}
+
+	pre, err := vm.MigratePreconditions(ctx, "")
+	assert.Nil(t, err)
+	require.NotNil(t, pre)
+	assert.True(t, pre.Running)
+	assert.True(t, pre.HasDBusVMState)
+	assert.Equal(t, []string{"node2", "node3"}, pre.AllowedNodes)
+	require.Contains(t, pre.NotAllowedNodes, "node4")
+	assert.Equal(t, []string{"local-lvm"}, pre.NotAllowedNodes["node4"].UnavailableStorages)
+	require.Len(t, pre.NotAllowedNodes["node4"].BlockingHAResources, 1)
+	assert.Equal(t, "vm:101", pre.NotAllowedNodes["node4"].BlockingHAResources[0].SID)
+	assert.Equal(t, "node-affinity", pre.NotAllowedNodes["node4"].BlockingHAResources[0].Cause)
+	require.Len(t, pre.LocalDisks, 1)
+	assert.Equal(t, "local-lvm:vm-101-disk-0", pre.LocalDisks[0].VolID)
+	assert.Equal(t, uint64(34359738368), pre.LocalDisks[0].Size)
+}
+
+func TestVirtualMachine_RemoteMigrate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   101,
+		Node:   "node1",
+	}
+
+	task, err := vm.RemoteMigrate(ctx, &VirtualMachineRemoteMigrateOptions{
+		TargetEndpoint: "apitoken=PVEAPIToken=user@pam!tok=secret host=target.example.com fingerprint=AA:BB",
+		TargetBridge:   "vmbr0=vmbr0",
+		TargetStorage:  "local=local",
+		TargetVMID:     201,
+		Online:         IntOrBool(true),
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+	assert.Contains(t, string(task.UPID), "qmremote-migrate")
+}
+
 func TestVirtualMachineClone(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()


### PR DESCRIPTION
## Summary

Wraps three previously-uncovered `/nodes/{node}/qemu/{vmid}` endpoints:

- `GET .../rrd` — server-rendered single-datasource PNG, returns its on-disk
  filename. Mirrors the existing `Container.RRD` shape.
- `GET .../migrate` — pre-flight preconditions for migration. Surfaces
  whether the VM is running, allowed/disallowed target nodes, local disks,
  local/mapped resources, HA dependencies, and `not_allowed_nodes` with
  per-node blocking storage / HA-resource reasons. No task is created.
- `POST .../remote_migrate` — EXPERIMENTAL upstream; cross-cluster migration
  taking a target endpoint bundle string plus storage/bridge pair-list
  mappings. Mirrors the existing `Container.RemoteMigrate` flow.

Lifts `nodes/qemu` schema coverage from 79 -> 82 / 97 (84.5%). All 3 endpoints
disappear from `.cache/pve-api/coverage.txt`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `mage test:unit` — passes locally
- [x] `mage endpoints:coverage` — nodes/qemu now 82/97; the three new
  endpoints no longer appear in the uncovered list
- [x] New unit tests in `virtual_machine_test.go` exercise each wrapper
  against gock mocks in `tests/mocks/pve9x/virtual_machines.go`:
  - `TestVirtualMachine_RRD` — confirms filename round-trip
  - `TestVirtualMachine_MigratePreconditions` — confirms full response
    decode including nested `not_allowed_nodes` and `local_disks`
  - `TestVirtualMachine_RemoteMigrate` — confirms task UPID round-trip