### PR TITLE
feat: wrap nodes/{scan,capabilities,hardware} read-only endpoints

### DIFF
--- a/nodes_capabilities.go
+++ b/nodes_capabilities.go
@@ -1,0 +1,92 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// /nodes/{node}/capabilities — node-level "what can this host run".
+// Currently only QEMU lives under here; arch parameter defaults to the host
+// architecture server-side.
+
+// CapabilitiesIndex enumerates the top-level capability subsystems ("qemu").
+func (n *Node) CapabilitiesIndex(ctx context.Context) ([]string, error) {
+	return n.capabilitiesDiridx(ctx, fmt.Sprintf("/nodes/%s/capabilities", n.Name))
+}
+
+// QEMUCapabilitiesIndex enumerates the QEMU capability subresources
+// ("cpu", "cpu-flags", "machines", "migration").
+func (n *Node) QEMUCapabilitiesIndex(ctx context.Context) ([]string, error) {
+	return n.capabilitiesDiridx(ctx, fmt.Sprintf("/nodes/%s/capabilities/qemu", n.Name))
+}
+
+// QEMUCPUModels lists all available CPU models, both built-in QEMU types and
+// any custom models defined on the cluster. arch is "" (host default),
+// "x86_64", or "aarch64".
+func (n *Node) QEMUCPUModels(ctx context.Context, arch string) (models []*QEMUCPUModel, err error) {
+	path := fmt.Sprintf("/nodes/%s/capabilities/qemu/cpu", n.Name)
+	if arch != "" {
+		q := url.Values{}
+		q.Set("arch", arch)
+		path = path + "?" + q.Encode()
+	}
+	err = n.client.Get(ctx, path, &models)
+	return
+}
+
+// QEMUCPUFlags lists VM-visible CPU flags supported on this node. accel is
+// "kvm" (default) or "tcg"; arch is "" / "x86_64" / "aarch64". aarch64
+// returns an empty list per PVE — no VM-specific flags are defined yet.
+func (n *Node) QEMUCPUFlags(ctx context.Context, arch, accel string) (flags []*QEMUCPUFlag, err error) {
+	q := url.Values{}
+	if arch != "" {
+		q.Set("arch", arch)
+	}
+	if accel != "" {
+		q.Set("accel", accel)
+	}
+	path := fmt.Sprintf("/nodes/%s/capabilities/qemu/cpu-flags", n.Name)
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	err = n.client.Get(ctx, path, &flags)
+	return
+}
+
+// QEMUMachineTypes returns the q35 / i440fx versions available on this host.
+// arch is "" (host default), "x86_64", or "aarch64".
+func (n *Node) QEMUMachineTypes(ctx context.Context, arch string) (types []*QEMUMachineType, err error) {
+	path := fmt.Sprintf("/nodes/%s/capabilities/qemu/machines", n.Name)
+	if arch != "" {
+		q := url.Values{}
+		q.Set("arch", arch)
+		path = path + "?" + q.Encode()
+	}
+	err = n.client.Get(ctx, path, &types)
+	return
+}
+
+// QEMUMigrationCapabilities returns node-specific live migration features —
+// currently just whether dbus-vmstate is available for live-migrating
+// additional VM state.
+func (n *Node) QEMUMigrationCapabilities(ctx context.Context) (caps *QEMUMigrationCapabilities, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/capabilities/qemu/migration", n.Name), &caps)
+	return
+}
+
+func (n *Node) capabilitiesDiridx(ctx context.Context, path string) ([]string, error) {
+	// PVE schema declares the items as `{}` (no properties) but in practice
+	// emits {"name": ...} for both indexes. Decode loosely.
+	var items []map[string]string
+	if err := n.client.Get(ctx, path, &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if v, ok := it["name"]; ok {
+			out = append(out, v)
+		}
+	}
+	return out, nil
+}

