### PR TITLE
refactor: node replication → node.Replication(id) + *NodeReplicationJob instance methods

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -619,29 +619,44 @@ func (n *Node) WakeOnLAN(ctx context.Context) (mac string, err error) {
 // reports per-node runtime state (last sync, last duration, fail count, etc.)
 // for each job that targets or originates on this node. guest filters to a
 // specific VMID; pass 0 for all.
-func (n *Node) Replications(ctx context.Context, guest int) (status []*NodeReplicationStatus, err error) {
+func (n *Node) Replications(ctx context.Context, guest int) (jobs []*NodeReplicationJob, err error) {
 	path := fmt.Sprintf("/nodes/%s/replication", n.Name)
 	if guest != 0 {
 		path += fmt.Sprintf("?guest=%d", guest)
 	}
-	err = n.client.Get(ctx, path, &status)
-	return
+	if err = n.client.Get(ctx, path, &jobs); err != nil {
+		return nil, err
+	}
+	for _, j := range jobs {
+		j.client = n.client
+		j.Node = n.Name
+	}
+	return jobs, nil
 }
 
-// ReplicationStatus returns runtime status for a single replication job.
+// Replication returns a handle to a single replication job on this node. It
+// does not perform an API call; use the returned job's methods to query or
+// act on the underlying /nodes/{node}/replication/{id}/* endpoints.
+func (n *Node) Replication(id string) *NodeReplicationJob {
+	return &NodeReplicationJob{
+		client: n.client,
+		Node:   n.Name,
+		ID:     id,
+	}
+}
+
+// Status refreshes runtime state for this replication job in-place.
 // GET /nodes/{node}/replication/{id}/status. The /replication/{id} root is
 // just a tree index and is intentionally not wrapped.
-func (n *Node) ReplicationStatus(ctx context.Context, id string) (status *NodeReplicationStatus, err error) {
-	status = &NodeReplicationStatus{}
-	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/replication/%s/status", n.Name, id), status)
-	return
+func (r *NodeReplicationJob) Status(ctx context.Context) error {
+	return r.client.Get(ctx, fmt.Sprintf("/nodes/%s/replication/%s/status", r.Node, r.ID), r)
 }
 
-// ReplicationLog returns the job's log lines. start/limit are optional
-// pagination — pass 0 for default. PVE returns a list of {n, t} entries
-// where n is line number and t is the line text.
-func (n *Node) ReplicationLog(ctx context.Context, id string, start, limit int) (entries []*LogEntry, err error) {
-	path := fmt.Sprintf("/nodes/%s/replication/%s/log", n.Name, id)
+// Log returns the job's log lines. start/limit are optional pagination — pass
+// 0 for default. PVE returns a list of {n, t} entries where n is line number
+// and t is the line text.
+func (r *NodeReplicationJob) Log(ctx context.Context, start, limit int) (entries []*LogEntry, err error) {
+	path := fmt.Sprintf("/nodes/%s/replication/%s/log", r.Node, r.ID)
 	q := ""
 	if start > 0 {
 		q = fmt.Sprintf("start=%d", start)
@@ -655,17 +670,17 @@ func (n *Node) ReplicationLog(ctx context.Context, id string, start, limit int) 
 	if q != "" {
 		path += "?" + q
 	}
-	err = n.client.Get(ctx, path, &entries)
+	err = r.client.Get(ctx, path, &entries)
 	return
 }
 
-// ReplicationScheduleNow asks PVE to run a replication job as soon as possible
+// ScheduleNow asks PVE to run this replication job as soon as possible
 // (bypassing its schedule). POST /nodes/{node}/replication/{id}/schedule_now —
 // returns a Task UPID.
-func (n *Node) ReplicationScheduleNow(ctx context.Context, id string) (*Task, error) {
+func (r *NodeReplicationJob) ScheduleNow(ctx context.Context) (*Task, error) {
 	var upid UPID
-	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/replication/%s/schedule_now", n.Name, id), nil, &upid); err != nil {
+	if err := r.client.Post(ctx, fmt.Sprintf("/nodes/%s/replication/%s/schedule_now", r.Node, r.ID), nil, &upid); err != nil {
 		return nil, err
 	}
-	return NewTask(upid, n.client), nil
+	return NewTask(upid, r.client), nil
 }

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -818,9 +818,10 @@ func TestNode_Replications(t *testing.T) {
 	assert.NotEmpty(t, reps)
 	assert.Equal(t, "100-0", reps[0].ID)
 	assert.Equal(t, 100, reps[0].Guest)
+	assert.Equal(t, "node1", reps[0].Node)
 }
 
-func TestNode_ReplicationStatusAndLog(t *testing.T) {
+func TestNodeReplicationJob_StatusAndLog(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -829,17 +830,21 @@ func TestNode_ReplicationStatusAndLog(t *testing.T) {
 	node, err := client.Node(ctx, "node1")
 	assert.Nil(t, err)
 
-	st, err := node.ReplicationStatus(ctx, "100-0")
-	assert.Nil(t, err)
-	assert.Equal(t, "100-0", st.ID)
+	job := node.Replication("100-0")
+	assert.Equal(t, "100-0", job.ID)
+	assert.Equal(t, "node1", job.Node)
 
-	log, err := node.ReplicationLog(ctx, "100-0", 0, 0)
+	err = job.Status(ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, "100-0", job.ID)
+
+	log, err := job.Log(ctx, 0, 0)
 	assert.Nil(t, err)
 	assert.Len(t, log, 2)
 	assert.Equal(t, 1, log[0].N)
 }
 
-func TestNode_ReplicationScheduleNow(t *testing.T) {
+func TestNodeReplicationJob_ScheduleNow(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -848,7 +853,7 @@ func TestNode_ReplicationScheduleNow(t *testing.T) {
 	node, err := client.Node(ctx, "node1")
 	assert.Nil(t, err)
 
-	task, err := node.ReplicationScheduleNow(ctx, "100-0")
+	task, err := node.Replication("100-0").ScheduleNow(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, task)
 }

--- a/types.go
+++ b/types.go
@@ -97,11 +97,16 @@ type LogEntry struct {
 	T string `json:"t"`
 }
 
-// NodeReplicationStatus is runtime state for a replication job on a node:
-// what was last synced, fail count, next-sync time. The cluster-wide
-// configuration of the job lives at /cluster/replication; this is the
-// per-node view of how that job is *running*.
-type NodeReplicationStatus struct {
+// NodeReplicationJob is a handle to a replication job on a node and the
+// runtime state for that job: what was last synced, fail count, next-sync
+// time. The cluster-wide configuration of the job lives at
+// /cluster/replication; this is the per-node view of how that job is
+// *running*. Methods on this type wrap /nodes/{node}/replication/{id}/*.
+type NodeReplicationJob struct {
+	client *Client
+
+	Node string `json:"-"`
+
 	ID        string  `json:"id"`
 	Type      string  `json:"type,omitempty"`
 	Source    string  `json:"source,omitempty"`


### PR DESCRIPTION
## Summary

Brings node replication endpoints in line with the repo's API ergonomics rule: multi-instance sub-resources get a getter + instance type with methods (singletons stay as methods on parent). The replication tree under `/nodes/{node}/replication/{id}/*` is multi-instance, so it should hang off an instance handle rather than taking the job id as an argument on every call.

The removed methods have not shipped in a tagged release — they only exist on `main` (working towards v0.6), so no semver break.

## Before / after

```go
// Before
node.ReplicationStatus(ctx, "100-0")            // *NodeReplicationStatus, error
node.ReplicationLog(ctx, "100-0", 0, 0)         // []*LogEntry, error
node.ReplicationScheduleNow(ctx, "100-0")       // *Task, error

// After
job := node.Replication("100-0")                // *NodeReplicationJob — no API call
job.Status(ctx)                                  // error — populates job in place
job.Log(ctx, 0, 0)                               // []*LogEntry, error
job.ScheduleNow(ctx)                             // *Task, error
```

`Node.Replications(ctx, guest)` still lists; it now returns `[]*NodeReplicationJob` with `client`/`Node`/`ID` populated on each element, so any entry from the list is directly callable.

## Methods that changed signature

| Old | New |
| --- | --- |
| `(*Node).Replications(ctx, guest) ([]*NodeReplicationStatus, error)` | `(*Node).Replications(ctx, guest) ([]*NodeReplicationJob, error)` |
| `(*Node).ReplicationStatus(ctx, id) (*NodeReplicationStatus, error)` | `(*NodeReplicationJob).Status(ctx) error` (in-place refresh) |
| `(*Node).ReplicationLog(ctx, id, start, limit) ([]*LogEntry, error)` | `(*NodeReplicationJob).Log(ctx, start, limit) ([]*LogEntry, error)` |
| `(*Node).ReplicationScheduleNow(ctx, id) (*Task, error)` | `(*NodeReplicationJob).ScheduleNow(ctx) (*Task, error)` |
| — | `(*Node).Replication(id) *NodeReplicationJob` (new getter, no API call) |

## Type rename

`NodeReplicationStatus` → `NodeReplicationJob`. The type now represents a job handle with operations (carrying `client`/`Node`/`ID`), not just a status payload. The wire fields are unchanged.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `mage test:unit` passes
- [x] `mage endpoints:coverage` — `nodes/replication 4/5` unchanged
