### PR TITLE
feat: wrap /nodes/{node}/sdn — runtime status (12 endpoints)

### DIFF
--- a/nodes_sdn.go
+++ b/nodes_sdn.go
@@ -1,0 +1,134 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+)
+
+// /nodes/{node}/sdn — runtime visibility into SDN on this node. All endpoints
+// are read-only; mutations live on Cluster (see cluster_sdn.go).
+
+// SDNIndex enumerates the children of /nodes/{node}/sdn (typically "vnets",
+// "zones", "fabrics"). The PVE schema documents it as a directory index, so
+// we collapse the {"subdir": ...} link objects into a flat []string.
+func (n *Node) SDNIndex(ctx context.Context) ([]string, error) {
+	return n.sdnDiridx(ctx, fmt.Sprintf("/nodes/%s/sdn", n.Name))
+}
+
+// SDNFabricIndex enumerates the children of /nodes/{node}/sdn/fabrics/{fabric}
+// (typically "routes", "neighbors", "interfaces").
+func (n *Node) SDNFabricIndex(ctx context.Context, fabric string) ([]string, error) {
+	if fabric == "" {
+		return nil, fmt.Errorf("fabric is required")
+	}
+	return n.sdnDiridx(ctx, fmt.Sprintf("/nodes/%s/sdn/fabrics/%s", n.Name, fabric))
+}
+
+// SDNFabricInterfaces returns the interfaces participating in the named fabric.
+func (n *Node) SDNFabricInterfaces(ctx context.Context, fabric string) (ifaces []*SDNFabricInterface, err error) {
+	if fabric == "" {
+		return nil, fmt.Errorf("fabric is required")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/fabrics/%s/interfaces", n.Name, fabric), &ifaces)
+	return
+}
+
+// SDNFabricNeighbors returns the FRR neighbor table for the named fabric.
+func (n *Node) SDNFabricNeighbors(ctx context.Context, fabric string) (neighbors []*SDNFabricNeighbor, err error) {
+	if fabric == "" {
+		return nil, fmt.Errorf("fabric is required")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/fabrics/%s/neighbors", n.Name, fabric), &neighbors)
+	return
+}
+
+// SDNFabricRoutes returns routes learned/configured for the named fabric.
+func (n *Node) SDNFabricRoutes(ctx context.Context, fabric string) (routes []*SDNFabricRoute, err error) {
+	if fabric == "" {
+		return nil, fmt.Errorf("fabric is required")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/fabrics/%s/routes", n.Name, fabric), &routes)
+	return
+}
+
+// SDNVNetIndex enumerates the children of /nodes/{node}/sdn/vnets/{vnet}
+// (currently just "mac-vrf" on EVPN zones).
+func (n *Node) SDNVNetIndex(ctx context.Context, vnet string) ([]string, error) {
+	if vnet == "" {
+		return nil, fmt.Errorf("vnet is required")
+	}
+	return n.sdnDiridx(ctx, fmt.Sprintf("/nodes/%s/sdn/vnets/%s", n.Name, vnet))
+}
+
+// SDNVNetMACVRF returns the MAC VRF for a VNet in an EVPN zone — entries
+// either self-originated by this node or learned via BGP.
+func (n *Node) SDNVNetMACVRF(ctx context.Context, vnet string) (entries []*SDNMACVRFEntry, err error) {
+	if vnet == "" {
+		return nil, fmt.Errorf("vnet is required")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/vnets/%s/mac-vrf", n.Name, vnet), &entries)
+	return
+}
+
+// SDNZones returns the runtime status of every SDN zone visible to the node.
+// Distinct from Cluster.SDNZones, which returns config — this returns
+// per-node deployment state ("available", "pending", "error").
+func (n *Node) SDNZones(ctx context.Context) (zones []*SDNZoneStatus, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/zones", n.Name), &zones)
+	return
+}
+
+// SDNZoneIndex enumerates the children of /nodes/{node}/sdn/zones/{zone}
+// (typically "content", "bridges", "ip-vrf").
+func (n *Node) SDNZoneIndex(ctx context.Context, zone string) ([]string, error) {
+	if zone == "" {
+		return nil, fmt.Errorf("zone is required")
+	}
+	return n.sdnDiridx(ctx, fmt.Sprintf("/nodes/%s/sdn/zones/%s", n.Name, zone))
+}
+
+// SDNZoneBridges returns the bridges (vnets) deployed for the zone, with
+// their member ports — useful for correlating guest NICs to VLANs.
+func (n *Node) SDNZoneBridges(ctx context.Context, zone string) (bridges []*SDNZoneBridge, err error) {
+	if zone == "" {
+		return nil, fmt.Errorf("zone is required")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/zones/%s/bridges", n.Name, zone), &bridges)
+	return
+}
+
+// SDNZoneContent lists VNets in the zone with their per-node deployment status.
+func (n *Node) SDNZoneContent(ctx context.Context, zone string) (content []*SDNZoneContent, err error) {
+	if zone == "" {
+		return nil, fmt.Errorf("zone is required")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/zones/%s/content", n.Name, zone), &content)
+	return
+}
+
+// SDNZoneIPVRF returns the IP VRF of an EVPN zone (entries from BGP and the
+// kernel routing table, excluding the /32s for guests on this host — those
+// go through the vnet bridge directly).
+func (n *Node) SDNZoneIPVRF(ctx context.Context, zone string) (entries []*SDNIPVRFEntry, err error) {
+	if zone == "" {
+		return nil, fmt.Errorf("zone is required")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/sdn/zones/%s/ip-vrf", n.Name, zone), &entries)
+	return
+}
+
+// sdnDiridx is a shared helper for the four SDN directory-index endpoints.
+// PVE returns [{"subdir":"..."}] — we collapse to []string.
+func (n *Node) sdnDiridx(ctx context.Context, path string) ([]string, error) {
+	var items []struct {
+		Subdir string `json:"subdir"`
+	}
+	if err := n.client.Get(ctx, path, &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Subdir)
+	}
+	return out, nil
+}

--- a/nodes_sdn_test.go
+++ b/nodes_sdn_test.go
@@ -1,0 +1,158 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func sdnNode() *Node {
+	return &Node{client: mockClient(), Name: "node1"}
+}
+
+func TestNode_SDNIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := sdnNode().SDNIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"vnets", "zones", "fabrics"}, subdirs)
+}
+
+func TestNode_SDNFabricIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := sdnNode().SDNFabricIndex(context.Background(), "fab1")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"routes", "neighbors", "interfaces"}, subdirs)
+
+	_, err = sdnNode().SDNFabricIndex(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNFabricInterfaces(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	ifaces, err := sdnNode().SDNFabricInterfaces(context.Background(), "fab1")
+	assert.Nil(t, err)
+	assert.Len(t, ifaces, 2)
+	assert.Equal(t, "eth0", ifaces[0].Name)
+	assert.Equal(t, "up", ifaces[0].State)
+
+	_, err = sdnNode().SDNFabricInterfaces(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNFabricNeighbors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	neighbors, err := sdnNode().SDNFabricNeighbors(context.Background(), "fab1")
+	assert.Nil(t, err)
+	assert.Len(t, neighbors, 1)
+	assert.Equal(t, "Established", neighbors[0].Status)
+	assert.Equal(t, "8h24m12s", neighbors[0].Uptime)
+
+	_, err = sdnNode().SDNFabricNeighbors(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNFabricRoutes(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	routes, err := sdnNode().SDNFabricRoutes(context.Background(), "fab1")
+	assert.Nil(t, err)
+	assert.Len(t, routes, 2)
+	assert.Equal(t, "10.0.0.0/24", routes[0].Route)
+	assert.Len(t, routes[0].Via, 2)
+
+	_, err = sdnNode().SDNFabricRoutes(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNVNetIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := sdnNode().SDNVNetIndex(context.Background(), "vnet1")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"mac-vrf"}, subdirs)
+
+	_, err = sdnNode().SDNVNetIndex(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNVNetMACVRF(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := sdnNode().SDNVNetMACVRF(context.Background(), "vnet1")
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", entries[0].MAC)
+
+	_, err = sdnNode().SDNVNetMACVRF(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNZones(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	zones, err := sdnNode().SDNZones(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, zones, 2)
+	assert.Equal(t, "zone1", zones[0].Zone)
+	assert.Equal(t, "available", zones[0].Status)
+}
+
+func TestNode_SDNZoneIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := sdnNode().SDNZoneIndex(context.Background(), "zone1")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"content", "bridges", "ip-vrf"}, subdirs)
+
+	_, err = sdnNode().SDNZoneIndex(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNZoneBridges(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	bridges, err := sdnNode().SDNZoneBridges(context.Background(), "zone1")
+	assert.Nil(t, err)
+	assert.Len(t, bridges, 1)
+	assert.Equal(t, "vnet1", bridges[0].Name)
+	assert.Equal(t, "1", bridges[0].VLANFiltering)
+	assert.Len(t, bridges[0].Ports, 2)
+	assert.Equal(t, float64(100), bridges[0].Ports[0].VMID)
+	assert.Equal(t, float64(100), bridges[0].Ports[0].PrimaryVLAN)
+
+	_, err = sdnNode().SDNZoneBridges(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNZoneContent(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	content, err := sdnNode().SDNZoneContent(context.Background(), "zone1")
+	assert.Nil(t, err)
+	assert.Len(t, content, 2)
+	assert.Equal(t, "vnet1", content[0].VNet)
+	assert.Equal(t, "awaiting reload", content[1].StatusMsg)
+
+	_, err = sdnNode().SDNZoneContent(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_SDNZoneIPVRF(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := sdnNode().SDNZoneIPVRF(context.Background(), "zone1")
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "10.0.0.0/24", entries[0].IP)
+	assert.Equal(t, 20, entries[0].Metric)
+	assert.Equal(t, "bgp", entries[0].Protocol)
+
+	_, err = sdnNode().SDNZoneIPVRF(context.Background(), "")
+	assert.NotNil(t, err)
+}

--- a/tests/mocks/pve9x/proxmox.go
+++ b/tests/mocks/pve9x/proxmox.go
@@ -10,5 +10,6 @@ func Load() {
 	containers()
 	virtualMachines()
 	storage()
+	sdn()
 	tasks()
 }

--- a/tests/mocks/pve9x/sdn.go
+++ b/tests/mocks/pve9x/sdn.go
@@ -1,0 +1,135 @@
+package pve9x
+
+import (
+	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/config"
+)
+
+func sdn() {
+	// GET /nodes/{node}/sdn - top-level diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"vnets"},
+			{"subdir":"zones"},
+			{"subdir":"fabrics"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/fabrics/{fabric} - fabric diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/fabrics/fab1$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"routes"},
+			{"subdir":"neighbors"},
+			{"subdir":"interfaces"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/fabrics/{fabric}/interfaces
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/fabrics/fab1/interfaces$").
+		Reply(200).
+		JSON(`{"data":[
+			{"name":"eth0","state":"up","type":"Point-to-Point"},
+			{"name":"eth1","state":"down","type":"Broadcast"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/fabrics/{fabric}/neighbors
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/fabrics/fab1/neighbors$").
+		Reply(200).
+		JSON(`{"data":[
+			{"neighbor":"10.0.0.2","status":"Established","uptime":"8h24m12s"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/fabrics/{fabric}/routes
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/fabrics/fab1/routes$").
+		Reply(200).
+		JSON(`{"data":[
+			{"route":"10.0.0.0/24","via":["10.0.0.1","10.0.0.2"]},
+			{"route":"10.0.1.0/24","via":["10.0.0.3"]}
+		]}`)
+
+	// GET /nodes/{node}/sdn/vnets/{vnet} - vnet diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/vnets/vnet1$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"mac-vrf"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/vnets/{vnet}/mac-vrf
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/vnets/vnet1/mac-vrf$").
+		Reply(200).
+		JSON(`{"data":[
+			{"ip":"10.0.0.10","mac":"aa:bb:cc:dd:ee:ff","nexthop":"10.0.0.1"},
+			{"ip":"10.0.0.11","mac":"aa:bb:cc:dd:ee:00","nexthop":"10.0.0.2"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/zones
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/zones$").
+		Reply(200).
+		JSON(`{"data":[
+			{"zone":"zone1","status":"available"},
+			{"zone":"zone2","status":"pending"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/zones/{zone} - zone diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/zones/zone1$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"content"},
+			{"subdir":"bridges"},
+			{"subdir":"ip-vrf"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/zones/{zone}/bridges
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/zones/zone1/bridges$").
+		Reply(200).
+		JSON(`{"data":[
+			{
+				"name":"vnet1",
+				"vlan_filtering":"1",
+				"ports":[
+					{"name":"tap100i0","index":"0","primary_vlan":100,"vlans":["200","300-310"],"vmid":100},
+					{"name":"fwln100i0"}
+				]
+			}
+		]}`)
+
+	// GET /nodes/{node}/sdn/zones/{zone}/content
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/zones/zone1/content$").
+		Reply(200).
+		JSON(`{"data":[
+			{"vnet":"vnet1","status":"available"},
+			{"vnet":"vnet2","status":"pending","statusmsg":"awaiting reload"}
+		]}`)
+
+	// GET /nodes/{node}/sdn/zones/{zone}/ip-vrf
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/sdn/zones/zone1/ip-vrf$").
+		Reply(200).
+		JSON(`{"data":[
+			{"ip":"10.0.0.0/24","metric":20,"nexthops":["10.0.0.1"],"protocol":"bgp"},
+			{"ip":"10.0.1.0/24","metric":0,"protocol":"connected"}
+		]}`)
+}

--- a/types.go
+++ b/types.go
@@ -3877,3 +3877,72 @@ type CephMDS struct {
 type CephMDSOptions struct {
 	HotStandby IntOrBool `json:"hotstandby,omitempty"`
 }
+
+// --- /nodes/{node}/sdn runtime types ---------------------------------------
+
+// SDNZoneStatus is one entry of the per-node SDN zone status index — distinct
+// from the cluster-level SDNZone config object.
+type SDNZoneStatus struct {
+	Zone   string `json:"zone"`
+	Status string `json:"status,omitempty"` // available | pending | error
+}
+
+// SDNZoneContent is one VNet's status within a zone, per node.
+type SDNZoneContent struct {
+	VNet      string `json:"vnet"`
+	Status    string `json:"status,omitempty"`
+	StatusMsg string `json:"statusmsg,omitempty"`
+}
+
+// SDNZoneBridge is one bridge (vnet) deployed in the zone, with its member
+// ports. VLAN-aware bridges carry primary_vlan + vlans on each port.
+type SDNZoneBridge struct {
+	Name          string              `json:"name"`
+	Ports         []*SDNBridgePort    `json:"ports,omitempty"`
+	VLANFiltering string              `json:"vlan_filtering,omitempty"`
+}
+
+// SDNBridgePort is one port attached to a SDN bridge — guest-owned ports
+// carry vmid + index (the guest's net{N} slot).
+type SDNBridgePort struct {
+	Name        string   `json:"name"`
+	Index       string   `json:"index,omitempty"`
+	PrimaryVLAN float64  `json:"primary_vlan,omitempty"`
+	VLANs       []string `json:"vlans,omitempty"`
+	VMID        float64  `json:"vmid,omitempty"`
+}
+
+// SDNIPVRFEntry is one route in an EVPN zone's IP VRF table.
+type SDNIPVRFEntry struct {
+	IP       string   `json:"ip"`
+	Metric   int      `json:"metric,omitempty"`
+	Nexthops []string `json:"nexthops,omitempty"`
+	Protocol string   `json:"protocol,omitempty"`
+}
+
+// SDNMACVRFEntry is one entry in an EVPN VNet's MAC VRF.
+type SDNMACVRFEntry struct {
+	IP      string `json:"ip,omitempty"`
+	MAC     string `json:"mac,omitempty"`
+	NextHop string `json:"nexthop,omitempty"`
+}
+
+// SDNFabricInterface is one interface participating in a fabric.
+type SDNFabricInterface struct {
+	Name  string `json:"name"`
+	State string `json:"state,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+// SDNFabricNeighbor is one FRR neighbor entry for a fabric.
+type SDNFabricNeighbor struct {
+	Neighbor string `json:"neighbor"`
+	Status   string `json:"status,omitempty"`
+	Uptime   string `json:"uptime,omitempty"` // FRR duration string (e.g. "8h24m12s")
+}
+
+// SDNFabricRoute is one route entry for a fabric.
+type SDNFabricRoute struct {
+	Route string   `json:"route"`
+	Via   []string `json:"via,omitempty"`
+}


### PR DESCRIPTION
## Summary

Wraps the 12 read-only `/nodes/{node}/sdn/*` endpoints — runtime visibility into SDN deployment on a node. Counterpart to `cluster_sdn.go`, which holds the mutating config endpoints.

- **Zones**: `SDNZones`, `SDNZoneIndex`, `SDNZoneBridges`, `SDNZoneContent`, `SDNZoneIPVRF`
- **VNets**: `SDNVNetIndex`, `SDNVNetMACVRF`
- **Fabrics**: `SDNFabricIndex`, `SDNFabricInterfaces`, `SDNFabricNeighbors`, `SDNFabricRoutes`
- **Top index**: `SDNIndex`

`SDNZones` on `*Node` returns the runtime status (`available` / `pending` / `error`) per zone — distinct from the cluster-level config returned by `Cluster.SDNZones`. Diridx endpoints collapse `[{"subdir":"..."}]` to `[]string` for ergonomics (same pattern as `ListCertificateSubresources`).

Closes the `nodes/sdn` coverage gap: 0/12 -> 12/12.

## Test plan

- [x] ``go build ./...``
- [x] ``go test -count=1 .`` (full unit suite)
- [x] 12 new tests in ``nodes_sdn_test.go``, all passing
- [x] gock mocks in ``tests/mocks/pve9x/sdn.go``