--- a/nodes_hardware.go
+++ b/nodes_hardware.go
@@ -1,0 +1,109 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// /nodes/{node}/hardware — physical device inventory. PCI and USB only; the
+// /hardware/pci/{id}/ branch is multi-instance per AGENTS.md and gets a
+// *PCIDevice handle.
+
+// HardwareIndex enumerates the hardware subtypes ("pci", "usb").
+func (n *Node) HardwareIndex(ctx context.Context) ([]string, error) {
+	var items []struct {
+		Type string `json:"type"`
+	}
+	if err := n.client.Get(ctx, fmt.Sprintf("/nodes/%s/hardware", n.Name), &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Type)
+	}
+	return out, nil
+}
+
+// HardwarePCIOptions is the query payload for ListPCIDevices. ClassBlacklist
+// is a list of PCI class hex codes to filter out (default server-side:
+// "05;06;0b" — memory, bridge, processor). Verbose unset means the verbose
+// default (1) — set Terse=true to get only PCI IDs.
+type HardwarePCIOptions struct {
+	ClassBlacklist []string
+	Terse          bool
+}
+
+// ListPCIDevices returns the PCI devices on this node. Returned *PCIDevice
+// handles are pre-populated with client/Node so callers can chain
+// Index()/Mdev() directly.
+func (n *Node) ListPCIDevices(ctx context.Context, opts *HardwarePCIOptions) (devices []*PCIDevice, err error) {
+	path := fmt.Sprintf("/nodes/%s/hardware/pci", n.Name)
+	if opts != nil {
+		q := url.Values{}
+		if len(opts.ClassBlacklist) > 0 {
+			q.Set("pci-class-blacklist", strings.Join(opts.ClassBlacklist, ";"))
+		}
+		if opts.Terse {
+			q.Set("verbose", "0")
+		}
+		if len(q) > 0 {
+			path = path + "?" + q.Encode()
+		}
+	}
+	if err = n.client.Get(ctx, path, &devices); err != nil {
+		return
+	}
+	for _, d := range devices {
+		d.client = n.client
+		d.Node = n.Name
+	}
+	return
+}
+
+// ListUSBDevices returns the USB devices on this node.
+func (n *Node) ListUSBDevices(ctx context.Context) (devices []*USBDevice, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/hardware/usb", n.Name), &devices)
+	return
+}
+
+// PCIDevice returns a handle for a single PCI device by id ("0000:01:00.0")
+// or by cluster-mapping name. No API call.
+func (n *Node) PCIDevice(id string) *PCIDevice {
+	return &PCIDevice{
+		client: n.client,
+		Node:   n.Name,
+		ID:     id,
+	}
+}
+
+// Index enumerates the subresources of the PCI device — currently just
+// ["mdev"].
+func (d *PCIDevice) Index(ctx context.Context) ([]string, error) {
+	if d.ID == "" {
+		return nil, errors.New("pci id is required")
+	}
+	var items []struct {
+		Method string `json:"method"`
+	}
+	if err := d.client.Get(ctx, fmt.Sprintf("/nodes/%s/hardware/pci/%s", d.Node, d.ID), &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Method)
+	}
+	return out, nil
+}
+
+// Mdev lists the mediated-device types this PCI device supports. Empty
+// result for cards without SR-IOV/mdev capability.
+func (d *PCIDevice) Mdev(ctx context.Context) (types []*PCIMdevType, err error) {
+	if d.ID == "" {
+		return nil, errors.New("pci id is required")
+	}
+	err = d.client.Get(ctx, fmt.Sprintf("/nodes/%s/hardware/pci/%s/mdev", d.Node, d.ID), &types)
+	return
+}

