### PR TITLE
docs(agents): codify the singleton-vs-instance-type rule for new endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,71 @@ parsing happens in `NewTask` (`tasks.go`).
 are name/value pairs flattened into the request body — this is how the
 package handles Proxmox's free-form, version-dependent config keys.
 
+### Required: pick the right shape for new endpoints (singleton vs. instance type)
+
+Every new endpoint wrapper must decide where to hang. The rule is mechanical:
+**look at the upstream PVE path** and apply one of two shapes.
+
+**Singleton sub-resource (no identifier in the path).** Path looks like
+`/parent/<sub>` or `/parent/<sub>/<fixed-action>` with no `/{id}/` segment.
+Wrap as a **method on the parent** type. Examples: `/nodes/{node}/apt/update`,
+`/nodes/{node}/dns`, `/nodes/{node}/ceph/status`. There's exactly one of these
+per parent — no identifier to hold.
+
+```go
+func (n *Node) APTUpdate(ctx context.Context, notify, quiet bool) (*Task, error) { … }
+func (n *Node) DNS(ctx context.Context) (*NodeDNS, error) { … }
+```
+
+**Multi-instance sub-resource (identifier in the path).** Path has
+`/{name}/` or `/{id}/` selecting one of many. Wrap as a **getter on the parent
+that returns an instance handle**, with operations as methods on the handle.
+Examples: `/nodes/{node}/storage/{storage}/...`, `/nodes/{node}/ceph/osd/{id}/...`,
+`/nodes/{node}/services/{service}/...`. The handle carries identity in its
+receiver so callers don't re-thread it on every call.
+
+```go
+// Getter: no API call, just constructs the handle.
+func (n *Node) CephOSD(id int) *CephOSD {
+    return &CephOSD{client: n.client, Node: n.Name, ID: id}
+}
+
+// Instance type: unexported client + exported identifying fields.
+type CephOSD struct {
+    client *Client
+    Node   string `json:"-"`
+    ID     int    `json:"-"`
+    // ...plus any data fields the list endpoint populates...
+}
+
+// Operations live on the instance, not the parent.
+func (o *CephOSD) Scrub(ctx context.Context, deep bool) error { … }
+func (o *CephOSD) Delete(ctx context.Context, cleanup bool) (*Task, error) { … }
+```
+
+**Anti-pattern to avoid:** `node.CephOSDScrub(ctx, id, ...)` or
+`node.DeleteCephOSD(ctx, id, ...)`. Threading the id through every call when
+the schema clearly identifies the resource in the path duplicates the
+identity argument across N methods and makes the godoc surface of the parent
+explode. `*Storage`, `*VirtualMachine`, `*Container`, `*NodeNetwork`,
+`*NodeService`, `*NodeReplicationJob`, `*CephOSD`, `*CephPool`,
+`*CephMon`/`Mgr`/`MDS`, `*CephFS`, `*FirewallRule`, `*VirtualMachineSnapshot`,
+and `*ContainerSnapshot` are all instance types — mirror their shape.
+
+**Construction:** the getter never makes an API call; it just builds the
+handle. The corresponding `List`/`Plural` accessor on the parent (e.g.
+`node.CephOSDs(ctx)`) populates `client` + identifying fields on each
+returned `*CephOSD` so list results are immediately chainable.
+
+**Creation stays on the parent.** `node.CreateCephOSD(ctx, opts)` — there's
+no instance yet, so the parent owns the constructor call. Same for `New*`
+patterns.
+
+**Singleton subsystems with many endpoints (e.g. ceph itself, disks,
+firewall-options) stay on the parent.** Don't introduce a top-level handle
+just because the area is big. Threshold: does the schema path namespace by
+identifier? If yes → handle; if no → parent method.
+
 ### Required: don't clobber PVE-side defaults on config structs
 
 Background: see issue #199. Several config structs (e.g. `ContainerConfig`,


### PR DESCRIPTION
## Summary

Adds a `### Required:` subsection under "Resource model" in `AGENTS.md` that names the pattern we've converged on this release cycle and gives the mechanical rule for picking the right shape for any new endpoint wrapper.

## Why

We hit this enough times in the v0.6 cycle to make it worth writing down:
- Multiple agents independently wrote `node.CephOSDScrub(ctx, id, …)` style methods until we noticed the schema clearly addresses OSDs at `/ceph/osd/{id}/scrub`.
- Same thing happened to `node.ServiceStart`/`Stop`/`Restart`, `node.ReplicationStatus`/`Log`, firewall rules across Node/VM/Container, and VM/container snapshots.
- The post-hoc refactors (PRs #307, #308, #309 plus the queued #310, #311) all applied the same fix: when the schema has `/{id}/`, hang operations off a getter-returned instance handle instead of threading the id through every call.

This commit gives that rule a name and a place so the next sub-agent (and human) reaches for it on the first pass.

## What the doc says

The rule is one decision:

| Schema path | Wrap as |
|---|---|
| `/parent/<sub>/<fixed-action>` (no `{id}`) | method on parent |
| `/parent/<sub>/{name}/...` | getter on parent → instance handle; operations as methods on handle |

Plus the construction pattern (no API call in the getter; list method pre-populates `client` + identity fields), where creation goes (still on the parent), and an enumerated list of existing instance types to mirror.

## Test plan

- [x] Doc-only change. No code touched.
- [ ] If sensible, future endpoint-wrapping PRs cite this section in their PR body.