### PR TITLE
feat: nodes/lxc → 100% (98.4% tool / 100% real) + scanner fix for *WithParams

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -460,3 +460,68 @@ func (c *Container) FirewallRefs(ctx context.Context) (refs []*FirewallRef, err 
 	return refs, c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/firewall/refs", c.Node, c.VMID), &refs)
 }
 
+// DirIndex returns the per-container directory index
+// (GET /nodes/{node}/lxc/{vmid}) — one entry per sub-resource (config, status,
+// snapshot, firewall, …). The sub-resources themselves are wrapped as their
+// own methods on *Container; this is mostly useful for discovery.
+func (c *Container) DirIndex(ctx context.Context) (entries []*ContainerDirIndexEntry, err error) {
+	err = c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d", c.Node, c.VMID), &entries)
+	return
+}
+
+// StatusIndex returns the container status directory index
+// (GET /nodes/{node}/lxc/{vmid}/status) — one entry per status sub-command
+// (current, start, stop, …). The operations are wrapped as Start/Stop/etc.
+// on *Container.
+func (c *Container) StatusIndex(ctx context.Context) (entries []*ContainerStatusIndexEntry, err error) {
+	err = c.client.Get(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/status", c.Node, c.VMID), &entries)
+	return
+}
+
+// MigratePreconditions returns the precondition check for migrating this
+// container (GET /nodes/{node}/lxc/{vmid}/migrate). If target is non-empty,
+// PVE evaluates the check against that specific target node; otherwise it
+// reports which nodes are allowed/not-allowed and any local-disk constraints.
+func (c *Container) MigratePreconditions(ctx context.Context, target string) (preconditions *ContainerMigratePreconditions, err error) {
+	u := url.URL{Path: fmt.Sprintf("/nodes/%s/lxc/%d/migrate", c.Node, c.VMID)}
+	if target != "" {
+		params := url.Values{}
+		params.Add("target", target)
+		u.RawQuery = params.Encode()
+	}
+	err = c.client.Get(ctx, u.String(), &preconditions)
+	return
+}
+
+// MigrationTunnel opens a migration tunnel for this container
+// (POST /nodes/{node}/lxc/{vmid}/mtunnel) and returns the Unix socket path,
+// authentication ticket, and worker UPID.
+//
+// PVE marks this endpoint as "for internal use by VM migration" — callers
+// should generally use Migrate or the higher-level migration flow rather
+// than wiring this up directly. Wrapped here for full API surface coverage.
+func (c *Container) MigrationTunnel(ctx context.Context, options *ContainerMigrationTunnelOptions) (tunnel *ContainerMigrationTunnel, err error) {
+	if options == nil {
+		options = &ContainerMigrationTunnelOptions{}
+	}
+	err = c.client.Post(ctx, fmt.Sprintf("/nodes/%s/lxc/%d/mtunnel", c.Node, c.VMID), options, &tunnel)
+	return
+}
+
+// MigrationTunnelWebSocketPath returns the path callers can pass to a
+// websocket dialer to upgrade the migration tunnel returned by
+// MigrationTunnel (GET /nodes/{node}/lxc/{vmid}/mtunnelwebsocket).
+//
+// PVE marks this endpoint as "for internal use by VM migration"; this helper
+// just builds the path with the correct query string. There is no generic
+// Client helper for migration-tunnel websockets — dial it directly with the
+// authenticated cookies/headers if you need to consume it.
+func (c *Container) MigrationTunnelWebSocketPath(tunnel *ContainerMigrationTunnel) string {
+	q := url.Values{}
+	if tunnel != nil {
+		q.Set("socket", tunnel.Socket)
+		q.Set("ticket", tunnel.Ticket)
+	}
+	return fmt.Sprintf("/nodes/%s/lxc/%d/mtunnelwebsocket?%s", c.Node, c.VMID, q.Encode())
+}
+

--- a/containers_test.go
+++ b/containers_test.go
@@ -615,3 +615,91 @@ func TestContainerUpdateSnapshot(t *testing.T) {
 		Description: "updated by tests",
 	}))
 }
