### PR TITLE
feat: nodes/qemu → 99% (100% real) — combined sweep of #301-#305

### DIFF
--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -237,6 +237,13 @@ func Coverage() error {
 //	u.RawQuery = params.Encode()
 //	err := v.client.Get(ctx, u.String(), &out)
 //
+// Additionally recognizes the websocket call signature used by *.VNCWebSocket
+// and *.TermWebSocket — these wrap GET /…/vncwebsocket and do not take a
+// context, so their first argument is the path:
+//
+//	p := fmt.Sprintf("/nodes/%s/qemu/%d/vncwebsocket?…", …)
+//	return v.client.VNCWebSocket(p, vnc)
+//
 // Returns normalized (method, path) pairs.
 func scanCallSites(root string) ([]extractedCall, error) {
 	var out []extractedCall
@@ -271,6 +278,10 @@ func scanCallSites(root string) ([]extractedCall, error) {
 		// which is correct because the corresponding Get/Post call always
 		// follows the assignment in the same function.
 		urlVars := map[string]string{}
+		// Per-file map of `<var>` → path for `<var> := fmt.Sprintf("/…", …)` or
+		// `<var> := "/…"` bindings, used by call sites that pass the path as a
+		// pre-built variable rather than inline (e.g. the websocket helpers).
+		pathVars := map[string]string{}
 		for line := 1; s.Scan(); line++ {
 			text := s.Text()
 
@@ -279,32 +290,62 @@ func scanCallSites(root string) ([]extractedCall, error) {
 					urlVars[am[1]] = p
 				}
 			}
-
-			m := callRE.FindStringSubmatch(text)
-			if m == nil {
-				continue
-			}
-			method := m[1]
-			rest := m[2]
-			pathLit := extractPathExpr(rest)
-			if pathLit == "" {
-				if um := urlStringRE.FindStringSubmatch(strings.TrimSpace(rest)); um != nil {
-					pathLit = urlVars[um[1]]
+			if pm := pathAssignRE.FindStringSubmatch(text); pm != nil {
+				if p := extractPathExpr(pm[2]); p != "" {
+					pathVars[pm[1]] = p
 				}
 			}
-			if pathLit == "" {
+
+			if m := callRE.FindStringSubmatch(text); m != nil {
+				method := m[1]
+				rest := m[2]
+				pathLit := resolvePath(rest, urlVars, pathVars)
+				if pathLit != "" {
+					out = append(out, extractedCall{
+						Method: method,
+						Path:   normalizePath(pathLit),
+						File:   filepath.ToSlash(path),
+						Line:   line,
+					})
+				}
 				continue
 			}
-			out = append(out, extractedCall{
-				Method: method,
-				Path:   normalizePath(pathLit),
-				File:   filepath.ToSlash(path),
-				Line:   line,
-			})
+
+			if wm := wsCallRE.FindStringSubmatch(text); wm != nil {
+				rest := wm[2]
+				pathLit := resolvePath(rest, urlVars, pathVars)
+				if pathLit == "" {
+					continue
+				}
+				// VNCWebSocket and TermWebSocket both wrap GET /…/vncwebsocket.
+				out = append(out, extractedCall{
+					Method: "GET",
+					Path:   normalizePath(pathLit),
+					File:   filepath.ToSlash(path),
+					Line:   line,
+				})
+			}
 		}
 		return s.Err()
 	})
 	return out, err
+}
+
+// resolvePath extracts a path literal from a call argument expression. It
+// understands fmt.Sprintf literals, bare string literals, url.URL{}.String()
+// indirection, and previously-tracked path variables.
+func resolvePath(expr string, urlVars, pathVars map[string]string) string {
+	if p := extractPathExpr(expr); p != "" {
+		return p
+	}
+	trimmed := strings.TrimSpace(expr)
+	if um := urlStringRE.FindStringSubmatch(trimmed); um != nil {
+		return urlVars[um[1]]
+	}
+	if vm := varRefRE.FindStringSubmatch(trimmed); vm != nil {
+		return pathVars[vm[1]]
+	}
+	return ""
 }
 
 // extractPathExpr pulls the path literal out of an expression like:
@@ -332,11 +373,18 @@ type extractedCall struct {
 
 var (
 	callRE      = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)\s*\(\s*ctx\s*,\s*(.*?)$`)
+	wsCallRE    = regexp.MustCompile(`\b\w+\.(VNCWebSocket|TermWebSocket)\s*\(\s*(.*?)$`)
 	sprintfRE   = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
 	urlAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*url\.URL\{\s*Path:\s*(.+)\}`)
-	urlStringRE = regexp.MustCompile(`^(\w+)\.String\(\)`)
-	braceRE     = regexp.MustCompile(`\{[^}]+\}`)
-	fmtVerbRE   = regexp.MustCompile(`%[sdvqxXt]`)
+	// `<var> := fmt.Sprintf("/…", …)` or `<var> := "/…"` — bindings that later
+	// flow into a Get/Post/WS call as a bare variable reference. Captures only
+	// the rhs head so extractPathExpr can pull the string literal; the rest of
+	// the Sprintf arglist may continue on subsequent lines.
+	pathAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*(fmt\.Sprintf\(\s*"[^"]+"|"/[^"]*")`)
+	urlStringRE  = regexp.MustCompile(`^(\w+)\.String\(\)`)
+	varRefRE     = regexp.MustCompile(`^(\w+)\s*[,)]`)
+	braceRE      = regexp.MustCompile(`\{[^}]+\}`)
+	fmtVerbRE    = regexp.MustCompile(`%[sdvqxXt]`)
 	// PVE volume identifiers serialize as `<storage>:<type>/<filename>` and are
 	// represented as a single `{volume}` segment in the schema. Go code that
 	// builds the path via `fmt.Sprintf(...content/%s:%s/%s, ...)` normalizes to

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -1129,4 +1129,27 @@ func virtualMachines() {
 		Post("^/nodes/node1/qemu/101/agent/file-write$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// POST /nodes/{node}/qemu/{vmid}/spiceproxy
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/spiceproxy$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "type": "spice",
+        "host": "node1.example.com",
+        "port": "61024",
+        "tls-port": "61025",
+        "password": "secret-ticket",
+        "proxy": "http://proxy.example.com",
+        "title": "VM 101",
+        "host-subject": "OU=PVE Cluster Node,O=Proxmox VE,CN=node1",
+        "ca": "-----BEGIN CERTIFICATE-----\nMIIB...==\n-----END CERTIFICATE-----",
+        "delete-this-file": "1",
+        "secure-attention": "Ctrl+Alt+Ins",
+        "release-cursor": "Ctrl+Alt+R",
+        "toggle-fullscreen": "Shift+F11"
+    }
+}`)
 }

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -1010,6 +1010,28 @@ func virtualMachines() {
 
 	gock.New(config.C.URI).
 		Persist().
+		Get("^/nodes/node1/qemu/101/agent$").
+		Reply(200).
+		JSON(`{"data": [
+			{"name": "exec"},
+			{"name": "ping"},
+			{"name": "fsfreeze-status"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/agent$").
+		Reply(200).
+		JSON(`{"data": {"result": {"echoed": "ping"}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/agent/get-memory-block-info$").
+		Reply(200).
+		JSON(`{"data": {"result": {"size": 134217728}}}`)
+
+	gock.New(config.C.URI).
+		Persist().
 		Post("^/nodes/node1/qemu/101/agent/ping$").
 		Reply(200).
 		JSON(`{"data": {"result": {}}}`)

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -804,6 +804,33 @@ func virtualMachines() {
     "data": "UPID:node1:00000004:00000004:00000004:qmconfig:100:root@pam:"
 }`)
 
+	// PUT /nodes/{node}/qemu/{vmid}/config - synchronous VM config update
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/qemu/100/config$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
+	// GET /nodes/{node}/qemu/{vmid}/feature - feature availability check
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/feature$").
+		MatchParam("feature", "[a-z]+").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "hasFeature": true,
+        "nodes": ["node1", "node2"]
+    }
+}`)
+
+	// POST /nodes/{node}/qemu/{vmid}/dbus-vmstate - control dbus-vmstate helper
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/100/dbus-vmstate$").
+		Reply(200).
+		JSON(`{"data": null}`)
+
 	// POST /nodes/{node}/qemu/{vmid}/status/start - Start VM
 	gock.New(config.C.URI).
 		Post("^/nodes/node1/qemu/100/status/start$").

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -1243,4 +1243,81 @@ func virtualMachines() {
         "toggle-fullscreen": "Shift+F11"
     }
 }`)
+
+	// GET /nodes/{node}/qemu/{vmid} — per-VM directory index (vmdiridx)
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"subdir": "config"},
+        {"subdir": "status"},
+        {"subdir": "snapshot"},
+        {"subdir": "firewall"},
+        {"subdir": "agent"},
+        {"subdir": "rrd"},
+        {"subdir": "rrddata"},
+        {"subdir": "monitor"},
+        {"subdir": "termproxy"},
+        {"subdir": "vncproxy"},
+        {"subdir": "vncwebsocket"},
+        {"subdir": "spiceproxy"},
+        {"subdir": "feature"},
+        {"subdir": "clone"},
+        {"subdir": "move_disk"},
+        {"subdir": "migrate"},
+        {"subdir": "resize"},
+        {"subdir": "sendkey"},
+        {"subdir": "unlink"},
+        {"subdir": "template"},
+        {"subdir": "cloudinit"},
+        {"subdir": "pending"},
+        {"subdir": "mtunnel"},
+        {"subdir": "mtunnelwebsocket"}
+    ]
+}`)
+
+	// GET /nodes/{node}/qemu/{vmid}/status — status directory index (vmcmdidx)
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/status$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"subdir": "current"},
+        {"subdir": "start"},
+        {"subdir": "stop"},
+        {"subdir": "reset"},
+        {"subdir": "shutdown"},
+        {"subdir": "suspend"},
+        {"subdir": "resume"},
+        {"subdir": "reboot"}
+    ]
+}`)
+
+	// GET /nodes/{node}/qemu/{vmid}/snapshot/{snapname} — snapshot directory index (snapshot_cmd_idx)
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/100/snapshot/snap1$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"subdir": "config"},
+        {"subdir": "rollback"}
+    ]
+}`)
+
+	// POST /nodes/{node}/qemu/{vmid}/mtunnel — open migration tunnel
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/100/mtunnel$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "socket": "/run/qemu-server/100.mtunnel",
+        "ticket": "PVEMTUNNELTICKET:abc123",
+        "upid": "UPID:node1:00001234:00005678:00009ABC:qmtunnel:100:root@pam:"
+    }
+}`)
 }

--- a/tests/mocks/pve9x/virtual_machines.go
+++ b/tests/mocks/pve9x/virtual_machines.go
@@ -715,6 +715,48 @@ func virtualMachines() {
     ]
 }`)
 
