### PR TITLE
refactor!: VM/container snapshots → instance-type pattern

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -192,11 +192,24 @@ func (c *Container) VNCProxy(ctx context.Context, vncOptions VNCProxyOptions) (v
 	return vnc, c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/vncproxy", c.Node, c.VMID), vncOptions, &vnc)
 }
 
+// Snapshots lists every snapshot of the container. Each returned
+// *ContainerSnapshot has its client/Node/VMID pre-populated so callers can
+// invoke instance methods (Rollback, Delete, Config, …) directly.
 func (c *Container) Snapshots(ctx context.Context) (snapshots []*ContainerSnapshot, err error) {
-	err = c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot", c.Node, c.VMID), &snapshots)
-	return
+	if err = c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot", c.Node, c.VMID), &snapshots); err != nil {
+		return nil, err
+	}
+	for _, s := range snapshots {
+		s.client = c.client
+		s.Node = c.Node
+		s.VMID = int(c.VMID)
+	}
+	return snapshots, nil
 }
 
+// NewSnapshot creates a snapshot of the container and returns the worker
+// task. The returned snapshot's metadata is reachable via c.Snapshot(name)
+// once the task completes.
 func (c *Container) NewSnapshot(ctx context.Context, snapName string) (task *Task, err error) {
 	var upid UPID
 	if err := c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot", c.Node, c.VMID), map[string]interface{}{"snapname": snapName}, &upid); err != nil {
@@ -205,37 +218,60 @@ func (c *Container) NewSnapshot(ctx context.Context, snapName string) (task *Tas
 	return NewTask(upid, c.client), nil
 }
 
-func (c *Container) GetSnapshot(ctx context.Context, snapshot string) (snap []*ContainerSnapshot, err error) {
-	return snap, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s", c.Node, c.VMID, snapshot), &snap)
+// Snapshot constructs a handle to a single snapshot by name. It performs no
+// API call; the returned *ContainerSnapshot is wired to the container's
+// client and node/vmid so its instance methods (Rollback, Delete, Config,
+// UpdateConfig, SubResources) target the correct snapshot path.
+func (c *Container) Snapshot(name string) *ContainerSnapshot {
+	return &ContainerSnapshot{
+		client: c.client,
+		Node:   c.Node,
+		VMID:   int(c.VMID),
+		Name:   name,
+	}
 }
 
-func (c *Container) DeleteSnapshot(ctx context.Context, snapshot string) (task *Task, err error) {
+// Rollback rolls the container back to this snapshot. When start is true the
+// container is started after the rollback completes.
+func (s *ContainerSnapshot) Rollback(ctx context.Context, start bool) (task *Task, err error) {
 	var upid UPID
-	if err := c.client.Delete(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s", c.Node, c.VMID, snapshot), &upid); err != nil {
+	if err := s.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/rollback", s.Node, s.VMID, s.Name), map[string]interface{}{"start": start}, &upid); err != nil {
 		return nil, err
 	}
-	return NewTask(upid, c.client), nil
+	return NewTask(upid, s.client), nil
 }
 
-func (c *Container) RollbackSnapshot(ctx context.Context, snapshot string, start bool) (task *Task, err error) {
+// Delete removes this snapshot from the container. Returns the worker task.
+func (s *ContainerSnapshot) Delete(ctx context.Context) (task *Task, err error) {
 	var upid UPID
-	if err := c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/rollback", c.Node, c.VMID, snapshot), map[string]interface{}{"start": start}, &upid); err != nil {
+	if err := s.client.Delete(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s", s.Node, s.VMID, s.Name), &upid); err != nil {
 		return nil, err
 	}
-	return NewTask(upid, c.client), nil
+	return NewTask(upid, s.client), nil
 }
 
-func (c *Container) GetSnapshotConfig(ctx context.Context, snapshot string) (config map[string]interface{}, err error) {
-	return config, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/config", c.Node, c.VMID, snapshot), &config)
+// Config reads this snapshot's metadata (description, parent, etc.). PVE
+// returns a free-form map since snapshot configs include arbitrary device
+// keys snapshotted at the time of creation.
+func (s *ContainerSnapshot) Config(ctx context.Context) (config map[string]interface{}, err error) {
+	return config, s.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/config", s.Node, s.VMID, s.Name), &config)
 }
 
-// UpdateSnapshot updates a container snapshot's metadata. PVE only allows
-// changing the description on this endpoint; pass nil options to clear it.
-func (c *Container) UpdateSnapshot(ctx context.Context, snapshot string, options *ContainerSnapshotUpdateOptions) error {
+// UpdateConfig updates this snapshot's metadata. PVE only allows changing
+// the description on this endpoint; pass nil options to clear it.
+func (s *ContainerSnapshot) UpdateConfig(ctx context.Context, options *ContainerSnapshotUpdateOptions) error {
 	if options == nil {
 		options = &ContainerSnapshotUpdateOptions{}
 	}
-	return c.client.Put(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/config", c.Node, c.VMID, snapshot), options, nil)
+	return s.client.Put(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s/config", s.Node, s.VMID, s.Name), options, nil)
+}
+
+// SubResources returns the per-snapshot directory index
+// (GET /nodes/{node}/lxc/{vmid}/snapshot/{snapname}) — one entry per
+// sub-resource (config, rollback) on this snapshot.
+func (s *ContainerSnapshot) SubResources(ctx context.Context) (entries []*ContainerSnapshotIndexEntry, err error) {
+	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/snapshot/%s", s.Node, s.VMID, s.Name), &entries)
+	return
 }
 
 func (c *Container) Firewall(ctx context.Context) (firewall *Firewall, err error) {

--- a/containers_test.go
+++ b/containers_test.go
@@ -336,6 +336,12 @@ func TestContainerSnapshots(t *testing.T) {
 	snapshots, err := container.Snapshots(ctx)
 	assert.Nil(t, err)
 	assert.Len(t, snapshots, 3)
+	// Returned snapshots must be wired to their parent container so
+	// instance methods can target the right snapshot path.
+	for _, s := range snapshots {
+		assert.Equal(t, "node1", s.Node)
+		assert.Equal(t, 101, s.VMID)
+	}
 }
 
 func TestContainerNewSnapshot(t *testing.T) {
@@ -353,22 +359,19 @@ func TestContainerNewSnapshot(t *testing.T) {
 	assert.NotEmpty(t, task)
 }
 
-func TestContainerGetSnapshot(t *testing.T) {
+func TestContainer_Snapshot_Getter(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
-	ctx := context.Background()
-	container := Container{
-		client: client,
-		Node:   "node1",
-		VMID:   101,
-	}
-	snapshot, err := container.GetSnapshot(ctx, "snapshot1")
-	assert.Nil(t, err)
-	assert.NotNil(t, snapshot)
+	c := &Container{client: client, Node: "node1", VMID: 101}
+	s := c.Snapshot("snapshot1")
+	assert.NotNil(t, s)
+	assert.Equal(t, "snapshot1", s.Name)
+	assert.Equal(t, "node1", s.Node)
+	assert.Equal(t, 101, s.VMID)
 }
 
-func TestContainerDeleteSnapshot(t *testing.T) {
+func TestContainerSnapshot_SubResources(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -378,12 +381,27 @@ func TestContainerDeleteSnapshot(t *testing.T) {
 		Node:   "node1",
 		VMID:   101,
 	}
-	task, err := container.DeleteSnapshot(ctx, "snapshot1")
+	entries, err := container.Snapshot("snapshot1").SubResources(ctx)
+	assert.Nil(t, err)
+	assert.NotNil(t, entries)
+}
+
+func TestContainerSnapshot_Delete(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+	ctx := context.Background()
+	container := Container{
+		client: client,
+		Node:   "node1",
+		VMID:   101,
+	}
+	task, err := container.Snapshot("snapshot1").Delete(ctx)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, task)
 }
 
-func TestContainerRollbackSnapshot(t *testing.T) {
+func TestContainerSnapshot_Rollback(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -393,7 +411,7 @@ func TestContainerRollbackSnapshot(t *testing.T) {
 		Node:   "node1",
 		VMID:   101,
 	}
-	task, err := container.RollbackSnapshot(ctx, "snapshot1", true)
+	task, err := container.Snapshot("snapshot1").Rollback(ctx, true)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, task)
 }
@@ -587,19 +605,19 @@ func TestContainerFirewallRefs(t *testing.T) {
 	assert.Equal(t, "blocked", refs[1].Name)
 }
 
-func TestContainerGetSnapshotConfig(t *testing.T) {
+func TestContainerSnapshot_Config(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
 	ctx := context.Background()
 
 	c := &Container{client: client, Node: "node1", VMID: 101}
-	config, err := c.GetSnapshotConfig(ctx, "snapshot1")
+	config, err := c.Snapshot("snapshot1").Config(ctx)
 	assert.Nil(t, err)
 	assert.Equal(t, "First snapshot", config["description"])
 }
 
-func TestContainerUpdateSnapshot(t *testing.T) {
+func TestContainerSnapshot_UpdateConfig(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	client := mockClient()
@@ -608,10 +626,10 @@ func TestContainerUpdateSnapshot(t *testing.T) {
 	c := &Container{client: client, Node: "node1", VMID: 101}
 
 	// nil options still posts a body successfully (was broken pre-fix)
-	assert.Nil(t, c.UpdateSnapshot(ctx, "snapshot1", nil))
+	assert.Nil(t, c.Snapshot("snapshot1").UpdateConfig(ctx, nil))
 
 	// explicit description
-	assert.Nil(t, c.UpdateSnapshot(ctx, "snapshot1", &ContainerSnapshotUpdateOptions{
+	assert.Nil(t, c.Snapshot("snapshot1").UpdateConfig(ctx, &ContainerSnapshotUpdateOptions{
 		Description: "updated by tests",
 	}))
 }

--- a/types.go
+++ b/types.go
@@ -2435,7 +2435,21 @@ type FirewallVirtualMachineOption struct {
 	Radv        bool   `json:"radv,omitempty"` // FIXME(issue-178): schema "boolean"; use IntOrBool (defaults match — no pointer needed).
 }
 
-type Snapshot struct {
+// VirtualMachineSnapshot is one entry from
+// GET /nodes/{node}/qemu/{vmid}/snapshot. The unexported client and the
+// parent-identifying Node/VMID fields are populated by
+// (*VirtualMachine).Snapshots and (*VirtualMachine).Snapshot so callers can
+// invoke instance methods (Rollback, Delete, Config, UpdateConfig,
+// SubResources) without re-threading those identifiers.
+type VirtualMachineSnapshot struct {
+	client *Client `json:"-"`
+	// Node is the cluster node that hosts the parent VM. Populated by the
+	// getter and not part of the upstream JSON payload.
+	Node string `json:"-"`
+	// VMID is the parent VM's numeric id. Populated by the getter and not
+	// part of the upstream JSON payload.
+	VMID int `json:"-"`
+
 	Name        string
 	Vmstate     int
 	Description string
@@ -2735,9 +2749,23 @@ type VNCProxyOptions struct {
 	Width     int    `json:"width,omitempty"`
 }
 
+// ContainerSnapshot is one entry from
+// GET /nodes/{node}/lxc/{vmid}/snapshot. The unexported client and the
+// parent-identifying Node/VMID fields are populated by
+// (*Container).Snapshots and (*Container).Snapshot so callers can invoke
+// instance methods (Rollback, Delete, Config, UpdateConfig, SubResources)
+// without re-threading those identifiers.
 type ContainerSnapshot struct {
+	client *Client `json:"-"`
+	// Node is the cluster node that hosts the parent container. Populated
+	// by the getter and not part of the upstream JSON payload.
+	Node string `json:"-"`
+	// VMID is the parent container's numeric id. Populated by the getter
+	// and not part of the upstream JSON payload.
+	VMID int `json:"-"`
+
 	Description          string `json:"description,omitempty"`
-	Name                 string `json:"snapname,omitempty"`
+	Name                 string `json:"name,omitempty"`
 	Parent               string `json:"parent,omitempty"`
 	SnapshotCreationTime int64  `json:"snaptime,omitempty"`
 }
@@ -3820,6 +3848,13 @@ type VirtualMachineStatusIndexEntry struct {
 // index (GET /nodes/{node}/qemu/{vmid}/snapshot/{snapname}) — each entry
 // names a sub-resource on the snapshot (config, rollback).
 type VirtualMachineSnapshotIndexEntry struct {
+	Subdir string `json:"subdir,omitempty"`
+}
+
+// ContainerSnapshotIndexEntry is one row in the per-snapshot directory index
+// (GET /nodes/{node}/lxc/{vmid}/snapshot/{snapname}) — each entry names a
+// sub-resource on the snapshot (config, rollback).
+type ContainerSnapshotIndexEntry struct {
 	Subdir string `json:"subdir,omitempty"`
 }
 

--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -832,6 +832,9 @@ func (v *VirtualMachine) FirewallRulesDelete(ctx context.Context, rulePos int) e
 	return v.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/firewall/rules/%d", v.Node, v.VMID, rulePos), nil)
 }
 
+// NewSnapshot creates a snapshot of the VM and returns the worker task. The
+// returned snapshot's metadata is reachable via v.Snapshot(name) once the
+// task completes.
 func (v *VirtualMachine) NewSnapshot(ctx context.Context, name string) (task *Task, err error) {
 	var upid UPID
 	if err = v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot", v.Node, v.VMID), map[string]string{"snapname": name}, &upid); err != nil {
@@ -841,33 +844,32 @@ func (v *VirtualMachine) NewSnapshot(ctx context.Context, name string) (task *Ta
 	return NewTask(upid, v.client), nil
 }
 
-func (v *VirtualMachine) Snapshots(ctx context.Context) (snapshots []*Snapshot, err error) {
-	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot", v.Node, v.VMID), &snapshots)
-	return
-}
-
-func (v *VirtualMachine) SnapshotRollback(ctx context.Context, name string) (task *Task, err error) {
-	var upid UPID
-	if err = v.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/rollback", v.Node, v.VMID, name), nil, &upid); err != nil {
+// Snapshots lists every snapshot of the VM. Each returned
+// *VirtualMachineSnapshot has its client/Node/VMID pre-populated so callers
+// can invoke instance methods (Rollback, Delete, Config, …) directly.
+func (v *VirtualMachine) Snapshots(ctx context.Context) (snapshots []*VirtualMachineSnapshot, err error) {
+	if err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot", v.Node, v.VMID), &snapshots); err != nil {
 		return nil, err
 	}
-
-	return NewTask(upid, v.client), nil
-}
-
-func (v *VirtualMachine) DeleteSnapshot(ctx context.Context, snapshot string) (task *Task, err error) {
-	var upid UPID
-	if err := v.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s", v.Node, v.VMID, snapshot), &upid); err != nil {
-		return nil, err
+	for _, s := range snapshots {
+		s.client = v.client
+		s.Node = v.Node
+		s.VMID = int(v.VMID)
 	}
-	return NewTask(upid, v.client), nil
+	return snapshots, nil
 }
 
-// GetSnapshotConfig reads a snapshot's metadata (description, parent, etc.).
-// PVE returns a free-form map since snapshot configs include arbitrary
-// device keys snapshotted at the time of creation.
-func (v *VirtualMachine) GetSnapshotConfig(ctx context.Context, snapshot string) (config map[string]interface{}, err error) {
-	return config, v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", v.Node, v.VMID, snapshot), &config)
+// Snapshot constructs a handle to a single snapshot by name. It performs no
+// API call; the returned *VirtualMachineSnapshot is wired to the VM's client
+// and node/vmid so its instance methods (Rollback, Delete, Config,
+// UpdateConfig, SubResources) target the correct snapshot path.
+func (v *VirtualMachine) Snapshot(name string) *VirtualMachineSnapshot {
+	return &VirtualMachineSnapshot{
+		client: v.client,
+		Node:   v.Node,
+		VMID:   int(v.VMID),
+		Name:   name,
+	}
 }
 
 // VirtualMachineSnapshotUpdateOptions is the body for PUT
@@ -877,13 +879,46 @@ type VirtualMachineSnapshotUpdateOptions struct {
 	Description string `json:"description,omitempty"`
 }
 
-// UpdateSnapshot updates a VM snapshot's metadata. PVE only allows changing
+// Rollback rolls the VM back to this snapshot. Returns the worker task.
+func (s *VirtualMachineSnapshot) Rollback(ctx context.Context) (task *Task, err error) {
+	var upid UPID
+	if err = s.client.Post(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/rollback", s.Node, s.VMID, s.Name), nil, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
+}
+
+// Delete removes this snapshot from the VM. Returns the worker task.
+func (s *VirtualMachineSnapshot) Delete(ctx context.Context) (task *Task, err error) {
+	var upid UPID
+	if err := s.client.Delete(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s", s.Node, s.VMID, s.Name), &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, s.client), nil
+}
+
+// Config reads this snapshot's metadata (description, parent, etc.). PVE
+// returns a free-form map since snapshot configs include arbitrary device
+// keys snapshotted at the time of creation.
+func (s *VirtualMachineSnapshot) Config(ctx context.Context) (config map[string]interface{}, err error) {
+	return config, s.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", s.Node, s.VMID, s.Name), &config)
+}
+
+// UpdateConfig updates this snapshot's metadata. PVE only allows changing
 // the description on this endpoint; pass nil options to clear it.
-func (v *VirtualMachine) UpdateSnapshot(ctx context.Context, snapshot string, options *VirtualMachineSnapshotUpdateOptions) error {
+func (s *VirtualMachineSnapshot) UpdateConfig(ctx context.Context, options *VirtualMachineSnapshotUpdateOptions) error {
 	if options == nil {
 		options = &VirtualMachineSnapshotUpdateOptions{}
 	}
-	return v.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", v.Node, v.VMID, snapshot), options, nil)
+	return s.client.Put(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s/config", s.Node, s.VMID, s.Name), options, nil)
+}
+
+// SubResources returns the per-snapshot directory index
+// (GET /nodes/{node}/qemu/{vmid}/snapshot/{snapname}) — one entry per
+// sub-resource (config, rollback) on this snapshot.
+func (s *VirtualMachineSnapshot) SubResources(ctx context.Context) (entries []*VirtualMachineSnapshotIndexEntry, err error) {
+	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s", s.Node, s.VMID, s.Name), &entries)
+	return
 }
 
 // RRD asks PVE to render a single-datasource PNG on the server and returns
@@ -975,14 +1010,6 @@ func (v *VirtualMachine) DirIndex(ctx context.Context) (entries []*VirtualMachin
 // Start/Stop/Reboot/etc. on *VirtualMachine.
 func (v *VirtualMachine) StatusIndex(ctx context.Context) (entries []*VirtualMachineStatusIndexEntry, err error) {
 	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/status", v.Node, v.VMID), &entries)
-	return
-}
-
-// SnapshotIndex returns the per-snapshot directory index
-// (GET /nodes/{node}/qemu/{vmid}/snapshot/{snapname}) — one entry per
-// sub-resource (config, rollback) on the named snapshot.
-func (v *VirtualMachine) SnapshotIndex(ctx context.Context, snapshot string) (entries []*VirtualMachineSnapshotIndexEntry, err error) {
-	err = v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/snapshot/%s", v.Node, v.VMID, snapshot), &entries)
 	return
 }
 

--- a/virtual_machine_snapshot_config_test.go
+++ b/virtual_machine_snapshot_config_test.go
@@ -8,20 +8,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVirtualMachine_GetSnapshotConfig(t *testing.T) {
+func TestVirtualMachineSnapshot_Config(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	cfg, err := vm100().GetSnapshotConfig(context.Background(), "snap1")
+	cfg, err := vm100().Snapshot("snap1").Config(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, "Before upgrade", cfg["description"])
 	assert.Equal(t, "snap0", cfg["parent"])
 }
 
-func TestVirtualMachine_UpdateSnapshot(t *testing.T) {
+func TestVirtualMachineSnapshot_UpdateConfig(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	err := vm100().UpdateSnapshot(context.Background(), "snap1", &VirtualMachineSnapshotUpdateOptions{Description: "renamed"})
+	err := vm100().Snapshot("snap1").UpdateConfig(context.Background(), &VirtualMachineSnapshotUpdateOptions{Description: "renamed"})
 	assert.Nil(t, err)
 	// nil options path
-	assert.Nil(t, vm100().UpdateSnapshot(context.Background(), "snap1", nil))
+	assert.Nil(t, vm100().Snapshot("snap1").UpdateConfig(context.Background(), nil))
 }

--- a/virtual_machine_test.go
+++ b/virtual_machine_test.go
@@ -652,6 +652,12 @@ func TestVirtualMachine_Snapshots(t *testing.T) {
 	assert.Equal(t, "snap1", snapshots[1].Name)
 	assert.Equal(t, "Before upgrade", snapshots[1].Description)
 	assert.Equal(t, "snap2", snapshots[2].Name)
+	// Returned snapshots must be wired to their parent VM so instance
+	// methods can target the right snapshot path.
+	for _, s := range snapshots {
+		assert.Equal(t, "node1", s.Node)
+		assert.Equal(t, 100, s.VMID)
+	}
 }
 
 func TestVirtualMachine_NewSnapshot(t *testing.T) {
@@ -683,7 +689,7 @@ func TestVirtualMachine_DeleteSnapshot(t *testing.T) {
 		Node:   "node1",
 		VMID:   100,
 	}
-	task, err := vm.DeleteSnapshot(ctx, "snap2")
+	task, err := vm.Snapshot("snap2").Delete(ctx)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, task)
 }
@@ -699,12 +705,23 @@ func TestVirtualMachine_SnapshotRollback(t *testing.T) {
 		Node:   "node1",
 	}
 
-	task, err := vm.SnapshotRollback(ctx, "snap1")
+	task, err := vm.Snapshot("snap1").Rollback(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, task)
 	assert.Equal(t, "node1", task.Node)
 	assert.Equal(t, "qmrollback", task.Type)
 	assert.Equal(t, "100", task.ID)
+}
+
+func TestVirtualMachine_Snapshot_Getter(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vm := vm100()
+	s := vm.Snapshot("snap1")
+	assert.NotNil(t, s)
+	assert.Equal(t, "snap1", s.Name)
+	assert.Equal(t, "node1", s.Node)
+	assert.Equal(t, 100, s.VMID)
 }
 
 func cleanupISO(t *testing.T, path string) {
@@ -946,10 +963,10 @@ func TestVirtualMachine_StatusIndex(t *testing.T) {
 	assert.True(t, names["reboot"])
 }
 
-func TestVirtualMachine_SnapshotIndex(t *testing.T) {
+func TestVirtualMachineSnapshot_SubResources(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	entries, err := vm100().SnapshotIndex(context.Background(), "snap1")
+	entries, err := vm100().Snapshot("snap1").SubResources(context.Background())
 	assert.Nil(t, err)
 	assert.Len(t, entries, 2)
 	names := make(map[string]bool, len(entries))


### PR DESCRIPTION
## Summary

Refactor VM and Container snapshots to follow the package-wide
multi-instance sub-resource pattern (`parent.Resource(name)` getter +
`*Resource` instance type with methods). Previously every per-snapshot
operation took the snapshot name as an argument, which differed from how
storage, firewalls, jobs, etc. expose their items.

- VM-side `Snapshot` type renamed to `VirtualMachineSnapshot` to mirror
  `ContainerSnapshot` and avoid colliding with the generic concept.
- `Snapshots(ctx)` list methods now populate `client`/`Node`/`VMID` on
  each returned snapshot so instance methods work out of the box.
- New `Snapshot(name) *VirtualMachineSnapshot` / `Snapshot(name)
  *ContainerSnapshot` getters construct a wired handle with no API call.
- Per-snapshot operations live on the instance: `Rollback`, `Delete`,
  `Config`, `UpdateConfig`, `SubResources`.
- `ContainerSnapshot.Name` JSON tag fixed from `snapname` to `name`
  (latent bug — PVE list response uses `name`).

### BREAKING CHANGE

Removed methods on `*VirtualMachine`:

- `SnapshotRollback(ctx, name)` → `vm.Snapshot(name).Rollback(ctx)`
- `DeleteSnapshot(ctx, name)` → `vm.Snapshot(name).Delete(ctx)`
- `GetSnapshotConfig(ctx, name)` → `vm.Snapshot(name).Config(ctx)`
- `UpdateSnapshot(ctx, name, opts)` →
  `vm.Snapshot(name).UpdateConfig(ctx, opts)`
- `SnapshotIndex(ctx, name)` →
  `vm.Snapshot(name).SubResources(ctx)`

Removed methods on `*Container`:

- `GetSnapshot(ctx, name)` → `c.Snapshot(name).SubResources(ctx)`
- `DeleteSnapshot(ctx, name)` → `c.Snapshot(name).Delete(ctx)`
- `RollbackSnapshot(ctx, name, start)` →
  `c.Snapshot(name).Rollback(ctx, start)`
- `GetSnapshotConfig(ctx, name)` → `c.Snapshot(name).Config(ctx)`
- `UpdateSnapshot(ctx, name, opts)` →
  `c.Snapshot(name).UpdateConfig(ctx, opts)`

Renamed type: `Snapshot` → `VirtualMachineSnapshot`.

### Before / after

```go
// before
task, err := vm.SnapshotRollback(ctx, "snap1")
err = vm.UpdateSnapshot(ctx, "snap1", &VirtualMachineSnapshotUpdateOptions{Description: "x"})
entries, err := vm.SnapshotIndex(ctx, "snap1")

// after
task, err := vm.Snapshot("snap1").Rollback(ctx)
err = vm.Snapshot("snap1").UpdateConfig(ctx, &VirtualMachineSnapshotUpdateOptions{Description: "x"})
entries, err := vm.Snapshot("snap1").SubResources(ctx)
```

```go
// before
task, err := ct.RollbackSnapshot(ctx, "snap1", true)
cfg, err := ct.GetSnapshotConfig(ctx, "snap1")

// after
task, err := ct.Snapshot("snap1").Rollback(ctx, true)
cfg, err := ct.Snapshot("snap1").Config(ctx)
```

`Snapshots(ctx)` / `NewSnapshot(ctx, name)` stay on the parent (list +
create), matching the pattern used by storage, jobs, ACME, etc.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `mage test:unit` passes
- [x] `mage endpoints:coverage` — qemu still at 99.0% (96/97), lxc still at 90.3% (56/62); no snapshot endpoints regressed
- [x] `golangci-lint run` clean