+
+func ct100() *Container {
+	return &Container{client: mockClient(), Node: "node1", VMID: 100}
+}
+
+func TestContainer_DirIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := ct100().DirIndex(context.Background())
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entries)
+	names := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		names[e.Subdir] = true
+	}
+	assert.True(t, names["config"])
+	assert.True(t, names["status"])
+	assert.True(t, names["snapshot"])
+	assert.True(t, names["firewall"])
+	assert.True(t, names["mtunnel"])
+}
+
+func TestContainer_StatusIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := ct100().StatusIndex(context.Background())
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entries)
+	names := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		names[e.Subdir] = true
+	}
+	assert.True(t, names["current"])
+	assert.True(t, names["start"])
+	assert.True(t, names["stop"])
+}
+
+func TestContainer_MigratePreconditions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	pre, err := ct100().MigratePreconditions(context.Background(), "")
+	assert.Nil(t, err)
+	require.NotNil(t, pre)
+	assert.True(t, pre.Running)
+	assert.Contains(t, pre.AllowedNodes, "node2")
+
+	// with target — same mock fields, just verify the call shape
+	pre2, err := ct100().MigratePreconditions(context.Background(), "node2")
+	assert.Nil(t, err)
+	require.NotNil(t, pre2)
+}
+
+func TestContainer_MigrationTunnel(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	tunnel, err := ct100().MigrationTunnel(context.Background(), nil)
+	assert.Nil(t, err)
+	require.NotNil(t, tunnel)
+	assert.Equal(t, "/run/pve/100.mtunnel", tunnel.Socket)
+	assert.Equal(t, "PVEMTUNNELTICKET:lxc-abc123", tunnel.Ticket)
+	assert.Contains(t, tunnel.UPID, "vzmtunnel")
+
+	// with explicit options
+	tunnel2, err := ct100().MigrationTunnel(context.Background(), &ContainerMigrationTunnelOptions{
+		Bridges:  "vmbr0",
+		Storages: "local-lvm",
+	})
+	assert.Nil(t, err)
+	require.NotNil(t, tunnel2)
+}
+
+func TestContainer_MigrationTunnelWebSocketPath(t *testing.T) {
+	c := ct100()
+	tunnel := &ContainerMigrationTunnel{
+		Socket: "/run/pve/100.mtunnel",
+		Ticket: "PVEMTUNNELTICKET:lxc-abc123",
+	}
+	path := c.MigrationTunnelWebSocketPath(tunnel)
+	assert.Contains(t, path, "/nodes/node1/lxc/100/mtunnelwebsocket")
+	assert.Contains(t, path, "socket=")
+	assert.Contains(t, path, "ticket=")
+	// ticket should be URL-encoded (':' becomes %3A)
+	assert.Contains(t, path, "PVEMTUNNELTICKET%3Alxc-abc123")
+
+	// nil tunnel still returns a valid path skeleton
+	emptyPath := c.MigrationTunnelWebSocketPath(nil)
+	assert.Contains(t, emptyPath, "/nodes/node1/lxc/100/mtunnelwebsocket")
+}

--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -372,7 +372,12 @@ type extractedCall struct {
 }
 
 var (
-	callRE      = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)\s*\(\s*ctx\s*,\s*(.*?)$`)
+	// Captures `<recv>.Get|Post|Put|Delete(WithParams)?(ctx, ...)`. The
+	// WithParams variants on *Client (GetWithParams, DeleteWithParams) take an
+	// extra body/query interface but the path is still the first non-ctx arg,
+	// so the same extractor handles both. The `(?:WithParams)?` is
+	// non-capturing — group 1 always returns the bare HTTP verb.
+	callRE      = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)(?:WithParams)?\s*\(\s*ctx\s*,\s*(.*?)$`)
 	wsCallRE    = regexp.MustCompile(`\b\w+\.(VNCWebSocket|TermWebSocket)\s*\(\s*(.*?)$`)
 	sprintfRE   = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
 	urlAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*url\.URL\{\s*Path:\s*(.+)\}`)

--- a/tests/mocks/pve9x/containers.go
+++ b/tests/mocks/pve9x/containers.go
@@ -366,4 +366,78 @@ func containers() {
         {"type": "ipset", "name": "blocked", "comment": "Blocked sources"}
     ]
 }`)
+
+	// GET /nodes/{node}/lxc/{vmid} — directory index (ct100 for lxc-100 sweep)
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/lxc/100$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"subdir": "config"},
+        {"subdir": "status"},
+        {"subdir": "snapshot"},
+        {"subdir": "firewall"},
+        {"subdir": "rrd"},
+        {"subdir": "rrddata"},
+        {"subdir": "vncproxy"},
+        {"subdir": "vncwebsocket"},
+        {"subdir": "spiceproxy"},
+        {"subdir": "termproxy"},
+        {"subdir": "migrate"},
+        {"subdir": "feature"},
+        {"subdir": "template"},
+        {"subdir": "clone"},
+        {"subdir": "resize"},
+        {"subdir": "move_volume"},
+        {"subdir": "pending"},
+        {"subdir": "mtunnel"},
+        {"subdir": "mtunnelwebsocket"}
+    ]
+}`)
+
+	// GET /nodes/{node}/lxc/{vmid}/status — status directory index
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/lxc/100/status$").
+		Reply(200).
+		JSON(`{
+    "data": [
+        {"subdir": "current"},
+        {"subdir": "start"},
+        {"subdir": "stop"},
+        {"subdir": "shutdown"},
+        {"subdir": "suspend"},
+        {"subdir": "resume"},
+        {"subdir": "reboot"}
+    ]
+}`)
+
+	// GET /nodes/{node}/lxc/{vmid}/migrate — migration preconditions
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/lxc/100/migrate").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "running": true,
+        "allowed_nodes": ["node2", "node3"],
+        "not_allowed_nodes": {},
+        "local_disks": [],
+        "local_resources": []
+    }
+}`)
+
+	// POST /nodes/{node}/lxc/{vmid}/mtunnel — open migration tunnel
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/lxc/100/mtunnel$").
+		Reply(200).
+		JSON(`{
+    "data": {
+        "socket": "/run/pve/100.mtunnel",
+        "ticket": "PVEMTUNNELTICKET:lxc-abc123",
+        "upid": "UPID:node1:00001234:00005678:12345678:vzmtunnel:100:root@pam:"
+    }
+}`)
 }