--- a/nodes_hardware_test.go
+++ b/nodes_hardware_test.go
@@ -1,0 +1,228 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func hwNode() *Node {
+	return &Node{client: mockClient(), Name: "node1"}
+}
+
+// --- /nodes/{node}/scan -----------------------------------------------------
+
+func TestNode_ScanIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	methods, err := hwNode().ScanIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, methods, "zfs")
+	assert.Contains(t, methods, "pbs")
+}
+
+func TestNode_ScanZFS(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	pools, err := hwNode().ScanZFS(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, pools, 2)
+	assert.Equal(t, "rpool", pools[0].Pool)
+}
+
+func TestNode_ScanLVM(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vgs, err := hwNode().ScanLVM(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, vgs, 2)
+	assert.Equal(t, "pve", vgs[0].VG)
+}
+
+func TestNode_ScanLVMThin(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	pools, err := hwNode().ScanLVMThin(context.Background(), "pve")
+	assert.Nil(t, err)
+	assert.Len(t, pools, 1)
+	assert.Equal(t, "data", pools[0].LV)
+
+	_, err = hwNode().ScanLVMThin(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_ScanNFS(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	exports, err := hwNode().ScanNFS(context.Background(), "nfs.example.com")
+	assert.Nil(t, err)
+	assert.Len(t, exports, 2)
+	assert.Equal(t, "/exports/backup", exports[0].Path)
+
+	_, err = hwNode().ScanNFS(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_ScanCIFS(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	shares, err := hwNode().ScanCIFS(context.Background(), &ScanCIFSOptions{
+		Server:   "cifs.example.com",
+		Username: "u",
+		Password: "p",
+		Domain:   "WORKGROUP",
+	})
+	assert.Nil(t, err)
+	assert.Len(t, shares, 2)
+	assert.Equal(t, "backup", shares[0].Share)
+
+	_, err = hwNode().ScanCIFS(context.Background(), nil)
+	assert.NotNil(t, err)
+	_, err = hwNode().ScanCIFS(context.Background(), &ScanCIFSOptions{})
+	assert.NotNil(t, err)
+}
+
+func TestNode_ScanPBS(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	stores, err := hwNode().ScanPBS(context.Background(), &ScanPBSOptions{
+		Server:      "pbs.example.com",
+		Username:    "user@pbs",
+		Password:    "p",
+		Fingerprint: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+		Port:        8007,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, stores, 2)
+	assert.Equal(t, "main", stores[0].Store)
+
+	_, err = hwNode().ScanPBS(context.Background(), &ScanPBSOptions{Server: "x"})
+	assert.NotNil(t, err)
+}
+
+func TestNode_ScanISCSI(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	targets, err := hwNode().ScanISCSI(context.Background(), "192.0.2.10:3260")
+	assert.Nil(t, err)
+	assert.Len(t, targets, 2)
+
+	_, err = hwNode().ScanISCSI(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+// --- /nodes/{node}/capabilities --------------------------------------------
+
+func TestNode_CapabilitiesIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subs, err := hwNode().CapabilitiesIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"qemu"}, subs)
+}
+
+func TestNode_QEMUCapabilitiesIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subs, err := hwNode().QEMUCapabilitiesIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"cpu", "cpu-flags", "machines", "migration"}, subs)
+}
+
+func TestNode_QEMUCPUModels(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	models, err := hwNode().QEMUCPUModels(context.Background(), "x86_64")
+	assert.Nil(t, err)
+	assert.Len(t, models, 3)
+	assert.True(t, models[2].Custom)
+	assert.True(t, models[1].Abstract)
+}
+
+func TestNode_QEMUCPUFlags(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	flags, err := hwNode().QEMUCPUFlags(context.Background(), "x86_64", "kvm")
+	assert.Nil(t, err)
+	assert.Len(t, flags, 2)
+	assert.Equal(t, "aes", flags[0].Name)
+	assert.Len(t, flags[0].SupportedOn, 2)
+}
+
+func TestNode_QEMUMachineTypes(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	types, err := hwNode().QEMUMachineTypes(context.Background(), "")
+	assert.Nil(t, err)
+	assert.Len(t, types, 2)
+	assert.Equal(t, "q35", types[0].Type)
+	assert.Equal(t, "pveX backport", types[1].Changes)
+}
+
+func TestNode_QEMUMigrationCapabilities(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	caps, err := hwNode().QEMUMigrationCapabilities(context.Background())
+	assert.Nil(t, err)
+	assert.True(t, caps.HasDbusVMState)
+}
+
+// --- /nodes/{node}/hardware ------------------------------------------------
+
+func TestNode_HardwareIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	types, err := hwNode().HardwareIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"pci", "usb"}, types)
+}
+
+func TestNode_ListPCIDevices(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	devices, err := hwNode().ListPCIDevices(context.Background(), &HardwarePCIOptions{
+		ClassBlacklist: []string{"05", "06"},
+		Terse:          false,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, devices, 2)
+	assert.Equal(t, "0000:01:00.0", devices[0].ID)
+	assert.True(t, devices[0].MdevCapable)
+	assert.Equal(t, "node1", devices[0].Node)
+}
+
+func TestNode_ListUSBDevices(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	devices, err := hwNode().ListUSBDevices(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, devices, 2)
+	assert.Equal(t, "Linux Foundation", devices[0].Manufacturer)
+	assert.Equal(t, "5000", devices[1].Speed)
+}
+
+func TestNode_PCIDevice_IndexAndMdev(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	d := hwNode().PCIDevice("0000:01:00.0")
+	assert.Equal(t, "node1", d.Node)
+	assert.Equal(t, "0000:01:00.0", d.ID)
+
+	methods, err := d.Index(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"mdev"}, methods)
+
+	mdevs, err := d.Mdev(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, mdevs, 2)
+	assert.Equal(t, "nvidia-256", mdevs[0].Type)
+	assert.Equal(t, 2, mdevs[0].Available)
+
+	empty := hwNode().PCIDevice("")
+	_, err = empty.Index(context.Background())
+	assert.NotNil(t, err)
+	_, err = empty.Mdev(context.Background())
+	assert.NotNil(t, err)
+}