+	// GET /nodes/{node}/qemu/{vmid}/rrd - render single-DS PNG, returns filename
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/rrd$").
+		Reply(200).
+		JSON(`{"data": {"filename": "/var/lib/rrdcached/db/pve2-vm/101.png"}}`)
+
+	// GET /nodes/{node}/qemu/{vmid}/migrate - migration preconditions
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/qemu/101/migrate$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "running": true,
+        "has-dbus-vmstate": true,
+        "allowed_nodes": ["node2", "node3"],
+        "not_allowed_nodes": {
+            "node4": {
+                "unavailable_storages": ["local-lvm"],
+                "blocking-ha-resources": [
+                    {"sid": "vm:101", "cause": "node-affinity"}
+                ]
+            }
+        },
+        "local_disks": [
+            {"volid": "local-lvm:vm-101-disk-0", "size": 34359738368, "cdrom": false, "is_unused": false}
+        ],
+        "local_resources": [],
+        "mapped-resources": [],
+        "mapped-resource-info": {},
+        "dependent-ha-resources": []
+    }
+}`)
+
+	// POST /nodes/{node}/qemu/{vmid}/remote_migrate - cross-cluster migration
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/qemu/101/remote_migrate$").
+		Reply(200).
+		JSON(`{"data": "UPID:node1:00009ABC:0000DEAD:5A3B7C8D:qmremote-migrate:101:root@pam:"}`)
+
 	// POST /nodes/{node}/qemu/{vmid}/clone - Clone VM
 	gock.New(config.C.URI).
 		Post("^/nodes/node1/qemu/101/clone").

--- a/types.go
+++ b/types.go
@@ -1076,6 +1076,15 @@ func indexedDeviceKey(k string) (prefix string, ok bool) {
 	return "", false
 }
 
+// VirtualMachineFeature is the response payload of
+// GET /nodes/{node}/qemu/{vmid}/feature. HasFeature reports whether the
+// requested feature is available for the VM (and optional snapshot); Nodes
+// lists the cluster nodes on which the feature is available.
+type VirtualMachineFeature struct {
+	HasFeature bool     `json:"hasFeature"`
+	Nodes      []string `json:"nodes,omitempty"`
+}
+
 type VirtualMachineMigrateOptions struct {
 	Target           string    `json:"target"`
 	BWLimit          uint64    `json:"bwlimit,omitempty"` // FIXME(issue-199): PVE default = datacenter/storage migrate limit; use *uint64 so unset doesn't impose 0.

--- a/types.go
+++ b/types.go
@@ -3440,3 +3440,49 @@ type ClusterNotificationWebhookOptions struct {
 	Digest  string   `json:"digest,omitempty"`
 	Delete  []string `json:"delete,omitempty"`
 }
+
+// --- /nodes/{node}/qemu/{vmid} directory indexes --------------------------
+
+// VirtualMachineDirIndexEntry is one row in the per-VM directory index
+// (GET /nodes/{node}/qemu/{vmid}) — each entry names a child resource
+// (config, status, snapshot, firewall, agent, …).
+type VirtualMachineDirIndexEntry struct {
+	Subdir string `json:"subdir,omitempty"`
+}
+
+// VirtualMachineStatusIndexEntry is one row in the VM status directory index
+// (GET /nodes/{node}/qemu/{vmid}/status) — each entry names a status
+// sub-command (current, start, stop, reboot, …).
+type VirtualMachineStatusIndexEntry struct {
+	Subdir string `json:"subdir,omitempty"`
+}
+
+// VirtualMachineSnapshotIndexEntry is one row in the per-snapshot directory
+// index (GET /nodes/{node}/qemu/{vmid}/snapshot/{snapname}) — each entry
+// names a sub-resource on the snapshot (config, rollback).
+type VirtualMachineSnapshotIndexEntry struct {
+	Subdir string `json:"subdir,omitempty"`
+}
+
+// --- /nodes/{node}/qemu/{vmid}/mtunnel ------------------------------------
+
+// VirtualMachineMigrationTunnel is the response from POST
+// /nodes/{node}/qemu/{vmid}/mtunnel — a Unix socket path plus an
+// authentication ticket the caller can use with the mtunnelwebsocket
+// endpoint. PVE marks this endpoint as "for internal use by VM migration".
+type VirtualMachineMigrationTunnel struct {
+	Socket string `json:"socket,omitempty"`
+	Ticket string `json:"ticket,omitempty"`
+	UPID   string `json:"upid,omitempty"`
+}
+
+// VirtualMachineMigrationTunnelOptions is the request body for POST
+// /nodes/{node}/qemu/{vmid}/mtunnel.
+type VirtualMachineMigrationTunnelOptions struct {
+	// Bridges is a comma-separated list of network bridges to check
+	// availability for. Optional.
+	Bridges string `json:"bridges,omitempty"`
+	// Storages is a comma-separated list of storages to check permission
+	// and availability for. Optional.
+	Storages string `json:"storages,omitempty"`
+}

--- a/types.go
+++ b/types.go
@@ -1997,6 +1997,19 @@ type AgentMemoryBlock struct {
 	CanOffline  bool `json:"can-offline,omitempty"`
 }
 
+// AgentMemoryBlockInfo is the response payload from qga's
+// guest-get-memory-block-info — currently just the per-block size in bytes.
+type AgentMemoryBlockInfo struct {
+	Size uint64 `json:"size"`
+}
+
+// AgentCommandIndexEntry is one entry in the GET /agent command index. PVE
+// only documents `{}` items, but exposes the subroute as the link's "name",
+// so we accept it as an open struct and surface the name when present.
+type AgentCommandIndexEntry struct {
+	Name string `json:"name,omitempty"`
+}
+
 // AgentFsfreezeStatus is the freeze state string ("thawed" or "frozen")
 // returned by qga's guest-fsfreeze-status.
 type AgentFsfreezeStatus string

--- a/types.go
+++ b/types.go
@@ -1142,6 +1142,71 @@ type ContainerRRD struct {
 	Filename string `json:"filename"`
 }
 
+// VirtualMachineRRD is the response from GET /nodes/{node}/qemu/{vmid}/rrd.
+// PVE renders a single PNG on the server (one datasource per call) and
+// returns its on-disk filename; callers typically want RRDData instead for
+// usable numeric series.
+type VirtualMachineRRD struct {
+	Filename string `json:"filename"`
+}
+
+// VirtualMachineRemoteMigrateOptions configures POST
+// /nodes/{node}/qemu/{vmid}/remote_migrate (cross-cluster VM migration —
+// flagged EXPERIMENTAL upstream). TargetEndpoint is the API-token bundle
+// string PVE accepts ("apitoken=PVEAPIToken=... host=... fingerprint=...");
+// see the pvesh docs for the exact shape. TargetBridge and TargetStorage are
+// "src=tgt,src2=tgt2" pair-list maps; the special value "1" maps each source
+// to itself.
+type VirtualMachineRemoteMigrateOptions struct {
+	TargetEndpoint string    `json:"target-endpoint"`
+	TargetBridge   string    `json:"target-bridge"`
+	TargetStorage  string    `json:"target-storage"`
+	TargetVMID     int       `json:"target-vmid,omitempty"`
+	BWLimit        uint64    `json:"bwlimit,omitempty"`
+	Delete         IntOrBool `json:"delete,omitempty"`
+	Online         IntOrBool `json:"online,omitempty"`
+}
+
+// VirtualMachineMigratePreconditionsLocalDisk describes one local disk
+// surfaced by GET /nodes/{node}/qemu/{vmid}/migrate. Local disks block
+// live migration unless WithLocalDisks is enabled on Migrate.
+type VirtualMachineMigratePreconditionsLocalDisk struct {
+	VolID    string `json:"volid"`
+	Size     uint64 `json:"size,omitempty"`
+	CDROM    bool   `json:"cdrom,omitempty"`
+	IsUnused bool   `json:"is_unused,omitempty"`
+}
+
+// VirtualMachineMigratePreconditionsBlockingHAResource identifies a HA
+// resource preventing the VM from migrating to a particular node.
+type VirtualMachineMigratePreconditionsBlockingHAResource struct {
+	SID   string `json:"sid"`
+	Cause string `json:"cause"` // "node-affinity" or "resource-affinity"
+}
+
+// VirtualMachineMigratePreconditionsNotAllowedNodes carries the per-node
+// reasons a target node is rejected for migration.
+type VirtualMachineMigratePreconditionsNotAllowedNodes struct {
+	UnavailableStorages  []string                                                `json:"unavailable_storages,omitempty"`
+	BlockingHAResources  []*VirtualMachineMigratePreconditionsBlockingHAResource `json:"blocking-ha-resources,omitempty"`
+}
+
+// VirtualMachineMigratePreconditions is the response from
+// GET /nodes/{node}/qemu/{vmid}/migrate — a dry-run summary of whether the
+// VM can be migrated, which nodes accept it, and what local state would
+// have to be moved along with it. Pre-flight only; no task is created.
+type VirtualMachineMigratePreconditions struct {
+	Running             bool                                                          `json:"running"`
+	HasDBusVMState      bool                                                          `json:"has-dbus-vmstate"`
+	AllowedNodes        []string                                                      `json:"allowed_nodes,omitempty"`
+	NotAllowedNodes     map[string]*VirtualMachineMigratePreconditionsNotAllowedNodes `json:"not_allowed_nodes,omitempty"`
+	LocalDisks          []*VirtualMachineMigratePreconditionsLocalDisk                `json:"local_disks,omitempty"`
+	LocalResources      []string                                                      `json:"local_resources,omitempty"`
+	MappedResources     []string                                                      `json:"mapped-resources,omitempty"`
+	MappedResourceInfo  map[string]interface{}                                        `json:"mapped-resource-info,omitempty"`
+	DependentHAResources []string                                                     `json:"dependent-ha-resources,omitempty"`
+}
+
 // SpiceProxy carries the SPICE connection info returned by /spiceproxy.
 // The field names match the keys remote-viewer expects in its .vv config.
 type SpiceProxy struct {

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -54,6 +54,44 @@ func (v *VirtualMachine) Config(ctx context.Context, options ...VirtualMachineOp
 	return NewTask(upid, v.client), err
 }
 
+// ConfigSync sets virtual machine options using the synchronous API
+// (PUT /nodes/{node}/qemu/{vmid}/config). It blocks until the change is
+// applied and does not return a task. Per the upstream docs, prefer the
+// asynchronous variant (Config) for any actions involving hotplug or storage
+// allocation.
+func (v *VirtualMachine) ConfigSync(ctx context.Context, options ...VirtualMachineOption) error {
+	data := make(map[string]interface{})
+	for _, opt := range options {
+		data[opt.Name] = opt.Value
+	}
+	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", v.Node, v.VMID), data, nil)
+}
+
+// Feature checks whether a given feature (for example "snapshot", "clone",
+// or "copy") is available for this VM. When snapname is non-empty the check
+// is performed against that specific snapshot. The returned VirtualMachineFeature
+// also lists which cluster nodes the feature is available on.
+func (v *VirtualMachine) Feature(ctx context.Context, feature, snapname string) (VirtualMachineFeature, error) {
+	var result VirtualMachineFeature
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/feature", v.Node, v.VMID)}
+	params := url.Values{}
+	params.Set("feature", feature)
+	if snapname != "" {
+		params.Set("snapname", snapname)
+	}
+	u.RawQuery = params.Encode()
+	err := v.client.Get(ctx, u.String(), &result)
+	return result, err
+}
+
+// DBusVMState controls the dbus-vmstate helper for a running VM. Valid
+// actions are "start" and "stop". This is a niche endpoint used to migrate
+// additional VM state via the dbus-vmstate helper.
+func (v *VirtualMachine) DBusVMState(ctx context.Context, action string) error {
+	data := map[string]interface{}{"action": action}
+	return v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/dbus-vmstate", v.Node, v.VMID), data, nil)
+}
+
 func (v *VirtualMachine) Monitor(ctx context.Context, command string) (s string, err error) {
 	data := make(map[string]interface{})
 	data["command"] = command

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -959,3 +959,64 @@ func (v *VirtualMachine) Pending(ctx context.Context) (pending *PendingConfigura
 	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/pending", v.Node, v.VMID), &pending)
 	return
 }
+
+// DirIndex returns the per-VM directory index
+// (GET /nodes/{node}/qemu/{vmid}) — one entry per child resource (config,
+// status, snapshot, firewall, agent, …). Mostly useful for discovery; the
+// actual resources are wrapped as their own methods on *VirtualMachine.
+func (v *VirtualMachine) DirIndex(ctx context.Context) (entries []*VirtualMachineDirIndexEntry, err error) {
+	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d", v.Node, v.VMID), &entries)
+	return
+}
+
+// StatusIndex returns the VM status directory index
+// (GET /nodes/{node}/qemu/{vmid}/status) — one entry per status sub-command
+// (current, start, stop, reboot, …). The actual operations are wrapped as
+// Start/Stop/Reboot/etc. on *VirtualMachine.
+func (v *VirtualMachine) StatusIndex(ctx context.Context) (entries []*VirtualMachineStatusIndexEntry, err error) {
+	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/status", v.Node, v.VMID), &entries)
+	return
+}
+
+// SnapshotIndex returns the per-snapshot directory index
+// (GET /nodes/{node}/qemu/{vmid}/snapshot/{snapname}) — one entry per
+// sub-resource (config, rollback) on the named snapshot.
+func (v *VirtualMachine) SnapshotIndex(ctx context.Context, snapshot string) (entries []*VirtualMachineSnapshotIndexEntry, err error) {
+	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s", v.Node, v.VMID, snapshot), &entries)
+	return
+}
+
+// MigrationTunnel opens a migration tunnel for this VM
+// (POST /nodes/{node}/qemu/{vmid}/mtunnel) and returns the Unix socket path,
+// authentication ticket, and worker UPID.
+//
+// PVE marks this endpoint as "for internal use by VM migration" — callers
+// should generally use Migrate or the higher-level migration flow rather
+// than wiring this up directly. It is wrapped here only for full API
+// surface coverage.
+func (v *VirtualMachine) MigrationTunnel(ctx context.Context, options *VirtualMachineMigrationTunnelOptions) (tunnel *VirtualMachineMigrationTunnel, err error) {
+	if options == nil {
+		options = &VirtualMachineMigrationTunnelOptions{}
+	}
+	err = v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/mtunnel", v.Node, v.VMID), options, &tunnel)
+	return
+}
+
+// MigrationTunnelWebSocketPath returns the path callers can pass to a
+// websocket dialer (or to Client.VNCWebSocket-style helpers) to upgrade the
+// migration tunnel returned by MigrationTunnel
+// (GET /nodes/{node}/qemu/{vmid}/mtunnelwebsocket).
+//
+// PVE marks this endpoint as "for internal use by VM migration"; this
+// helper just builds the path with the correct query string. There is no
+// generic Client helper for migration-tunnel websockets — the protocol
+// differs from the VNC/term tunnels — so dial it directly with the
+// authenticated cookies/headers if you need to consume it.
+func (v *VirtualMachine) MigrationTunnelWebSocketPath(tunnel *VirtualMachineMigrationTunnel) string {
+	q := url.Values{}
+	if tunnel != nil {
+		q.Set("socket", tunnel.Socket)
+		q.Set("ticket", tunnel.Ticket)
+	}
+	return fmt.Sprintf("/nodes/%s/qemu/%d/mtunnelwebsocket?%s", v.Node, v.VMID, q.Encode())
+}

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -477,6 +477,23 @@ func (v *VirtualMachine) deleteCloudInitISO(ctx context.Context) (ok bool, err e
 	return true, nil
 }
 
+// MigratePreconditions is the pre-flight sibling of Migrate: it returns
+// whether the VM is movable, which target nodes accept it, and what local
+// state (disks, PCI/USB resources, HA dependencies) would have to be moved
+// along with it. target is optional — pass "" to query against every node
+// in the cluster; pass a node name to scope the answer to just that target.
+// No task is created.
+func (v *VirtualMachine) MigratePreconditions(ctx context.Context, target string) (preconditions *VirtualMachineMigratePreconditions, err error) {
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/migrate", v.Node, v.VMID)}
+	if target != "" {
+		params := url.Values{}
+		params.Add("target", target)
+		u.RawQuery = params.Encode()
+	}
+	err = v.client.Get(ctx, u.String(), &preconditions)
+	return
+}
+
 func (v *VirtualMachine) Migrate(
 	ctx context.Context,
 	params *VirtualMachineMigrateOptions,
@@ -491,6 +508,22 @@ func (v *VirtualMachine) Migrate(
 		return nil, err
 	}
 
+	return NewTask(upid, v.client), nil
+}
+
+// RemoteMigrate triggers a cross-cluster migration of this VM. The target
+// endpoint is an API-token bundle string per PVE's pvesh docs (e.g.
+// "apitoken=PVEAPIToken=user@pam!tok=secret host=target.example.com
+// fingerprint=AA:BB:..."). EXPERIMENTAL upstream — the schema and behavior
+// may change between PVE versions.
+func (v *VirtualMachine) RemoteMigrate(ctx context.Context, params *VirtualMachineRemoteMigrateOptions) (task *Task, err error) {
+	var upid UPID
+	if params == nil {
+		params = &VirtualMachineRemoteMigrateOptions{}
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/remote_migrate", v.Node, v.VMID), params, &upid); err != nil {
+		return nil, err
+	}
 	return NewTask(upid, v.client), nil
 }
 
@@ -813,6 +846,26 @@ func (v *VirtualMachine) UpdateSnapshot(ctx context.Context, snapshot string, op
 		options = &VirtualMachineSnapshotUpdateOptions{}
 	}
 	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", v.Node, v.VMID, snapshot), options, nil)
+}
+
+// RRD asks PVE to render a single-datasource PNG on the server and returns
+// its on-disk filename (the file lives in PVE's rrdcached directory). Most
+// callers want RRDData instead for numeric series; this exists for API
+// parity with the web UI's graph rendering.
+func (v *VirtualMachine) RRD(ctx context.Context, ds string, timeframe Timeframe, consolidationFunction ...ConsolidationFunction) (rrd *VirtualMachineRRD, err error) {
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/rrd", v.Node, v.VMID)}
+	params := url.Values{}
+	if len(consolidationFunction) > 0 {
+		if len(consolidationFunction) != 1 {
+			return nil, fmt.Errorf("only one consolidation function allowed")
+		}
+		params.Add("cf", string(consolidationFunction[0]))
+	}
+	params.Add("ds", ds)
+	params.Add("timeframe", string(timeframe))
+	u.RawQuery = params.Encode()
+	err = v.client.Get(ctx, u.String(), &rrd)
+	return
 }
 
 // RRDData takes a timeframe enum and an optional consolidation function

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -325,6 +325,13 @@ func (v *VirtualMachine) VNCWebSocket(vnc *VNC) (chan []byte, chan []byte, chan 
 	return v.client.VNCWebSocket(p, vnc)
 }
 
+// SpiceProxy returns SPICE proxy connection info for the VM. Mirrors the
+// Container.SpiceProxy surface and serializes the .vv file fields remote-viewer
+// expects.
+func (v *VirtualMachine) SpiceProxy(ctx context.Context) (spice *SpiceProxy, err error) {
+	return spice, v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/spiceproxy", v.Node, v.VMID), nil, &spice)
+}
+
 func (v *VirtualMachine) IsRunning() bool {
 	return v.Status == StatusVirtualMachineRunning && (v.QMPStatus == "" || v.QMPStatus == StatusVirtualMachineRunning)
 }

--- a/virtual_machine_agent.go
+++ b/virtual_machine_agent.go
@@ -17,6 +17,38 @@ import (
 // the standard {"data": ...} envelope the client already strips. The helpers
 // below unwrap that inner "result" before returning a typed value.
 
+// AgentCommandIndex lists the QEMU guest-agent sub-commands the PVE node
+// exposes for this VM. This is the index served at GET /agent — it surfaces
+// the routing table the proxy itself knows about and is independent of what
+// the in-guest agent actually advertises (see AgentGetInfo for that).
+func (v *VirtualMachine) AgentCommandIndex(ctx context.Context) ([]*AgentCommandIndexEntry, error) {
+	var out []*AgentCommandIndexEntry
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent", v.Node, v.VMID), &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// AgentCommand is the low-level POST /agent helper that runs any QGA command
+// by name. The specific helpers (AgentPing, AgentGetTime, …) are preferable
+// for known commands because they return typed values; this exists for the
+// rare command not otherwise wrapped (or for forward-compat with new QGA
+// verbs PVE adds). PVE constrains the accepted names — see the enum on the
+// API endpoint — but we don't gate that here so callers stay forward-compat.
+// The raw {"result": ...} envelope payload is returned as a JSON map.
+func (v *VirtualMachine) AgentCommand(ctx context.Context, command string) (map[string]interface{}, error) {
+	body := map[string]interface{}{
+		"command": command,
+	}
+	var resp struct {
+		Result map[string]interface{} `json:"result"`
+	}
+	if err := v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent", v.Node, v.VMID), body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
 // AgentPing is a cheap probe that the guest-agent socket is reachable. PVE
 // returns an empty result on success; any non-nil error means the agent is
 // unreachable or the VM is off.
@@ -93,6 +125,19 @@ func (v *VirtualMachine) AgentGetMemoryBlocks(ctx context.Context) ([]*AgentMemo
 		Result []*AgentMemoryBlock `json:"result"`
 	}
 	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-memory-blocks", v.Node, v.VMID), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Result, nil
+}
+
+// AgentGetMemoryBlockInfo returns hot-pluggable memory-block sizing for the
+// guest — the per-block byte size that AgentGetMemoryBlocks's phys-index
+// references. Returns zero on guests without memory-hotplug support.
+func (v *VirtualMachine) AgentGetMemoryBlockInfo(ctx context.Context) (*AgentMemoryBlockInfo, error) {
+	var resp struct {
+		Result *AgentMemoryBlockInfo `json:"result"`
+	}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/agent/get-memory-block-info", v.Node, v.VMID), &resp); err != nil {
 		return nil, err
 	}
 	return resp.Result, nil

--- a/virtual_machine_firewall.go
+++ b/virtual_machine_firewall.go
@@ -26,7 +26,7 @@ func (v *VirtualMachine) FirewallGetRule(ctx context.Context, pos int) (rule *Fi
 // FirewallLog returns the per-VM firewall log entries. start/limit page the
 // result; since/until filter by UNIX epoch — pass 0 to omit.
 func (v *VirtualMachine) FirewallLog(ctx context.Context, start, limit, since, until int) (entries []*FirewallLogEntry, err error) {
-	path := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/log", v.Node, v.VMID)
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/firewall/log", v.Node, v.VMID)}
 	q := url.Values{}
 	if start > 0 {
 		q.Set("start", strconv.Itoa(start))
@@ -40,23 +40,21 @@ func (v *VirtualMachine) FirewallLog(ctx context.Context, start, limit, since, u
 	if until > 0 {
 		q.Set("until", strconv.Itoa(until))
 	}
-	if len(q) > 0 {
-		path = path + "?" + q.Encode()
-	}
-	return entries, v.client.Get(ctx, path, &entries)
+	u.RawQuery = q.Encode()
+	return entries, v.client.Get(ctx, u.String(), &entries)
 }
 
 // FirewallRefs lists IPSets and aliases reachable from this VM's scope —
 // useful when authoring rules that reference cluster/node-level objects
 // alongside VM-local ones. Pass refType ("alias"|"ipset"|"") to filter.
 func (v *VirtualMachine) FirewallRefs(ctx context.Context, refType string) (refs []*FirewallRef, err error) {
-	path := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/refs", v.Node, v.VMID)
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/qemu/%d/firewall/refs", v.Node, v.VMID)}
 	if refType != "" {
 		q := url.Values{}
 		q.Set("type", refType)
-		path = path + "?" + q.Encode()
+		u.RawQuery = q.Encode()
 	}
-	return refs, v.client.Get(ctx, path, &refs)
+	return refs, v.client.Get(ctx, u.String(), &refs)
 }
 
 // GetFirewallAliases lists per-VM firewall aliases.

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -724,6 +724,23 @@ func TestMakeCloudInitISO_JolietSVD(t *testing.T) {
 	assert.True(t, foundJoliet, "Joliet Supplementary Volume Descriptor not found in ISO")
 }
 
+func TestVirtualMachine_SpiceProxy(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+
+	vm := &VirtualMachine{client: client, Node: "node1", VMID: 101}
+	spice, err := vm.SpiceProxy(ctx)
+	assert.Nil(t, err)
+	require.NotNil(t, spice)
+	assert.Equal(t, "spice", spice.Type)
+	assert.Equal(t, "node1.example.com", spice.Host)
+	assert.Equal(t, "61024", spice.Port)
+	assert.Equal(t, "secret-ticket", spice.Password)
+	assert.Equal(t, "61025", spice.TLSPort)
+}
+
 func TestMakeCloudInitISO_VolumeIdentifier(t *testing.T) {
 	isoPath, err := makeCloudInitISO("test-volid.iso", "userdata", "metadata", "", "")
 	require.NoError(t, err)

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -911,3 +911,89 @@ func TestMakeCloudInitISO_VolumeIdentifier(t *testing.T) {
 	volID := strings.TrimRight(string(pvd[40:72]), " \x00")
 	assert.Equal(t, volumeIdentifier, volID)
 }
+
+func TestVirtualMachine_DirIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := vm100().DirIndex(context.Background())
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entries)
+	// at minimum the canonical PVE child resources should be present
+	names := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		names[e.Subdir] = true
+	}
+	assert.True(t, names["config"])
+	assert.True(t, names["status"])
+	assert.True(t, names["snapshot"])
+	assert.True(t, names["firewall"])
+	assert.True(t, names["mtunnel"])
+}
+
+func TestVirtualMachine_StatusIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := vm100().StatusIndex(context.Background())
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entries)
+	names := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		names[e.Subdir] = true
+	}
+	assert.True(t, names["current"])
+	assert.True(t, names["start"])
+	assert.True(t, names["stop"])
+	assert.True(t, names["reboot"])
+}
+
+func TestVirtualMachine_SnapshotIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := vm100().SnapshotIndex(context.Background(), "snap1")
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	names := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		names[e.Subdir] = true
+	}
+	assert.True(t, names["config"])
+	assert.True(t, names["rollback"])
+}
+
+func TestVirtualMachine_MigrationTunnel(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	tunnel, err := vm100().MigrationTunnel(context.Background(), nil)
+	assert.Nil(t, err)
+	require.NotNil(t, tunnel)
+	assert.Equal(t, "/run/qemu-server/100.mtunnel", tunnel.Socket)
+	assert.Equal(t, "PVEMTUNNELTICKET:abc123", tunnel.Ticket)
+	assert.Contains(t, tunnel.UPID, "qmtunnel")
+
+	// with explicit options
+	tunnel2, err := vm100().MigrationTunnel(context.Background(), &VirtualMachineMigrationTunnelOptions{
+		Bridges:  "vmbr0",
+		Storages: "local-lvm",
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, tunnel2)
+	assert.Equal(t, tunnel.Socket, tunnel2.Socket)
+}
+
+func TestVirtualMachine_MigrationTunnelWebSocketPath(t *testing.T) {
+	vm := vm100()
+	tunnel := &VirtualMachineMigrationTunnel{
+		Socket: "/run/qemu-server/100.mtunnel",
+		Ticket: "PVEMTUNNELTICKET:abc123",
+	}
+	path := vm.MigrationTunnelWebSocketPath(tunnel)
+	assert.Contains(t, path, "/nodes/node1/qemu/100/mtunnelwebsocket")
+	assert.Contains(t, path, "socket=")
+	assert.Contains(t, path, "ticket=")
+	// ticket should be URL-encoded (':' becomes %3A)
+	assert.Contains(t, path, "PVEMTUNNELTICKET%3Aabc123")
+
+	// nil tunnel still returns a valid path skeleton
+	emptyPath := vm.MigrationTunnelWebSocketPath(nil)
+	assert.Contains(t, emptyPath, "/nodes/node1/qemu/100/mtunnelwebsocket")
+}

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -253,6 +253,60 @@ func TestVirtualMachine_Config(t *testing.T) {
 	assert.Equal(t, "100", task.ID)
 }
 
+func TestVirtualMachine_ConfigSync(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   100,
+		Node:   "node1",
+	}
+
+	// ConfigSync blocks until the change is applied and returns no task.
+	err := vm.ConfigSync(ctx, VirtualMachineOption{Name: "description", Value: "synchronous update"})
+	assert.Nil(t, err)
+}
+
+func TestVirtualMachine_Feature(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   100,
+		Node:   "node1",
+	}
+
+	// Feature without a snapshot.
+	feature, err := vm.Feature(ctx, "snapshot", "")
+	assert.Nil(t, err)
+	assert.True(t, feature.HasFeature)
+	assert.Equal(t, []string{"node1", "node2"}, feature.Nodes)
+
+	// Feature against a specific snapshot.
+	feature, err = vm.Feature(ctx, "clone", "snap1")
+	assert.Nil(t, err)
+	assert.True(t, feature.HasFeature)
+}
+
+func TestVirtualMachine_DBusVMState(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   100,
+		Node:   "node1",
+	}
+
+	assert.Nil(t, vm.DBusVMState(ctx, "start"))
+	assert.Nil(t, vm.DBusVMState(ctx, "stop"))
+}
+
 func TestVirtualMachine_Start(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -482,6 +482,36 @@ func TestVirtualMachine_AgentFileWrite(t *testing.T) {
 	assert.Nil(t, vm.AgentFileWrite(context.Background(), "/tmp/foo", []byte("hello")))
 }
 
+func TestVirtualMachine_AgentCommandIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	cmds, err := vm.AgentCommandIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, cmds, 3)
+	assert.Equal(t, "exec", cmds[0].Name)
+	assert.Equal(t, "ping", cmds[1].Name)
+}
+
+func TestVirtualMachine_AgentCommand(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	out, err := vm.AgentCommand(context.Background(), "ping")
+	assert.Nil(t, err)
+	assert.Equal(t, "ping", out["echoed"])
+}
+
+func TestVirtualMachine_AgentGetMemoryBlockInfo(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := VirtualMachine{client: mockClient(), VMID: 101, Node: "node1"}
+	info, err := vm.AgentGetMemoryBlockInfo(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, uint64(134217728), info.Size)
+}
+
 func TestVirtualMachine_Snapshots(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -49,6 +49,73 @@ func TestVirtualMachine_RRDData(t *testing.T) {
 	assert.Len(t, rdddata, 70)
 }
 
+func TestVirtualMachine_RRD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   101,
+		Node:   "node1",
+	}
+
+	rrd, err := vm.RRD(ctx, "cpu", TimeframeHour)
+	assert.Nil(t, err)
+	require.NotNil(t, rrd)
+	assert.Contains(t, rrd.Filename, "101.png")
+}
+
+func TestVirtualMachine_MigratePreconditions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   101,
+		Node:   "node1",
+	}
+
+	pre, err := vm.MigratePreconditions(ctx, "")
+	assert.Nil(t, err)
+	require.NotNil(t, pre)
+	assert.True(t, pre.Running)
+	assert.True(t, pre.HasDBusVMState)
+	assert.Equal(t, []string{"node2", "node3"}, pre.AllowedNodes)
+	require.Contains(t, pre.NotAllowedNodes, "node4")
+	assert.Equal(t, []string{"local-lvm"}, pre.NotAllowedNodes["node4"].UnavailableStorages)
+	require.Len(t, pre.NotAllowedNodes["node4"].BlockingHAResources, 1)
+	assert.Equal(t, "vm:101", pre.NotAllowedNodes["node4"].BlockingHAResources[0].SID)
+	assert.Equal(t, "node-affinity", pre.NotAllowedNodes["node4"].BlockingHAResources[0].Cause)
+	require.Len(t, pre.LocalDisks, 1)
+	assert.Equal(t, "local-lvm:vm-101-disk-0", pre.LocalDisks[0].VolID)
+	assert.Equal(t, uint64(34359738368), pre.LocalDisks[0].Size)
+}
+
+func TestVirtualMachine_RemoteMigrate(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	vm := VirtualMachine{
+		client: client,
+		VMID:   101,
+		Node:   "node1",
+	}
+
+	task, err := vm.RemoteMigrate(ctx, &VirtualMachineRemoteMigrateOptions{
+		TargetEndpoint: "apitoken=PVEAPIToken=user@pam!tok=secret host=target.example.com fingerprint=AA:BB",
+		TargetBridge:   "vmbr0=vmbr0",
+		TargetStorage:  "local=local",
+		TargetVMID:     201,
+		Online:         IntOrBool(true),
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, task)
+	assert.Contains(t, string(task.UPID), "qmremote-migrate")
+}
+
 func TestVirtualMachineClone(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()


### PR DESCRIPTION
## Summary

Combined sweep that takes `nodes/qemu` from **79/97 (81.4%)** to **96/97 (99.0%)** tool-reported / **100%** real coverage. The single remaining tool gap is `mtunnelwebsocket`, which is wrapped as a path-builder helper (no HTTP call site to register — same convention used by the existing `vncwebsocket` wrappers).

Supersedes the 5 individual PRs that were opened in parallel by sub-agents:
- #301 `feat/qemu-agent-extensions`
- #302 `feat/qemu-config-feature-dbus`
- #303 `feat/qemu-rrd-migrate`
- #304 `feat/qemu-indexes-mtunnel`
- #305 `feat/qemu-firewall-spice-vnc`

Cherry-picked into one branch to avoid the 4-way rebase dance on shared files (`virtual_machine.go`, `tests/mocks/pve9x/virtual_machines.go`, `types.go`, `virtual_machine_test.go`). Per-feature commits preserved for review.

## Commits

| Commit | Endpoints added | Notes |
|---|---|---|
| `049ca13` | `POST /qemu/{vmid}/spiceproxy` | also refactors `FirewallLog`/`FirewallRefs` to `url.URL{}` pattern + extends `mage endpoints` scanner to recognize `*.VNCWebSocket`/`*.TermWebSocket` call sites |
| `766657c` | `GET /qemu/{vmid}/agent` (index), `POST /qemu/{vmid}/agent` (generic exec), `GET /qemu/{vmid}/agent/get-memory-block-info` | extends `virtual_machine_agent.go` |
| `4115444` | `GET /qemu/{vmid}/rrd`, `GET /qemu/{vmid}/migrate` (preconditions), `POST /qemu/{vmid}/remote_migrate` | adds `VirtualMachineRRD`, `VirtualMachineMigratePreconditions*`, `VirtualMachineRemoteMigrateOptions` |
| `fa50087` | `PUT /qemu/{vmid}/config` (sync), `GET /qemu/{vmid}/feature`, `POST /qemu/{vmid}/dbus-vmstate` | adds `VirtualMachineFeature` |
| `8508c38` | `GET /qemu/{vmid}` (vmdiridx), `GET /qemu/{vmid}/status` (vmcmdidx), `GET /qemu/{vmid}/snapshot/{snapname}` (snapshot_cmd_idx), `POST /qemu/{vmid}/mtunnel`, `GET /qemu/{vmid}/mtunnelwebsocket` (path-builder) | adds 4 dir-index entry types + `VirtualMachineMigrationTunnel*` |

## Coverage impact

| metric | before (`main`) | after |
|---|---:|---:|
| `nodes/qemu` covered | 79 / 97 (81.4%) | **96 / 97 (99.0%)** |
| overall covered | 363 / 675 (53.8%) | **400 / 675 (59.3%)** |
| call sites scanned | 378 | 419 |
| match rate | 99.7% | 99.8% |

The overall jump is bigger than just qemu (+17) because the scanner extension in `049ca13` also recognized previously-invisible `VNCWebSocket`/`TermWebSocket` call sites in `containers.go` and `nodes.go`, adding `/lxc/{vmid}/vncwebsocket`, `/nodes/{node}/vncwebsocket`, etc.

The 1 remaining qemu gap (`mtunnelwebsocket`) is a known scanner blind spot — the wrapper exists as `VirtualMachine.MigrationTunnelWebSocketPath` (path-builder), but with no HTTP-method call site for the scanner to match.

## Conflict resolution

Only one real conflict during cherry-picks: `tests/mocks/pve9x/virtual_machines.go` between the spiceproxy mock (`049ca13`) and the dir-index/mtunnel mocks (`8508c38`) — both adding new gock blocks at end of file. Resolved by stacking them in cherry-pick order with proper JSON/gock closing braces.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `mage test:unit` — all unit tests pass
- [x] `mage endpoints:coverage` — `nodes/qemu` at 96/97, only `mtunnelwebsocket` remains (real coverage 100%)
- [ ] CI lint / coverage check on PR (mage lint denied locally by sandbox)

## Follow-ups (separate work)

- `GetWithParams()` is another scanner blind spot — discovered by the Group 4 sub-agent, who refactored to the `url.URL{}` pattern to make their assertion pass. Worth a future scanner extension.
- The `mtunnelwebsocket` path-builder could either be (a) accepted as a known scanner blind spot, or (b) addressed by teaching the scanner to recognize path-builder methods that return a string literal starting with `/`. Low priority.
