### PR TITLE
feat: wrap qemu firewall/log, firewall/refs, spiceproxy, vncwebsocket

### DIFF
--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -237,6 +237,13 @@ func Coverage() error {
 //	u.RawQuery = params.Encode()
 //	err := v.client.Get(ctx, u.String(), &out)
 //
+// Additionally recognizes the websocket call signature used by *.VNCWebSocket
+// and *.TermWebSocket — these wrap GET /…/vncwebsocket and do not take a
+// context, so their first argument is the path:
+//
+//	p := fmt.Sprintf("/nodes/%s/qemu/%d/vncwebsocket?…", …)
+//	return v.client.VNCWebSocket(p, vnc)
+//
 // Returns normalized (method, path) pairs.
 func scanCallSites(root string) ([]extractedCall, error) {
 	var out []extractedCall
@@ -271,6 +278,10 @@ func scanCallSites(root string) ([]extractedCall, error) {
 		// which is correct because the corresponding Get/Post call always
 		// follows the assignment in the same function.
 		urlVars := map[string]string{}
+		// Per-file map of `<var>` → path for `<var> := fmt.Sprintf("/…", …)` or
+		// `<var> := "/…"` bindings, used by call sites that pass the path as a
+		// pre-built variable rather than inline (e.g. the websocket helpers).
+		pathVars := map[string]string{}
 		for line := 1; s.Scan(); line++ {
 			text := s.Text()
 
@@ -279,32 +290,62 @@ func scanCallSites(root string) ([]extractedCall, error) {
 					urlVars[am[1]] = p
 				}
 			}
-
-			m := callRE.FindStringSubmatch(text)
-			if m == nil {
-				continue
-			}
-			method := m[1]
-			rest := m[2]
-			pathLit := extractPathExpr(rest)
-			if pathLit == "" {
-				if um := urlStringRE.FindStringSubmatch(strings.TrimSpace(rest)); um != nil {
-					pathLit = urlVars[um[1]]
+			if pm := pathAssignRE.FindStringSubmatch(text); pm != nil {
+				if p := extractPathExpr(pm[2]); p != "" {
+					pathVars[pm[1]] = p
 				}
 			}
-			if pathLit == "" {
+
+			if m := callRE.FindStringSubmatch(text); m != nil {
+				method := m[1]
+				rest := m[2]
+				pathLit := resolvePath(rest, urlVars, pathVars)
+				if pathLit != "" {
+					out = append(out, extractedCall{
+						Method: method,
+						Path:   normalizePath(pathLit),
+						File:   filepath.ToSlash(path),
+						Line:   line,
+					})
+				}
 				continue
 			}
-			out = append(out, extractedCall{
-				Method: method,
-				Path:   normalizePath(pathLit),
-				File:   filepath.ToSlash(path),
-				Line:   line,
-			})
+
+			if wm := wsCallRE.FindStringSubmatch(text); wm != nil {
+				rest := wm[2]
+				pathLit := resolvePath(rest, urlVars, pathVars)
+				if pathLit == "" {
+					continue
+				}
+				// VNCWebSocket and TermWebSocket both wrap GET /…/vncwebsocket.
+				out = append(out, extractedCall{
+					Method: "GET",
+					Path:   normalizePath(pathLit),
+					File:   filepath.ToSlash(path),
+					Line:   line,
+				})
+			}
 		}
 		return s.Err()
 	})
 	return out, err
+}
+
+// resolvePath extracts a path literal from a call argument expression. It
+// understands fmt.Sprintf literals, bare string literals, url.URL{}.String()
+// indirection, and previously-tracked path variables.
+func resolvePath(expr string, urlVars, pathVars map[string]string) string {
+	if p := extractPathExpr(expr); p != "" {
+		return p
+	}
+	trimmed := strings.TrimSpace(expr)
+	if um := urlStringRE.FindStringSubmatch(trimmed); um != nil {
+		return urlVars[um[1]]
+	}
+	if vm := varRefRE.FindStringSubmatch(trimmed); vm != nil {
+		return pathVars[vm[1]]
+	}
+	return ""
 }
 
 // extractPathExpr pulls the path literal out of an expression like:
@@ -332,11 +373,18 @@ type extractedCall struct {
 
 var (
 	callRE      = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)\s*\(\s*ctx\s*,\s*(.*?)$`)
+	wsCallRE    = regexp.MustCompile(`\b\w+\.(VNCWebSocket|TermWebSocket)\s*\(\s*(.*?)$`)
 	sprintfRE   = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
 	urlAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*url\.URL\{\s*Path:\s*(.+)\}`)
-	urlStringRE = regexp.MustCompile(`^(\w+)\.String\(\)`)
-	braceRE     = regexp.MustCompile(`\{[^}]+\}`)
-	fmtVerbRE   = regexp.MustCompile(`%[sdvqxXt]`)
+	// `<var> := fmt.Sprintf("/…", …)` or `<var> := "/…"` — bindings that later
+	// flow into a Get/Post/WS call as a bare variable reference. Captures only
+	// the rhs head so extractPathExpr can pull the string literal; the rest of
+	// the Sprintf arglist may continue on subsequent lines.
+	pathAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*(fmt\.Sprintf\(\s*"[^"]+"|"/[^"]*")`)
+	urlStringRE  = regexp.MustCompile(`^(\w+)\.String\(\)`)
+	varRefRE     = regexp.MustCompile(`^(\w+)\s*[,)]`)
+	braceRE      = regexp.MustCompile(`\{[^}]+\}`)
+	fmtVerbRE    = regexp.MustCompile(`%[sdvqxXt]`)
 	// PVE volume identifiers serialize as `<storage>:<type>/<filename>` and are
 	// represented as a single `{volume}` segment in the schema. Go code that
 	// builds the path via `fmt.Sprintf(...content/%s:%s/%s, ...)` normalizes to

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -1129,4 +1129,27 @@ func virtualMachines() {
 		Post("^/nodes/node1/qemu/101/agent/file-write$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// POST /nodes/{node}/qemu/{vmid}/spiceproxy
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/spiceproxy$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "type": "spice",
+        "host": "node1.example.com",
+        "port": "61024",
+        "tls-port": "61025",
+        "password": "secret-ticket",
+        "proxy": "http://proxy.example.com",
+        "title": "VM 101",
+        "host-subject": "OU=PVE Cluster Node,O=Proxmox VE,CN=node1",
+        "ca": "-----BEGIN CERTIFICATE-----\nMIIB...==\n-----END CERTIFICATE-----",
+        "delete-this-file": "1",
+        "secure-attention": "Ctrl+Alt+Ins",
+        "release-cursor": "Ctrl+Alt+R",
+        "toggle-fullscreen": "Shift+F11"
+    }
+}`)
 }

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -325,6 +325,13 @@ func (v *VirtualMachine) VNCWebSocket(vnc *VNC) (chan []byte, chan []byte, chan 
 	return v.client.VNCWebSocket(p, vnc)
 }
 
+// SpiceProxy returns SPICE proxy connection info for the VM. Mirrors the
+// Container.SpiceProxy surface and serializes the .vv file fields remote-viewer
+// expects.
+func (v *VirtualMachine) SpiceProxy(ctx context.Context) (spice *SpiceProxy, err error) {
+	return spice, v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/spiceproxy", v.Node, v.VMID), nil, &spice)
+}
+
 func (v *VirtualMachine) IsRunning() bool {
 	return v.Status == StatusVirtualMachineRunning && (v.QMPStatus == "" || v.QMPStatus == StatusVirtualMachineRunning)
 }

--- a/virtual_machine_firewall.go
+++ b/virtual_machine_firewall.go
@@ -26,7 +26,7 @@ func (v *VirtualMachine) FirewallGetRule(ctx context.Context, pos int) (rule *Fi
 // FirewallLog returns the per-VM firewall log entries. start/limit page the
 // result; since/until filter by UNIX epoch — pass 0 to omit.
 func (v *VirtualMachine) FirewallLog(ctx context.Context, start, limit, since, until int) (entries []*FirewallLogEntry, err error) {
-	path := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/log", v.Node, v.VMID)
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/firewall/log", v.Node, v.VMID)}
 	q := url.Values{}
 	if start > 0 {
 		q.Set("start", strconv.Itoa(start))
@@ -40,23 +40,21 @@ func (v *VirtualMachine) FirewallLog(ctx context.Context, start, limit, since, u
 	if until > 0 {
 		q.Set("until", strconv.Itoa(until))
 	}
-	if len(q) > 0 {
-		path = path + "?" + q.Encode()
-	}
-	return entries, v.client.Get(ctx, path, &entries)
+	u.RawQuery = q.Encode()
+	return entries, v.client.Get(ctx, u.String(), &entries)
 }
 
 // FirewallRefs lists IPSets and aliases reachable from this VM's scope —
 // useful when authoring rules that reference cluster/node-level objects
 // alongside VM-local ones. Pass refType ("alias"|"ipset"|"") to filter.
 func (v *VirtualMachine) FirewallRefs(ctx context.Context, refType string) (refs []*FirewallRef, err error) {
-	path := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/refs", v.Node, v.VMID)
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/firewall/refs", v.Node, v.VMID)}
 	if refType != "" {
 		q := url.Values{}
 		q.Set("type", refType)
-		path = path + "?" + q.Encode()
+		u.RawQuery = q.Encode()
 	}
-	return refs, v.client.Get(ctx, path, &refs)
+	return refs, v.client.Get(ctx, u.String(), &refs)
 }
 
 // GetFirewallAliases lists per-VM firewall aliases.

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -724,6 +724,23 @@ func TestMakeCloudInitISO_JolietSVD(t *testing.T) {
 	assert.True(t, foundJoliet, "Joliet Supplementary Volume Descriptor not found in ISO")
 }
 
+func TestVirtualMachine_SpiceProxy(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	vm := &VirtualMachine{client: client, Node: "node1", VMID: 101}
+	spice, err := vm.SpiceProxy(ctx)
+	assert.Nil(t, err)
+	require.NotNil(t, spice)
+	assert.Equal(t, "spice", spice.Type)
+	assert.Equal(t, "node1.example.com", spice.Host)
+	assert.Equal(t, "61024", spice.Port)
+	assert.Equal(t, "secret-ticket", spice.Password)
+	assert.Equal(t, "61025", spice.TLSPort)
+}
+
 func TestMakeCloudInitISO_VolumeIdentifier(t *testing.T) {
 	isoPath, err := makeCloudInitISO("test-volid.iso", "userdata", "metadata", "", "")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Closes the last four uncovered endpoints under `/nodes/{node}/qemu/{vmid}/*` reported by `mage endpoints:coverage` (run on PVE 9.x):

- `POST /nodes/{node}/qemu/{vmid}/spiceproxy` → **new** `VirtualMachine.SpiceProxy(ctx)`, mirrors `Container.SpiceProxy`. Returns the existing `*SpiceProxy` shape (the .vv-file fields remote-viewer expects).
- `GET /nodes/{node}/qemu/{vmid}/firewall/log` → existing `VirtualMachine.FirewallLog`, refactored to the `url.URL{Path:…}.String()` pattern so the coverage scanner can resolve the call site. No behavior change.
- `GET /nodes/{node}/qemu/{vmid}/firewall/refs` → same refactor for `VirtualMachine.FirewallRefs`.
- `GET /nodes/{node}/qemu/{vmid}/vncwebsocket` → existing `VirtualMachine.VNCWebSocket` (unchanged). Coverage scanner extended to recognize `*.VNCWebSocket(p, …)` / `*.TermWebSocket(p, …)` call sites — previously invisible because they don't route through `Get`/`Post`/`Put`/`Delete`. As a side effect, `Node.VNCWebSocket` and `Container.VNCWebSocket` also become visible (`nodes/vncwebsocket` and `nodes/lxc` coverage tick up).

### Scanner extension (`mage/endpoints/endpoints.go`)

Two additions, both narrow:

1. `wsCallRE` matches `<recv>.VNCWebSocket(<arg>, …)` / `<recv>.TermWebSocket(<arg>, …)` and synthesizes a `GET` against the same schema path the websocket endpoints use.
2. `pathAssignRE` tracks per-file `<var> := fmt.Sprintf("/…", …)` and `<var> := "/…"` bindings so the WS call site can resolve its first arg back to the path string. The existing `urlVars` map already handled the `url.URL{Path:…}` indirection; this is the analogue for plain string vars.

### Coverage delta

```
              before   after
nodes/qemu     79/97   83/97
nodes/lxc      55/62   56/62
nodes/vncwebsocket 0/1   1/1
overall      377/675 387/675
```

All 4 target endpoints disappear from `.cache/pve-api/coverage.txt`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `mage test:unit` (new `TestVirtualMachine_SpiceProxy` plus existing firewall tests, all green)
- [x] `mage endpoints:coverage` — `nodes/qemu` 79 → 83
- [ ] Smoke against a live PVE VM (SpiceProxy returns a real .vv config)