--- a/nodes_scan.go
+++ b/nodes_scan.go
@@ -1,0 +1,133 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// /nodes/{node}/scan — storage discovery probes. All are GET-with-query, all
+// require Datastore.Allocate on /storage (except the diridx). Used during
+// "add storage" UI flows: pick a server, list what's there.
+
+// ScanIndex enumerates the children of /nodes/{node}/scan ("zfs", "lvm",
+// "nfs", ...). PVE schema returns [{"method":...}]; collapsed to []string.
+func (n *Node) ScanIndex(ctx context.Context) ([]string, error) {
+	var items []struct {
+		Method string `json:"method"`
+	}
+	if err := n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan", n.Name), &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Method)
+	}
+	return out, nil
+}
+
+// ScanZFS lists ZFS pools on this node — local probe, no parameters.
+func (n *Node) ScanZFS(ctx context.Context) (pools []*ScanZFSPool, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan/zfs", n.Name), &pools)
+	return
+}
+
+// ScanLVM lists LVM volume groups on this node — local probe, no parameters.
+func (n *Node) ScanLVM(ctx context.Context) (vgs []*ScanLVMVG, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan/lvm", n.Name), &vgs)
+	return
+}
+
+// ScanLVMThin lists thin pools inside the given LVM volume group.
+func (n *Node) ScanLVMThin(ctx context.Context, vg string) (pools []*ScanLVMThinPool, err error) {
+	if vg == "" {
+		return nil, errors.New("vg is required")
+	}
+	q := url.Values{}
+	q.Set("vg", vg)
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan/lvmthin?%s", n.Name, q.Encode()), &pools)
+	return
+}
+
+// ScanNFS lists NFS exports on the given server. Server is name or IP.
+func (n *Node) ScanNFS(ctx context.Context, server string) (exports []*ScanNFSExport, err error) {
+	if server == "" {
+		return nil, errors.New("server is required")
+	}
+	q := url.Values{}
+	q.Set("server", server)
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan/nfs?%s", n.Name, q.Encode()), &exports)
+	return
+}
+
+// ScanCIFSOptions is the query payload for ScanCIFS. Server is required;
+// username/password/domain are needed only for non-anonymous shares.
+type ScanCIFSOptions struct {
+	Server   string `url:"server"`
+	Username string `url:"username,omitempty"`
+	Password string `url:"password,omitempty"`
+	Domain   string `url:"domain,omitempty"`
+}
+
+// ScanCIFS lists shares on the given SMB/CIFS server.
+func (n *Node) ScanCIFS(ctx context.Context, opts *ScanCIFSOptions) (shares []*ScanCIFSShare, err error) {
+	if opts == nil || opts.Server == "" {
+		return nil, errors.New("server is required")
+	}
+	q := url.Values{}
+	q.Set("server", opts.Server)
+	if opts.Username != "" {
+		q.Set("username", opts.Username)
+	}
+	if opts.Password != "" {
+		q.Set("password", opts.Password)
+	}
+	if opts.Domain != "" {
+		q.Set("domain", opts.Domain)
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan/cifs?%s", n.Name, q.Encode()), &shares)
+	return
+}
+
+// ScanPBSOptions is the query payload for ScanPBS. Server, Username, and
+// Password are required; Fingerprint is needed when PBS uses a self-signed
+// cert; Port defaults to 8007 server-side.
+type ScanPBSOptions struct {
+	Server      string
+	Username    string
+	Password    string
+	Fingerprint string
+	Port        int
+}
+
+// ScanPBS lists datastores on the given Proxmox Backup Server.
+func (n *Node) ScanPBS(ctx context.Context, opts *ScanPBSOptions) (stores []*ScanPBSStore, err error) {
+	if opts == nil || opts.Server == "" || opts.Username == "" || opts.Password == "" {
+		return nil, errors.New("server, username, and password are required")
+	}
+	q := url.Values{}
+	q.Set("server", opts.Server)
+	q.Set("username", opts.Username)
+	q.Set("password", opts.Password)
+	if opts.Fingerprint != "" {
+		q.Set("fingerprint", opts.Fingerprint)
+	}
+	if opts.Port > 0 {
+		q.Set("port", fmt.Sprintf("%d", opts.Port))
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan/pbs?%s", n.Name, q.Encode()), &stores)
+	return
+}
+
+// ScanISCSI lists iSCSI targets reachable through the portal (IP or DNS,
+// optionally with :port).
+func (n *Node) ScanISCSI(ctx context.Context, portal string) (targets []*ScanISCSITarget, err error) {
+	if portal == "" {
+		return nil, errors.New("portal is required")
+	}
+	q := url.Values{}
+	q.Set("portal", portal)
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/scan/iscsi?%s", n.Name, q.Encode()), &targets)
+	return
+}

--- a/tests/mocks/pve9x/hardware.go
+++ b/tests/mocks/pve9x/hardware.go
@@ -1,0 +1,184 @@
+package pve9x
+
+import (
+	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/config"
+)
+
+// hardware registers gock fixtures for the /nodes/{node}/scan,
+// /nodes/{node}/capabilities, and /nodes/{node}/hardware endpoint families.
+// All read-only — no body assertions.
+func hardware() {
+	// ---- /nodes/{node}/scan ------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan$").
+		Reply(200).
+		JSON(`{"data":[
+			{"method":"zfs"},{"method":"lvm"},{"method":"lvmthin"},
+			{"method":"nfs"},{"method":"cifs"},{"method":"pbs"},{"method":"iscsi"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan/zfs$").
+		Reply(200).
+		JSON(`{"data":[{"pool":"rpool"},{"pool":"tank"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan/lvm$").
+		Reply(200).
+		JSON(`{"data":[{"vg":"pve"},{"vg":"data"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan/lvmthin").
+		Reply(200).
+		JSON(`{"data":[{"lv":"data"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan/nfs").
+		Reply(200).
+		JSON(`{"data":[
+			{"path":"/exports/backup","options":"rw,no_root_squash"},
+			{"path":"/exports/iso","options":"ro"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan/cifs").
+		Reply(200).
+		JSON(`{"data":[
+			{"share":"backup","description":"Backup share"},
+			{"share":"iso"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan/pbs").
+		Reply(200).
+		JSON(`{"data":[
+			{"store":"main","comment":"primary datastore"},
+			{"store":"archive"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/scan/iscsi").
+		Reply(200).
+		JSON(`{"data":[
+			{"target":"iqn.2024.example:storage.0","portal":"192.0.2.10:3260"},
+			{"target":"iqn.2024.example:storage.1","portal":"192.0.2.10:3260"}
+		]}`)
+
+	// ---- /nodes/{node}/capabilities ---------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/capabilities$").
+		Reply(200).
+		JSON(`{"data":[{"name":"qemu"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/capabilities/qemu$").
+		Reply(200).
+		JSON(`{"data":[
+			{"name":"cpu"},{"name":"cpu-flags"},{"name":"machines"},{"name":"migration"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get(`^/nodes/node1/capabilities/qemu/cpu(\?|$)`).
+		Reply(200).
+		JSON(`{"data":[
+			{"name":"host","vendor":"GenuineIntel","custom":false},
+			{"name":"x86-64-v3","vendor":"GenuineIntel","custom":false,"abstract":true},
+			{"name":"custom-mycpu","vendor":"GenuineIntel","custom":true}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/capabilities/qemu/cpu-flags").
+		Reply(200).
+		JSON(`{"data":[
+			{"name":"aes","description":"AES instruction set","supported-on":["node1","node2"]},
+			{"name":"avx2","description":"Advanced Vector Extensions 2"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/capabilities/qemu/machines").
+		Reply(200).
+		JSON(`{"data":[
+			{"id":"pc-q35-9.0","type":"q35","version":"9.0"},
+			{"id":"pc-i440fx-9.0","type":"i440fx","version":"9.0","changes":"pveX backport"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/capabilities/qemu/migration$").
+		Reply(200).
+		JSON(`{"data":{"has-dbus-vmstate":true}}`)
+
+	// ---- /nodes/{node}/hardware -------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/hardware$").
+		Reply(200).
+		JSON(`{"data":[{"type":"pci"},{"type":"usb"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/hardware/pci$").
+		Reply(200).
+		JSON(`{"data":[
+			{
+				"id":"0000:01:00.0","class":"0x030000",
+				"vendor":"0x10de","vendor_name":"NVIDIA Corporation",
+				"device":"0x2204","device_name":"GA102 [GeForce RTX 3090]",
+				"iommugroup":15,"mdev":true
+			},
+			{
+				"id":"0000:02:00.0","class":"0x010802",
+				"vendor":"0x8086","device":"0xa808",
+				"iommugroup":16
+			}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/hardware/usb$").
+		Reply(200).
+		JSON(`{"data":[
+			{
+				"busnum":1,"devnum":2,"port":1,"level":1,"class":9,
+				"vendid":"0x1d6b","prodid":"0x0002",
+				"speed":"480","manufacturer":"Linux Foundation","product":"USB 2.0 root hub",
+				"usbpath":"1-1"
+			},
+			{
+				"busnum":2,"devnum":1,"port":0,"level":0,"class":9,
+				"vendid":"0x1d6b","prodid":"0x0003","speed":"5000"
+			}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/hardware/pci/0000:01:00.0$").
+		Reply(200).
+		JSON(`{"data":[{"method":"mdev"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/hardware/pci/0000:01:00.0/mdev$").
+		Reply(200).
+		JSON(`{"data":[
+			{"type":"nvidia-256","name":"GRID A40-4Q","description":"4GB profile","available":2},
+			{"type":"nvidia-257","name":"GRID A40-8Q","description":"8GB profile","available":1}
+		]}`)
+}

--- a/tests/mocks/pve9x/proxmox.go
+++ b/tests/mocks/pve9x/proxmox.go
@@ -11,5 +11,6 @@ func Load() {
 	virtualMachines()
 	storage()
 	sdn()
+	hardware()
 	tasks()
 }

--- a/types.go
+++ b/types.go
@@ -3994,3 +3994,127 @@ type SDNFabricRoute struct {
 	Route string   `json:"route"`
 	Via   []string `json:"via,omitempty"`
 }
+
+// --- /nodes/{node}/scan types ----------------------------------------------
+
+// ScanZFSPool is one entry from the local ZFS pool probe.
+type ScanZFSPool struct {
+	Pool string `json:"pool"`
+}
+
+// ScanLVMVG is one entry from the local LVM volume-group probe.
+type ScanLVMVG struct {
+	VG string `json:"vg"`
+}
+
+// ScanLVMThinPool is one thin pool inside an LVM volume group.
+type ScanLVMThinPool struct {
+	LV string `json:"lv"`
+}
+
+// ScanNFSExport is one export advertised by a remote NFS server.
+type ScanNFSExport struct {
+	Path    string `json:"path"`
+	Options string `json:"options,omitempty"`
+}
+
+// ScanCIFSShare is one share advertised by a remote SMB/CIFS server.
+type ScanCIFSShare struct {
+	Share       string `json:"share"`
+	Description string `json:"description,omitempty"`
+}
+
+// ScanPBSStore is one datastore on a remote Proxmox Backup Server.
+type ScanPBSStore struct {
+	Store   string `json:"store"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// ScanISCSITarget is one iSCSI target advertised by a portal.
+type ScanISCSITarget struct {
+	Target string `json:"target"`
+	Portal string `json:"portal,omitempty"`
+}
+
+// --- /nodes/{node}/capabilities/qemu types ---------------------------------
+
+// QEMUCPUModel is one row of /capabilities/qemu/cpu — both QEMU built-ins
+// and custom CPU models defined on the cluster. Custom models are prefixed
+// "custom-" in Name. Abstract is true for PVE-internal profiles like
+// x86-64-v2/v3/v4 — those don't correspond to a real QEMU CPU type and
+// can't be used as a custom model's reported-model.
+type QEMUCPUModel struct {
+	Name     string `json:"name"`
+	Vendor   string `json:"vendor"`
+	Custom   bool   `json:"custom"`
+	Abstract bool   `json:"abstract,omitempty"`
+}
+
+// QEMUCPUFlag is one VM-visible CPU flag and which cluster nodes support it
+// under the queried acceleration mode.
+type QEMUCPUFlag struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	SupportedOn []string `json:"supported-on,omitempty"`
+}
+
+// QEMUMachineType is one row of /capabilities/qemu/machines — a q35 or
+// i440fx variant available on this host. Changes is set for +pveX versions.
+type QEMUMachineType struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Version string `json:"version"`
+	Changes string `json:"changes,omitempty"`
+}
+
+// QEMUMigrationCapabilities reports node-specific live-migration support.
+type QEMUMigrationCapabilities struct {
+	HasDbusVMState bool `json:"has-dbus-vmstate"`
+}
+
+// --- /nodes/{node}/hardware types ------------------------------------------
+
+// PCIDevice is one local PCI device, also serves as the handle for the
+// /hardware/pci/{id}/* multi-instance subresources (per AGENTS.md). client
+// and Node are populated by ListPCIDevices and Node.PCIDevice().
+type PCIDevice struct {
+	client *Client
+	Node   string `json:"-"`
+
+	ID                  string `json:"id"`
+	Class               string `json:"class,omitempty"`
+	Vendor              string `json:"vendor,omitempty"`
+	VendorName          string `json:"vendor_name,omitempty"`
+	Device              string `json:"device,omitempty"`
+	DeviceName          string `json:"device_name,omitempty"`
+	SubsystemVendor     string `json:"subsystem_vendor,omitempty"`
+	SubsystemVendorName string `json:"subsystem_vendor_name,omitempty"`
+	SubsystemDevice     string `json:"subsystem_device,omitempty"`
+	SubsystemDeviceName string `json:"subsystem_device_name,omitempty"`
+	IOMMUGroup          int    `json:"iommugroup,omitempty"`
+	MdevCapable         bool   `json:"mdev,omitempty"`
+}
+
+// PCIMdevType is one mediated-device type advertised by a PCI device.
+type PCIMdevType struct {
+	Type        string `json:"type"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Available   int    `json:"available"`
+}
+
+// USBDevice is one local USB device.
+type USBDevice struct {
+	BusNum       int    `json:"busnum"`
+	DevNum       int    `json:"devnum"`
+	Port         int    `json:"port"`
+	Level        int    `json:"level"`
+	Class        int    `json:"class"`
+	VendID       string `json:"vendid"`
+	ProdID       string `json:"prodid"`
+	Speed        string `json:"speed"`
+	Manufacturer string `json:"manufacturer,omitempty"`
+	Product      string `json:"product,omitempty"`
+	Serial       string `json:"serial,omitempty"`
+	USBPath      string `json:"usbpath,omitempty"`
+}


### PR DESCRIPTION
## Summary

Wraps 19 read-only GET endpoints across three node runtime-discovery surfaces:

- **`nodes/scan` (8)** — storage discovery probes: `ScanZFS`, `ScanLVM`, `ScanLVMThin`, `ScanNFS`, `ScanCIFS`, `ScanPBS`, `ScanISCSI`, + `ScanIndex`.
- **`nodes/capabilities` (6)** — `QEMUCPUModels`, `QEMUCPUFlags`, `QEMUMachineTypes`, `QEMUMigrationCapabilities`, + two diridx (`CapabilitiesIndex`, `QEMUCapabilitiesIndex`).
- **`nodes/hardware` (5)** — `ListPCIDevices`, `ListUSBDevices`, plus the multi-instance `*PCIDevice` handle (`Index`, `Mdev`) + `HardwareIndex`.

`PCIDevice` follows the singleton-vs-instance convention codified in PR #312 / AGENTS.md — the device id is carried by the handle, not threaded through each call.

Coverage: 458/675 -> 475/675 (67.9% -> 70.4%).

## Test plan

- [x] ``go build ./...``
- [x] ``go test -count=1 .`` (full unit suite, 2.6s)
- [x] 17 new tests in ``nodes_hardware_test.go``, all passing
- [x] gock mocks in ``tests/mocks/pve9x/hardware.go``
- [x] ``mage endpoints:coverage`` confirms uptick

## Note

The two ``capabilities`` and four ``sdn`` ``diridx`` endpoints route through small helpers, so the static coverage scanner counts them as missing even though they're wrapped + tested. Behaviorally complete.