--- a/types.go
+++ b/types.go
@@ -1384,6 +1384,54 @@ type ContainerRRD struct {
 	Filename string `json:"filename"`
 }
 
+// ContainerDirIndexEntry is one row of the /nodes/{node}/lxc/{vmid} directory
+// index — each entry names a child resource (config, status, snapshot,
+// firewall, …).
+type ContainerDirIndexEntry struct {
+	Subdir string `json:"subdir,omitempty"`
+}
+
+// ContainerStatusIndexEntry is one row of the
+// /nodes/{node}/lxc/{vmid}/status directory index — each entry names a
+// status sub-command (current, start, stop, …).
+type ContainerStatusIndexEntry struct {
+	Subdir string `json:"subdir,omitempty"`
+}
+
+// ContainerMigratePreconditions is the response from
+// GET /nodes/{node}/lxc/{vmid}/migrate — the migration precondition check.
+// Re-uses the VM-side sub-types (NotAllowedNodes, LocalDisk) because PVE
+// shares the same migration-constraint shapes between qemu and lxc.
+type ContainerMigratePreconditions struct {
+	Running         bool                                                          `json:"running"`
+	AllowedNodes    []string                                                      `json:"allowed_nodes,omitempty"`
+	NotAllowedNodes map[string]*VirtualMachineMigratePreconditionsNotAllowedNodes `json:"not_allowed_nodes,omitempty"`
+	LocalDisks      []*VirtualMachineMigratePreconditionsLocalDisk                `json:"local_disks,omitempty"`
+	LocalResources  []string                                                      `json:"local_resources,omitempty"`
+}
+
+// ContainerMigrationTunnel is the response from
+// POST /nodes/{node}/lxc/{vmid}/mtunnel — the migration tunnel handle that
+// MigrationTunnelWebSocketPath consumes.
+type ContainerMigrationTunnel struct {
+	Socket string `json:"socket,omitempty"`
+	Ticket string `json:"ticket,omitempty"`
+	UPID   string `json:"upid,omitempty"`
+}
+
+// ContainerMigrationTunnelOptions are the parameters for
+// POST /nodes/{node}/lxc/{vmid}/mtunnel. PVE marks this endpoint internal —
+// most callers go through Migrate or RemoteMigrate, which manage the tunnel
+// lifecycle themselves.
+type ContainerMigrationTunnelOptions struct {
+	// Bridges is a comma-separated list of network bridges to check
+	// availability for. Optional.
+	Bridges string `json:"bridges,omitempty"`
+	// Storages is a comma-separated list of storages to check permission
+	// and availability for. Optional.
+	Storages string `json:"storages,omitempty"`
+}
+
 // VirtualMachineRRD is the response from GET /nodes/{node}/qemu/{vmid}/rrd.
 // PVE renders a single PNG on the server (one datasource per call) and
 // returns its on-disk filename; callers typically want RRDData instead for


### PR DESCRIPTION
## Summary

Closes out `nodes/lxc` by mirroring the qemu surface for migration/discovery, and fixes a scanner blind spot that was hiding `Container.Delete`.

## Commits

| Commit | What |
|---|---|
| `e00a6aa` | **fix(mage):** scanner regex extended to recognize `*.GetWithParams` / `*.DeleteWithParams` call sites. Was silently dropping `Container.Delete` (which uses `c.client.DeleteWithParams`), masking `DELETE /lxc/{vmid}` as uncovered. |
| `31d98ed` | **feat:** five new `*Container` methods covering dir index, status index, migrate preconditions, mtunnel, and the mtunnelwebsocket path-builder. |

## Coverage impact

| metric | before | after |
|---|---:|---:|
| `nodes/lxc` | 56 / 62 (90.3%) | **61 / 62 (98.4%)** tool, **100%** real |
| overall | 445 / 675 (65.9%) | **450 / 675 (66.7%)** |
| match rate | 100.0% | 100.0% |
| call sites scanned | 463 | 468 |

The one remaining `nodes/lxc` entry in `coverage.txt` is `GET /nodes/{node}/lxc/{vmid}/mtunnelwebsocket` — same path-builder blind spot as qemu's. Real coverage = 100%.

## Type re-use

`ContainerMigratePreconditions` references `VirtualMachineMigratePreconditionsLocalDisk` and `VirtualMachineMigratePreconditionsNotAllowedNodes` directly — PVE shares the same migration-constraint shapes between qemu and lxc, so duplicating the sub-types would be churn for no signal. Documented inline on the type.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `mage test:unit` passes (5 new tests, all green)
- [x] `mage endpoints:coverage` reports `nodes/lxc 61/62`, match rate 100.0%
- [x] `DELETE /lxc/{vmid}` no longer appears in `.cache/pve-api/coverage.txt` (scanner now sees `Container.Delete`)