### PR TITLE
refactor: node services → node.Service(name) + *NodeService instance methods

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -453,51 +453,95 @@ func (n *Node) parseVzdumpConfig(vzdumpExtractedConfig string) (*VzdumpConfig, e
 // ---- /nodes/{node}/services --------------------------------------------------
 
 // Services returns the list of services on the node (pveproxy, pvedaemon,
-// corosync, ssh, etc.). GET /nodes/{node}/services.
+// corosync, ssh, etc.). GET /nodes/{node}/services. Each returned
+// *NodeService is pre-populated with client and Node so callers can chain
+// instance methods (Start, Stop, Restart, Reload, State) directly.
 func (n *Node) Services(ctx context.Context) (services []*NodeService, err error) {
 	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/services", n.Name), &services)
+	if err != nil {
+		return
+	}
+	for _, s := range services {
+		s.client = n.client
+		s.Node = n.Name
+		// PVE returns "service" as the canonical id and usually mirrors it in
+		// "name"; make sure Name is populated either way so instance methods
+		// always have a path segment.
+		if s.Name == "" {
+			s.Name = s.Service
+		}
+	}
 	return
 }
 
-// ServiceState returns the current state of a single service.
-// GET /nodes/{node}/services/{service}/state. The /services/{service} root is
-// just a directory index and is intentionally not wrapped — state is the only
+// Service returns a handle for a single service without making an API call.
+// Use State to populate the handle from /nodes/{node}/services/{name}/state,
+// or just call Start/Stop/Restart/Reload directly.
+func (n *Node) Service(name string) *NodeService {
+	return &NodeService{
+		client: n.client,
+		Node:   n.Name,
+		Name:   name,
+	}
+}
+
+// State refreshes the service handle from
+// GET /nodes/{node}/services/{name}/state. The /services/{name} root is just
+// a directory index and is intentionally not wrapped — state is the only
 // useful read on a specific service.
-func (n *Node) ServiceState(ctx context.Context, service string) (state *NodeService, err error) {
-	state = &NodeService{}
-	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/services/%s/state", n.Name, service), state)
-	return
+func (s *NodeService) State(ctx context.Context) error {
+	// Preserve the caller's identifying fields — the API response will
+	// repopulate Service/Name but we want our cached Node and client to
+	// survive the round-trip.
+	client, node, name := s.client, s.Node, s.Name
+	if err := client.Get(ctx, fmt.Sprintf("/nodes/%s/services/%s/state", node, name), s); err != nil {
+		return err
+	}
+	s.client = client
+	s.Node = node
+	if s.Name == "" {
+		s.Name = name
+	}
+	return nil
 }
 
-// ServiceStart issues POST /nodes/{node}/services/{service}/start. Returns a
-// Task because PVE does service control asynchronously.
-func (n *Node) ServiceStart(ctx context.Context, service string) (*Task, error) {
-	return n.serviceAction(ctx, service, "start")
-}
-
-// ServiceStop issues POST /nodes/{node}/services/{service}/stop.
-func (n *Node) ServiceStop(ctx context.Context, service string) (*Task, error) {
-	return n.serviceAction(ctx, service, "stop")
-}
-
-// ServiceRestart issues POST /nodes/{node}/services/{service}/restart — a
-// hard restart. Use Reload for graceful restart of services that support it.
-func (n *Node) ServiceRestart(ctx context.Context, service string) (*Task, error) {
-	return n.serviceAction(ctx, service, "restart")
-}
-
-// ServiceReload issues POST /nodes/{node}/services/{service}/reload, which
-// PVE documents as "falls back to restart if reload isn't supported".
-func (n *Node) ServiceReload(ctx context.Context, service string) (*Task, error) {
-	return n.serviceAction(ctx, service, "reload")
-}
-
-func (n *Node) serviceAction(ctx context.Context, service, action string) (*Task, error) {
+// Start issues POST /nodes/{node}/services/{name}/start. Returns a Task
+// because PVE does service control asynchronously.
+func (s *NodeService) Start(ctx context.Context) (*Task, error) {
 	var upid UPID
-	if err := n.client.Post(ctx, fmt.Sprintf("/nodes/%s/services/%s/%s", n.Name, service, action), nil, &upid); err != nil {
+	if err := s.client.Post(ctx, fmt.Sprintf("/nodes/%s/services/%s/start", s.Node, s.Name), nil, &upid); err != nil {
 		return nil, err
 	}
-	return NewTask(upid, n.client), nil
+	return NewTask(upid, s.client), nil
+}
+
+// Stop issues POST /nodes/{node}/services/{name}/stop.
+func (s *NodeService) Stop(ctx context.Context) (*Task, error) {
+	var upid UPID
+	if err := s.client.Post(ctx, fmt.Sprintf("/nodes/%s/services/%s/stop", s.Node, s.Name), nil, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
+}
+
+// Restart issues POST /nodes/{node}/services/{name}/restart — a hard
+// restart. Use Reload for graceful restart of services that support it.
+func (s *NodeService) Restart(ctx context.Context) (*Task, error) {
+	var upid UPID
+	if err := s.client.Post(ctx, fmt.Sprintf("/nodes/%s/services/%s/restart", s.Node, s.Name), nil, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
+}
+
+// Reload issues POST /nodes/{node}/services/{name}/reload, which PVE
+// documents as "falls back to restart if reload isn't supported".
+func (s *NodeService) Reload(ctx context.Context) (*Task, error) {
+	var upid UPID
+	if err := s.client.Post(ctx, fmt.Sprintf("/nodes/%s/services/%s/reload", s.Node, s.Name), nil, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
 }
 
 // Time returns the node's current time and timezone configuration.

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -615,10 +615,14 @@ func TestNode_Services(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, services)
 	assert.Equal(t, "pveproxy", services[0].Service)
-	assert.Equal(t, "running", services[0].State)
+	assert.Equal(t, "running", services[0].Status)
+	// Services should pre-populate the chaining fields so callers can invoke
+	// instance methods on returned items without re-wiring.
+	assert.Equal(t, "node1", services[0].Node)
+	assert.Equal(t, "pveproxy", services[0].Name)
 }
 
-func TestNode_ServiceState(t *testing.T) {
+func TestNode_Service_State(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -627,13 +631,20 @@ func TestNode_ServiceState(t *testing.T) {
 	node, err := client.Node(ctx, "node1")
 	assert.Nil(t, err)
 
-	state, err := node.ServiceState(ctx, "pveproxy")
+	svc := node.Service("pveproxy")
+	assert.Equal(t, "node1", svc.Node)
+	assert.Equal(t, "pveproxy", svc.Name)
+
+	err = svc.State(ctx)
 	assert.Nil(t, err)
-	assert.Equal(t, "pveproxy", state.Service)
-	assert.Equal(t, "active", state.ActiveState)
+	assert.Equal(t, "pveproxy", svc.Service)
+	assert.Equal(t, "active", svc.ActiveState)
+	// Chaining fields must survive the unmarshal.
+	assert.Equal(t, "node1", svc.Node)
+	assert.Equal(t, "pveproxy", svc.Name)
 }
 
-func TestNode_ServiceActions(t *testing.T) {
+func TestNode_Service_Actions(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -642,12 +653,13 @@ func TestNode_ServiceActions(t *testing.T) {
 	node, err := client.Node(ctx, "node1")
 	assert.Nil(t, err)
 
+	svc := node.Service("pveproxy")
 	// All four actions hit the same mock regex; just verify each method
 	// constructs the right URL by exercising it.
-	for _, fn := range []func(context.Context, string) (*Task, error){
-		node.ServiceStart, node.ServiceStop, node.ServiceRestart, node.ServiceReload,
+	for _, fn := range []func(context.Context) (*Task, error){
+		svc.Start, svc.Stop, svc.Restart, svc.Reload,
 	} {
-		task, err := fn(ctx, "pveproxy")
+		task, err := fn(ctx)
 		assert.Nil(t, err)
 		assert.NotNil(t, task)
 	}

--- a/types.go
+++ b/types.go
@@ -53,11 +53,23 @@ type Version struct {
 // NodeService is one row of the services list and the response shape of
 // /nodes/{node}/services/{service}/state. The same struct fits both because
 // the list returns the same per-service info, just batched.
+//
+// client and Node are populated by Node.Services and Node.Service so callers
+// can chain instance methods (Start/Stop/Restart/Reload/State) without
+// re-threading the client. Name holds the service identifier
+// (e.g. "pveproxy") — it doubles as the JSON-decoded "name" field returned by
+// PVE and as the path segment used by the instance methods.
 type NodeService struct {
-	Service     string `json:"service"`
-	Name        string `json:"name,omitempty"`
-	Desc        string `json:"desc,omitempty"`
-	State       string `json:"state,omitempty"`        // running / stopped / unknown
+	client *Client
+	Node   string `json:"-"`
+
+	Service string `json:"service"`
+	Name    string `json:"name,omitempty"`
+	Desc    string `json:"desc,omitempty"`
+	// Status is PVE's "state" field — running / stopped / unknown. Renamed
+	// from State so the instance method State(ctx) can populate the handle
+	// without colliding with a field of the same name.
+	Status      string `json:"state,omitempty"`
 	ActiveState string `json:"active-state,omitempty"` // active / inactive / failed
 	UnitState   string `json:"unit-state,omitempty"`   // enabled / disabled / masked
 }


### PR DESCRIPTION
## Summary

Refactors node service lifecycle from method-on-Node into a getter +
instance type, matching the repo-wide pattern for multi-instance
sub-resources (e.g. `node.Storage(name)`, `node.Network(iface)`).

The removed methods have not shipped in a tagged release — they only
exist on `main` (working towards v0.6), so no semver break.

## Why

The PVE schema clearly addresses services per-instance:
`/nodes/{node}/services/{service}/{action}` (state/start/stop/restart/reload).
The old `*Node` methods didn't reflect that, and the private
`serviceAction` helper built the path with `fmt.Sprintf("...%s/%s", service, action)`
— a generic-path call site the endpoint-coverage scanner couldn't resolve.
This was the lone "no-match" call site in the whole codebase.

## Before / after

Before:

```go
task, err := node.ServiceStart(ctx, "pveproxy")
state, err := node.ServiceState(ctx, "pveproxy")
fmt.Println(state.State) // "running"
```

After:

```go
svc := node.Service("pveproxy")
task, err := svc.Start(ctx)
err = svc.State(ctx)
fmt.Println(svc.Status) // "running"
```

`Node.Services(ctx)` still returns the list and now pre-populates
`client` / `Node` / `Name` on every element so callers can chain
immediately.

## Signatures that changed

Removed from `*Node`:

- `Services(ctx) ([]*NodeService, error)` — kept (still on `*Node`),
  now also pre-populates chaining fields on every returned entry
- `ServiceState(ctx, service) (*NodeService, error)` — gone
- `ServiceStart(ctx, service) (*Task, error)` — gone
- `ServiceStop(ctx, service) (*Task, error)` — gone
- `ServiceRestart(ctx, service) (*Task, error)` — gone
- `ServiceReload(ctx, service) (*Task, error)` — gone
- `serviceAction(ctx, service, action) (*Task, error)` — gone (private)

Added:

- `(*Node).Service(name string) *NodeService` — no API call, returns handle
- `(*NodeService).State(ctx) error` — GET /services/{name}/state, populates `s`
- `(*NodeService).Start(ctx) (*Task, error)`
- `(*NodeService).Stop(ctx) (*Task, error)`
- `(*NodeService).Restart(ctx) (*Task, error)`
- `(*NodeService).Reload(ctx) (*Task, error)`

Type change on `NodeService`:

- New unexported `client *Client`
- New exported `Node string` (json:"-")
- Field `State string` renamed to `Status string` (JSON tag still
  `state,omitempty`). Required so the instance method `State(ctx)` does
  not collide with a field of the same name.

## Coverage scanner impact

Endpoint-coverage scanner (`mage endpoints:coverage`):

| metric | before | after |
| --- | --- | --- |
| no-match call sites | 1 | **0** |
| scanner match rate | 99.8% | **100.0%** |
| `nodes/services` coverage | 2/7 | **6/7** |

The 7th endpoint (`/services/{service}` directory index) is
intentionally not wrapped — PVE documents it as a stub returning only
sub-paths, and `state` is the only useful read on a specific service.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `mage test:unit` passes
- [x] `mage endpoints:coverage` reports scanner match rate 100% and
      `nodes/services` at 6/7
