### PR TITLE
feat: wrap the 'loose' /nodes/{node}/* endpoints + storage extras

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -313,6 +313,47 @@ func (n *Node) FirewallRulesDelete(ctx context.Context, rulePos int) error {
 	return n.client.Delete(ctx, fmt.Sprintf("/nodes/%s/firewall/rules/%d", n.Name, rulePos), nil)
 }
 
+// FirewallGetRule fetches one rule by position. Companion to
+// FirewallGetRules, mirroring the per-rule getter on Container/VirtualMachine.
+func (n *Node) FirewallGetRule(ctx context.Context, rulePos int) (rule *FirewallRule, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/firewall/rules/%d", n.Name, rulePos), &rule)
+	return
+}
+
+// NodeFirewallLogOptions filters the host-firewall log read. All optional.
+type NodeFirewallLogOptions struct {
+	Start int
+	Limit int
+	Since int64 // unix epoch
+	Until int64 // unix epoch
+}
+
+// FirewallLog returns the host firewall's iptables/nftables log entries.
+// Each LogEntry is {n: line-number, t: text}.
+func (n *Node) FirewallLog(ctx context.Context, opts *NodeFirewallLogOptions) (entries []*LogEntry, err error) {
+	path := fmt.Sprintf("/nodes/%s/firewall/log", n.Name)
+	if opts != nil {
+		q := url.Values{}
+		if opts.Start > 0 {
+			q.Set("start", fmt.Sprintf("%d", opts.Start))
+		}
+		if opts.Limit > 0 {
+			q.Set("limit", fmt.Sprintf("%d", opts.Limit))
+		}
+		if opts.Since > 0 {
+			q.Set("since", fmt.Sprintf("%d", opts.Since))
+		}
+		if opts.Until > 0 {
+			q.Set("until", fmt.Sprintf("%d", opts.Until))
+		}
+		if len(q) > 0 {
+			path = path + "?" + q.Encode()
+		}
+	}
+	err = n.client.Get(ctx, path, &entries)
+	return
+}
+
 func (n *Node) UploadCustomCertificate(ctx context.Context, cert *CustomCertificate) error {
 	return n.client.Post(ctx, fmt.Sprintf("/nodes/%s/certificates/custom", n.Name), cert, nil)
 }

--- a/nodes_admin.go
+++ b/nodes_admin.go
@@ -1,0 +1,341 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// This file fills in the "loose" /nodes/{node}/* gaps that don't warrant
+// their own dedicated file: node config + /etc/hosts, power management
+// (reboot/shutdown), console launchers, log readers, command execute,
+// finished-task listing, and pending-network revert.
+
+// --- /nodes/{node}/config -------------------------------------------------
+
+// GetConfig returns node-level config (acme/acmedomain[0-5], description,
+// location, ballooning-target, startall-onboot-delay, wakeonlan, digest).
+// PVE encodes substructures (acme, location, wakeonlan) as property strings.
+func (n *Node) GetConfig(ctx context.Context) (cfg *NodeConfig, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/config", n.Name), &cfg)
+	return
+}
+
+// GetConfigProperty fetches just one property from the node config
+// ("acme"|"acmedomain0..5"|"ballooning-target"|"description"|"location"
+// |"startall-onboot-delay"|"wakeonlan"). The returned config has only that
+// field populated; others are zero-valued.
+func (n *Node) GetConfigProperty(ctx context.Context, property string) (cfg *NodeConfig, err error) {
+	if property == "" {
+		return n.GetConfig(ctx)
+	}
+	q := url.Values{}
+	q.Set("property", property)
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/config?%s", n.Name, q.Encode()), &cfg)
+	return
+}
+
+// UpdateConfig sets node configuration options. Passing nil opts is a no-op
+// on the server. Use opts.Delete to unset specific keys.
+func (n *Node) UpdateConfig(ctx context.Context, opts *NodeConfigOptions) error {
+	if opts == nil {
+		opts = &NodeConfigOptions{}
+	}
+	return n.client.Put(ctx, fmt.Sprintf("/nodes/%s/config", n.Name), opts, nil)
+}
+
+// --- /nodes/{node}/hosts --------------------------------------------------
+
+// Hosts returns the full contents of /etc/hosts plus a digest for optimistic
+// concurrency. Pass the digest back to UpdateHosts to refuse the write on
+// concurrent modification.
+func (n *Node) Hosts(ctx context.Context) (hosts *NodeHosts, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/hosts", n.Name), &hosts)
+	return
+}
+
+// UpdateHosts overwrites /etc/hosts on the node. digest is optional — if
+// non-empty, PVE refuses the write when the current file differs from it.
+func (n *Node) UpdateHosts(ctx context.Context, data, digest string) error {
+	body := map[string]string{"data": data}
+	if digest != "" {
+		body["digest"] = digest
+	}
+	return n.client.Post(ctx, fmt.Sprintf("/nodes/%s/hosts", n.Name), body, nil)
+}
+
+// --- /nodes/{node}/status (power) -----------------------------------------
+
+// Reboot reboots the node. Requires Sys.PowerMgmt on /nodes/{node}.
+// PVE returns null — no task to track.
+func (n *Node) Reboot(ctx context.Context) error {
+	return n.client.Post(ctx, fmt.Sprintf("/nodes/%s/status", n.Name),
+		map[string]string{"command": "reboot"}, nil)
+}
+
+// Shutdown powers off the node. Requires Sys.PowerMgmt on /nodes/{node}.
+func (n *Node) Shutdown(ctx context.Context) error {
+	return n.client.Post(ctx, fmt.Sprintf("/nodes/%s/status", n.Name),
+		map[string]string{"command": "shutdown"}, nil)
+}
+
+// --- /nodes/{node}/{journal,syslog,netstat} -------------------------------
+
+// NodeJournalOptions filters the systemd journal read. Pass either Since/
+// Until OR StartCursor/EndCursor (PVE rejects mixing). LastEntries conflicts
+// with any range.
+type NodeJournalOptions struct {
+	Since       int64
+	Until       int64
+	StartCursor string
+	EndCursor   string
+	LastEntries int
+}
+
+// Journal returns systemd journal lines as plain strings. PVE caps line
+// count server-side; use LastEntries or a Since/Until range to bound output.
+func (n *Node) Journal(ctx context.Context, opts *NodeJournalOptions) (lines []string, err error) {
+	path := fmt.Sprintf("/nodes/%s/journal", n.Name)
+	if opts != nil {
+		q := url.Values{}
+		if opts.Since > 0 {
+			q.Set("since", strconv.FormatInt(opts.Since, 10))
+		}
+		if opts.Until > 0 {
+			q.Set("until", strconv.FormatInt(opts.Until, 10))
+		}
+		if opts.StartCursor != "" {
+			q.Set("startcursor", opts.StartCursor)
+		}
+		if opts.EndCursor != "" {
+			q.Set("endcursor", opts.EndCursor)
+		}
+		if opts.LastEntries > 0 {
+			q.Set("lastentries", strconv.Itoa(opts.LastEntries))
+		}
+		if len(q) > 0 {
+			path = path + "?" + q.Encode()
+		}
+	}
+	err = n.client.Get(ctx, path, &lines)
+	return
+}
+
+// NodeSyslogOptions filters the classic syslog reader. Since/Until are
+// "YYYY-MM-DD[ HH:MM[:SS]]" strings per PVE; Service filters to one unit.
+type NodeSyslogOptions struct {
+	Start   int
+	Limit   int
+	Since   string
+	Until   string
+	Service string
+}
+
+// Syslog returns rsyslog lines as {n, t} entries — n is the line number, t
+// the text. For systemd journal, use Journal instead.
+func (n *Node) Syslog(ctx context.Context, opts *NodeSyslogOptions) (entries []*LogEntry, err error) {
+	path := fmt.Sprintf("/nodes/%s/syslog", n.Name)
+	if opts != nil {
+		q := url.Values{}
+		if opts.Start > 0 {
+			q.Set("start", strconv.Itoa(opts.Start))
+		}
+		if opts.Limit > 0 {
+			q.Set("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.Since != "" {
+			q.Set("since", opts.Since)
+		}
+		if opts.Until != "" {
+			q.Set("until", opts.Until)
+		}
+		if opts.Service != "" {
+			q.Set("service", opts.Service)
+		}
+		if len(q) > 0 {
+			path = path + "?" + q.Encode()
+		}
+	}
+	err = n.client.Get(ctx, path, &entries)
+	return
+}
+
+// Netstat returns per-VM/CT tap interface counters. PVE leaves the response
+// shape loose — wrap each entry as a generic map.
+func (n *Node) Netstat(ctx context.Context) (entries []map[string]any, err error) {
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/netstat", n.Name), &entries)
+	return
+}
+
+// --- /nodes/{node}/execute (batch API call) -------------------------------
+
+// NodeExecuteCommand is one entry in the Execute batch. Args carries the
+// API parameters as PVE-native key/value pairs.
+type NodeExecuteCommand struct {
+	Method string                 `json:"method"`
+	Path   string                 `json:"path"`
+	Args   map[string]interface{} `json:"args,omitempty"`
+}
+
+// Execute runs a batch of API calls in order. Root-only on PVE. Returns the
+// responses in submission order — each entry is the same envelope PVE would
+// return from the single endpoint.
+func (n *Node) Execute(ctx context.Context, commands []*NodeExecuteCommand) (results []map[string]any, err error) {
+	if len(commands) == 0 {
+		return nil, errors.New("at least one command is required")
+	}
+	body := map[string]interface{}{"commands": commands}
+	err = n.client.Post(ctx, fmt.Sprintf("/nodes/%s/execute", n.Name), body, &results)
+	return
+}
+
+// --- /nodes/{node}/{vncshell,spiceshell} ----------------------------------
+
+// NodeConsoleCmd narrows the shell command. Empty defaults to "login"
+// (requires root@pam).
+type NodeConsoleCmd string
+
+const (
+	NodeConsoleLogin       NodeConsoleCmd = "login"
+	NodeConsoleUpgrade     NodeConsoleCmd = "upgrade"
+	NodeConsoleCephInstall NodeConsoleCmd = "ceph_install"
+)
+
+// NodeVNCShellOptions configures the noVNC console launcher. WebSocket
+// enables noVNC-style transport; Width/Height are pixel dimensions
+// (16-4096 / 16-2160). CmdOpts are null-separated arguments to Cmd.
+type NodeVNCShellOptions struct {
+	Cmd       NodeConsoleCmd
+	CmdOpts   string
+	Width     int
+	Height    int
+	WebSocket bool
+}
+
+// VNCShell opens a VNC proxy to the node — typically a serial-like login
+// shell. Returns ticket + port for the websocket follow-up call.
+func (n *Node) VNCShell(ctx context.Context, opts *NodeVNCShellOptions) (vnc *VNC, err error) {
+	body := map[string]interface{}{}
+	if opts != nil {
+		if opts.Cmd != "" {
+			body["cmd"] = string(opts.Cmd)
+		}
+		if opts.CmdOpts != "" {
+			body["cmd-opts"] = opts.CmdOpts
+		}
+		if opts.Width > 0 {
+			body["width"] = opts.Width
+		}
+		if opts.Height > 0 {
+			body["height"] = opts.Height
+		}
+		if opts.WebSocket {
+			body["websocket"] = 1
+		}
+	}
+	err = n.client.Post(ctx, fmt.Sprintf("/nodes/%s/vncshell", n.Name), body, &vnc)
+	return
+}
+
+// NodeSpiceShellOptions configures the SPICE console launcher. Proxy
+// overrides the SPICE proxy hostname (defaults to the node itself).
+type NodeSpiceShellOptions struct {
+	Cmd     NodeConsoleCmd
+	CmdOpts string
+	Proxy   string
+}
+
+// SpiceShell opens a SPICE proxy. Returned object can be fed directly to
+// remote-viewer.
+func (n *Node) SpiceShell(ctx context.Context, opts *NodeSpiceShellOptions) (proxy *SpiceProxy, err error) {
+	body := map[string]interface{}{}
+	if opts != nil {
+		if opts.Cmd != "" {
+			body["cmd"] = string(opts.Cmd)
+		}
+		if opts.CmdOpts != "" {
+			body["cmd-opts"] = opts.CmdOpts
+		}
+		if opts.Proxy != "" {
+			body["proxy"] = opts.Proxy
+		}
+	}
+	err = n.client.Post(ctx, fmt.Sprintf("/nodes/%s/spiceshell", n.Name), body, &proxy)
+	return
+}
+
+// --- /nodes/{node}/tasks (list) -------------------------------------------
+
+// NodeTasksOptions filters the finished-task index. All fields are optional.
+type NodeTasksOptions struct {
+	Errors       bool
+	Limit        int
+	Since        int64
+	Until        int64
+	Source       string // "archive" | "active" | "all"
+	Start        int
+	StatusFilter string // comma-separated task statuses
+	TypeFilter   string // task type, e.g. "vzdump"
+	UserFilter   string
+	VMID         int
+}
+
+// Tasks lists finished tasks on this node. Pre-populates each *Task with
+// client + node so callers can chain Wait/Log/Stop. Unlike Task.Wait which
+// targets one UPID, this lists archived/active tasks for monitoring.
+func (n *Node) Tasks(ctx context.Context, opts *NodeTasksOptions) (tasks []*Task, err error) {
+	path := fmt.Sprintf("/nodes/%s/tasks", n.Name)
+	if opts != nil {
+		q := url.Values{}
+		if opts.Errors {
+			q.Set("errors", "1")
+		}
+		if opts.Limit > 0 {
+			q.Set("limit", strconv.Itoa(opts.Limit))
+		}
+		if opts.Since > 0 {
+			q.Set("since", strconv.FormatInt(opts.Since, 10))
+		}
+		if opts.Until > 0 {
+			q.Set("until", strconv.FormatInt(opts.Until, 10))
+		}
+		if opts.Source != "" {
+			q.Set("source", opts.Source)
+		}
+		if opts.Start > 0 {
+			q.Set("start", strconv.Itoa(opts.Start))
+		}
+		if opts.StatusFilter != "" {
+			q.Set("statusfilter", opts.StatusFilter)
+		}
+		if opts.TypeFilter != "" {
+			q.Set("typefilter", opts.TypeFilter)
+		}
+		if opts.UserFilter != "" {
+			q.Set("userfilter", opts.UserFilter)
+		}
+		if opts.VMID > 0 {
+			q.Set("vmid", strconv.Itoa(opts.VMID))
+		}
+		if len(q) > 0 {
+			path = path + "?" + q.Encode()
+		}
+	}
+	if err = n.client.Get(ctx, path, &tasks); err != nil {
+		return
+	}
+	for _, t := range tasks {
+		t.client = n.client
+	}
+	return
+}
+
+// --- /nodes/{node}/network (revert pending) -------------------------------
+
+// RevertNetworkChanges discards any pending /etc/network/interfaces.new
+// staged by network create/update calls but not yet reloaded.
+func (n *Node) RevertNetworkChanges(ctx context.Context) error {
+	return n.client.Delete(ctx, fmt.Sprintf("/nodes/%s/network", n.Name), nil)
+}

--- a/nodes_loose_test.go
+++ b/nodes_loose_test.go
@@ -1,0 +1,262 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func looseNode() *Node {
+	return &Node{client: mockClient(), Name: "node1"}
+}
+
+func TestNode_GetConfig(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cfg, err := looseNode().GetConfig(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, "primary hypervisor", cfg.Description)
+	assert.Equal(t, 80, cfg.BallooningTarget)
+	assert.Equal(t, "abc123", cfg.Digest)
+}
+
+func TestNode_GetConfigProperty(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cfg, err := looseNode().GetConfigProperty(context.Background(), "description")
+	assert.Nil(t, err)
+	assert.NotNil(t, cfg)
+}
+
+func TestNode_UpdateConfig(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	target := 75
+	err := looseNode().UpdateConfig(context.Background(), &NodeConfigOptions{
+		Description:      "updated",
+		BallooningTarget: &target,
+		Delete:           "wakeonlan",
+	})
+	assert.Nil(t, err)
+
+	assert.Nil(t, looseNode().UpdateConfig(context.Background(), nil))
+}
+
+func TestNode_Hosts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	hosts, err := looseNode().Hosts(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, hosts.Data, "node1.example.com")
+	assert.Equal(t, "hostsdigest123", hosts.Digest)
+}
+
+func TestNode_UpdateHosts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	err := looseNode().UpdateHosts(context.Background(),
+		"127.0.0.1 localhost\n10.0.0.1 node1\n", "hostsdigest123")
+	assert.Nil(t, err)
+
+	assert.Nil(t, looseNode().UpdateHosts(context.Background(), "data", ""))
+}
+
+func TestNode_RebootAndShutdown(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	assert.Nil(t, looseNode().Reboot(context.Background()))
+	assert.Nil(t, looseNode().Shutdown(context.Background()))
+}
+
+func TestNode_Journal(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	lines, err := looseNode().Journal(context.Background(), &NodeJournalOptions{
+		LastEntries: 100,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, lines, 2)
+	assert.Contains(t, lines[0], "systemd[1]")
+
+	lines, err = looseNode().Journal(context.Background(), nil)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, lines)
+}
+
+func TestNode_Syslog(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := looseNode().Syslog(context.Background(), &NodeSyslogOptions{
+		Limit:   50,
+		Service: "pveproxy",
+	})
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, 1, entries[0].N)
+}
+
+func TestNode_Netstat(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := looseNode().Netstat(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "tap100i0", entries[0]["dev"])
+}
+
+func TestNode_Execute(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	results, err := looseNode().Execute(context.Background(), []*NodeExecuteCommand{
+		{Method: "GET", Path: "/version"},
+		{Method: "GET", Path: "/cluster/status"},
+	})
+	assert.Nil(t, err)
+	assert.Len(t, results, 2)
+
+	_, err = looseNode().Execute(context.Background(), nil)
+	assert.NotNil(t, err)
+}
+
+func TestNode_VNCShell(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	vnc, err := looseNode().VNCShell(context.Background(), &NodeVNCShellOptions{
+		Cmd:       NodeConsoleLogin,
+		Width:     1024,
+		Height:    768,
+		WebSocket: true,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "vncpw", vnc.Password)
+	assert.NotEmpty(t, vnc.Ticket)
+}
+
+func TestNode_SpiceShell(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	proxy, err := looseNode().SpiceShell(context.Background(), nil)
+	assert.Nil(t, err)
+	assert.Equal(t, "node1.example.com", proxy.Host)
+	assert.Equal(t, "spice", proxy.Type)
+}
+
+func TestNode_RRD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	img, err := looseNode().RRD(context.Background(), "cpu,mem", TimeframeHour, AVERAGE)
+	assert.Nil(t, err)
+	assert.Equal(t, "rrd-node-graph.png", img.Filename)
+
+	_, err = looseNode().RRD(context.Background(), "", TimeframeHour, "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_RRDData(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	data, err := looseNode().RRDData(context.Background(), TimeframeHour, "")
+	assert.Nil(t, err)
+	assert.Len(t, data, 2)
+}
+
+func TestNode_QueryURLMetadata(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	verify := false
+	meta, err := looseNode().QueryURLMetadata(context.Background(),
+		"https://example.com/debian.iso", &verify)
+	assert.Nil(t, err)
+	assert.Equal(t, "debian-12.iso", meta.Filename)
+	assert.Equal(t, int64(654311424), meta.Size)
+
+	_, err = looseNode().QueryURLMetadata(context.Background(), "", nil)
+	assert.NotNil(t, err)
+}
+
+func TestNode_QueryOCIRepoTags(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	tags, err := looseNode().QueryOCIRepoTags(context.Background(), "docker.io/library/alpine")
+	assert.Nil(t, err)
+	assert.Contains(t, tags, "latest")
+	assert.Len(t, tags, 4)
+
+	_, err = looseNode().QueryOCIRepoTags(context.Background(), "")
+	assert.NotNil(t, err)
+}
+
+func TestNode_VzdumpDefaults(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	defaults, err := looseNode().VzdumpDefaults(context.Background(), "backup")
+	assert.Nil(t, err)
+	assert.Equal(t, "snapshot", defaults["mode"])
+	assert.Equal(t, "zstd", defaults["compress"])
+}
+
+func TestNode_FirewallGetRule(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	rule, err := looseNode().FirewallGetRule(context.Background(), 0)
+	assert.Nil(t, err)
+	assert.Equal(t, "ACCEPT", rule.Action)
+	assert.Equal(t, "ssh", rule.Comment)
+}
+
+func TestNode_FirewallLog(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	entries, err := looseNode().FirewallLog(context.Background(), &NodeFirewallLogOptions{Limit: 100})
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Contains(t, entries[0].T, "DROP")
+
+	entries, err = looseNode().FirewallLog(context.Background(), nil)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entries)
+}
+
+func TestNode_Tasks(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	tasks, err := looseNode().Tasks(context.Background(), &NodeTasksOptions{
+		Limit:  10,
+		Source: "all",
+		VMID:   100,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, tasks, 2)
+	assert.NotNil(t, tasks[0].client) // wired up for chaining
+	assert.Equal(t, "vzdump", tasks[0].Type)
+}
+
+func TestNode_RevertNetworkChanges(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	assert.Nil(t, looseNode().RevertNetworkChanges(context.Background()))
+}
+
+func TestStorage_Identity(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	s := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+	id, err := s.Identity(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, "local", id.ID)
+	assert.Equal(t, "dir", id.Type)
+}
+
+func TestStorage_RRD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	s := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+	img, err := s.RRD(context.Background(), "total,used", TimeframeWeek, MAX)
+	assert.Nil(t, err)
+	assert.Equal(t, "rrd-storage-graph.png", img.Filename)
+
+	_, err = s.RRD(context.Background(), "", TimeframeHour, "")
+	assert.NotNil(t, err)
+}

--- a/nodes_metrics.go
+++ b/nodes_metrics.go
@@ -1,0 +1,93 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Node-level RRD + external-network queries — graph rendering, time-series,
+// URL/OCI pre-flight, vzdump defaults.
+
+// --- /nodes/{node}/rrd[data] ---------------------------------------------
+
+// RRD asks PVE to render a single-graph PNG and returns its on-disk path
+// (lives in PVE's rrdcached dir). Most callers want RRDData for numbers;
+// this exists for parity with the web UI's graph rendering. ds is a
+// comma-separated list of datasources (cpu/mem/diskread/...). cf is
+// optional — empty defaults to AVERAGE server-side.
+func (n *Node) RRD(ctx context.Context, ds string, timeframe Timeframe, cf ConsolidationFunction) (rrd *NodeRRDImage, err error) {
+	if ds == "" {
+		return nil, errors.New("ds is required")
+	}
+	q := url.Values{}
+	q.Set("ds", ds)
+	q.Set("timeframe", string(timeframe))
+	if cf != "" {
+		q.Set("cf", string(cf))
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/rrd?%s", n.Name, q.Encode()), &rrd)
+	return
+}
+
+// RRDData returns the node's historical cpu/mem/disk/net timeseries. cf is
+// optional — empty defaults to AVERAGE server-side.
+func (n *Node) RRDData(ctx context.Context, timeframe Timeframe, cf ConsolidationFunction) (data []*RRDData, err error) {
+	q := url.Values{}
+	q.Set("timeframe", string(timeframe))
+	if cf != "" {
+		q.Set("cf", string(cf))
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/rrddata?%s", n.Name, q.Encode()), &data)
+	return
+}
+
+// --- /nodes/{node}/query-url-metadata -------------------------------------
+
+// QueryURLMetadata HEADs the URL and returns filename / mimetype / size.
+// Used to pre-flight a download-url request without committing storage.
+// verifyTLS=nil uses the PVE default (true); pass false to skip cert
+// validation against self-signed servers.
+func (n *Node) QueryURLMetadata(ctx context.Context, fileURL string, verifyTLS *bool) (meta *NodeURLMetadata, err error) {
+	if fileURL == "" {
+		return nil, errors.New("url is required")
+	}
+	q := url.Values{}
+	q.Set("url", fileURL)
+	if verifyTLS != nil && !*verifyTLS {
+		q.Set("verify-certificates", "0")
+	}
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/query-url-metadata?%s", n.Name, q.Encode()), &meta)
+	return
+}
+
+// --- /nodes/{node}/query-oci-repo-tags ------------------------------------
+
+// QueryOCIRepoTags lists all tags advertised by an OCI registry for the
+// given repo reference (e.g. "docker.io/library/alpine").
+func (n *Node) QueryOCIRepoTags(ctx context.Context, reference string) (tags []string, err error) {
+	if reference == "" {
+		return nil, errors.New("reference is required")
+	}
+	q := url.Values{}
+	q.Set("reference", reference)
+	err = n.client.Get(ctx, fmt.Sprintf("/nodes/%s/query-oci-repo-tags?%s", n.Name, q.Encode()), &tags)
+	return
+}
+
+// --- /nodes/{node}/vzdump/defaults ----------------------------------------
+
+// VzdumpDefaults returns the effective default vzdump options for this
+// node, optionally narrowed to a specific backup storage. The schema mirrors
+// POST /nodes/{node}/vzdump — wrapped as a map for forward compatibility.
+func (n *Node) VzdumpDefaults(ctx context.Context, storage string) (defaults map[string]any, err error) {
+	path := fmt.Sprintf("/nodes/%s/vzdump/defaults", n.Name)
+	if storage != "" {
+		q := url.Values{}
+		q.Set("storage", storage)
+		path = path + "?" + q.Encode()
+	}
+	err = n.client.Get(ctx, path, &defaults)
+	return
+}

--- a/storage.go
+++ b/storage.go
@@ -361,6 +361,31 @@ func (s *Storage) ImportMetadata(ctx context.Context, volume string) (*ImportMet
 	return &meta, nil
 }
 
+// Identity returns the storage's stable id + plugin type. PBS storages
+// surface a content-addressed datastore id here for namespace tracking;
+// other plugins typically return the storage name as the id.
+func (s *Storage) Identity(ctx context.Context) (id *StorageIdentity, err error) {
+	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/storage/%s/identity", s.Node, s.Name), &id)
+	return
+}
+
+// RRD asks PVE to render a storage-utilization PNG and returns its on-disk
+// filename. ds is a comma-separated list of datasources ("total,used");
+// timeframe is hour/day/week/month/year (no decade for storage).
+func (s *Storage) RRD(ctx context.Context, ds string, timeframe Timeframe, cf ConsolidationFunction) (rrd *NodeRRDImage, err error) {
+	if ds == "" {
+		return nil, fmt.Errorf("ds is required")
+	}
+	q := url.Values{}
+	q.Set("ds", ds)
+	q.Set("timeframe", string(timeframe))
+	if cf != "" {
+		q.Set("cf", string(cf))
+	}
+	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/storage/%s/rrd?%s", s.Node, s.Name, q.Encode()), &rrd)
+	return
+}
+
 func deleteVolume(ctx context.Context, c *Client, n, s, v, p, t string) (*Task, error) {
 	var upid UPID
 	if v == "" && p == "" {

--- a/tests/mocks/pve9x/node_loose.go
+++ b/tests/mocks/pve9x/node_loose.go
@@ -1,0 +1,243 @@
+package pve9x
+
+import (
+	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks/config"
+)
+
+// nodeLoose registers gock fixtures for the small "loose" /nodes/{node}/*
+// endpoints — node config, hosts, power, journal/syslog/netstat, execute,
+// console launchers, RRD, URL/OCI/vzdump queries, firewall extras,
+// tasks list, network revert, and storage identity/rrd.
+func nodeLoose() {
+	// ---- /nodes/{node}/config -------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/config").
+		Reply(200).
+		JSON(`{"data":{
+			"description":"primary hypervisor",
+			"ballooning-target":80,
+			"startall-onboot-delay":30,
+			"wakeonlan":"mac=aa:bb:cc:dd:ee:ff,bind-interface=vmbr0",
+			"digest":"abc123"
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/nodes/node1/config$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// ---- /nodes/{node}/hosts --------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/hosts$").
+		Reply(200).
+		JSON(`{"data":{
+			"data":"127.0.0.1 localhost\n10.0.0.1 node1.example.com node1\n",
+			"digest":"hostsdigest123"
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/hosts$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// ---- /nodes/{node}/status (POST = reboot/shutdown) ------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/status$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// ---- /nodes/{node}/journal ------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/journal").
+		Reply(200).
+		JSON(`{"data":[
+			"Jan 01 00:00:01 node1 systemd[1]: Started PVE API Daemon.",
+			"Jan 01 00:00:02 node1 pveproxy[1234]: starting server"
+		]}`)
+
+	// ---- /nodes/{node}/syslog -------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/syslog").
+		Reply(200).
+		JSON(`{"data":[
+			{"n":1,"t":"Jan 01 00:00:01 node1 kernel: Linux version 6.8.0"},
+			{"n":2,"t":"Jan 01 00:00:02 node1 systemd[1]: Reached target Multi-User"}
+		]}`)
+
+	// ---- /nodes/{node}/netstat ------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/netstat$").
+		Reply(200).
+		JSON(`{"data":[
+			{"dev":"tap100i0","vmid":100,"in":12345,"out":67890},
+			{"dev":"veth101i0","vmid":101,"in":111,"out":222}
+		]}`)
+
+	// ---- /nodes/{node}/execute ------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/execute$").
+		Reply(200).
+		JSON(`{"data":[{"status":200,"data":"ok"},{"status":200,"data":"ok"}]}`)
+
+	// ---- /nodes/{node}/vncshell + spiceshell ----------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/vncshell$").
+		Reply(200).
+		JSON(`{"data":{
+			"cert":"-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----",
+			"port":5901,
+			"ticket":"PVE:root@pam:VNCSHELL",
+			"upid":"UPID:node1:00000001:00000001:00000001:vncshell::root@pam:",
+			"user":"root@pam",
+			"password":"vncpw"
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/nodes/node1/spiceshell$").
+		Reply(200).
+		JSON(`{"data":{
+			"host":"node1.example.com",
+			"password":"spicepw",
+			"proxy":"node1.example.com",
+			"tls-port":"3128",
+			"type":"spice"
+		}}`)
+
+	// ---- /nodes/{node}/rrd + rrddata ------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/rrd$").
+		Reply(200).
+		JSON(`{"data":{"filename":"rrd-node-graph.png"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/rrddata").
+		Reply(200).
+		JSON(`{"data":[
+			{"time":1715000000,"cpu":0.12,"mem":1000000,"maxmem":8000000},
+			{"time":1715000060,"cpu":0.18,"mem":1100000,"maxmem":8000000}
+		]}`)
+
+	// ---- /nodes/{node}/query-url-metadata -------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/query-url-metadata").
+		Reply(200).
+		JSON(`{"data":{
+			"filename":"debian-12.iso",
+			"mimetype":"application/x-iso9660-image",
+			"size":654311424
+		}}`)
+
+	// ---- /nodes/{node}/query-oci-repo-tags ------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/query-oci-repo-tags").
+		Reply(200).
+		JSON(`{"data":["latest","3.18","3.19","3.20"]}`)
+
+	// ---- /nodes/{node}/vzdump/defaults ----------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/vzdump/defaults").
+		Reply(200).
+		JSON(`{"data":{
+			"mode":"snapshot",
+			"compress":"zstd",
+			"storage":"backup",
+			"remove":1,
+			"prune-backups":"keep-last=3,keep-daily=7"
+		}}`)
+
+	// ---- /nodes/{node}/firewall/log + /firewall/rules/{pos} -------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/firewall/log").
+		Reply(200).
+		JSON(`{"data":[
+			{"n":1,"t":"DROP IN=vmbr0 OUT= MAC=aa:bb:cc"},
+			{"n":2,"t":"ACCEPT IN=vmbr0 OUT= MAC=dd:ee:ff"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/firewall/rules/0$").
+		Reply(200).
+		JSON(`{"data":{
+			"pos":0,
+			"type":"in",
+			"action":"ACCEPT",
+			"enable":1,
+			"proto":"tcp",
+			"dport":"22",
+			"comment":"ssh"
+		}}`)
+
+	// ---- /nodes/{node}/tasks --------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get(`^/nodes/node1/tasks$`).
+		Reply(200).
+		JSON(`{"data":[
+			{
+				"upid":"UPID:node1:00000001:00000001:00000001:vzdump:100:root@pam:",
+				"node":"node1","pid":1,"pstart":1,"starttime":1715000000,
+				"endtime":1715000100,"type":"vzdump","id":"100","user":"root@pam",
+				"status":"OK"
+			},
+			{
+				"upid":"UPID:node1:00000002:00000002:00000002:qmstart:100:root@pam:",
+				"node":"node1","pid":2,"pstart":2,"starttime":1715000200,
+				"type":"qmstart","id":"100","user":"root@pam"
+			}
+		]}`)
+
+	// ---- /nodes/{node}/network (DELETE = revert) ------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/nodes/node1/network$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// ---- /nodes/{node}/storage/{storage}/identity + rrd -----------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/local/identity$").
+		Reply(200).
+		JSON(`{"data":{"id":"local","type":"dir"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/local/rrd$").
+		Reply(200).
+		JSON(`{"data":{"filename":"rrd-storage-graph.png"}}`)
+}

--- a/tests/mocks/pve9x/proxmox.go
+++ b/tests/mocks/pve9x/proxmox.go
@@ -12,5 +12,6 @@ func Load() {
 	storage()
 	sdn()
 	hardware()
+	nodeLoose()
 	tasks()
 }

--- a/types.go
+++ b/types.go
@@ -4118,3 +4118,75 @@ type USBDevice struct {
 	Serial       string `json:"serial,omitempty"`
 	USBPath      string `json:"usbpath,omitempty"`
 }
+
+// --- /nodes/{node}/config types -------------------------------------------
+
+// NodeConfig is the read shape of GET /nodes/{node}/config. Substructure
+// fields (Acme, AcmeDomain[N], Location, WakeOnLAN) come back as PVE
+// property strings ("key=val,..."); parsing them is left to callers since
+// the schema may grow.
+type NodeConfig struct {
+	Acme                string `json:"acme,omitempty"`
+	AcmeDomain0         string `json:"acmedomain0,omitempty"`
+	AcmeDomain1         string `json:"acmedomain1,omitempty"`
+	AcmeDomain2         string `json:"acmedomain2,omitempty"`
+	AcmeDomain3         string `json:"acmedomain3,omitempty"`
+	AcmeDomain4         string `json:"acmedomain4,omitempty"`
+	AcmeDomain5         string `json:"acmedomain5,omitempty"`
+	BallooningTarget    int    `json:"ballooning-target,omitempty"`
+	Description         string `json:"description,omitempty"`
+	Digest              string `json:"digest,omitempty"`
+	Location            string `json:"location,omitempty"`
+	StartAllOnBootDelay int    `json:"startall-onboot-delay,omitempty"`
+	WakeOnLAN           string `json:"wakeonlan,omitempty"`
+}
+
+// NodeConfigOptions is the write shape for PUT /nodes/{node}/config. Set
+// Delete to a comma-separated list of keys to unset them; pass Digest from
+// a prior GetConfig for optimistic concurrency.
+type NodeConfigOptions struct {
+	Acme                string `json:"acme,omitempty"`
+	AcmeDomain0         string `json:"acmedomain0,omitempty"`
+	AcmeDomain1         string `json:"acmedomain1,omitempty"`
+	AcmeDomain2         string `json:"acmedomain2,omitempty"`
+	AcmeDomain3         string `json:"acmedomain3,omitempty"`
+	AcmeDomain4         string `json:"acmedomain4,omitempty"`
+	AcmeDomain5         string `json:"acmedomain5,omitempty"`
+	BallooningTarget    *int   `json:"ballooning-target,omitempty"` // FIXME(issue-199): PVE default 80; pointer so unset doesn't override.
+	Delete              string `json:"delete,omitempty"`
+	Description         string `json:"description,omitempty"`
+	Digest              string `json:"digest,omitempty"`
+	Location            string `json:"location,omitempty"`
+	StartAllOnBootDelay *int   `json:"startall-onboot-delay,omitempty"`
+	WakeOnLAN           string `json:"wakeonlan,omitempty"`
+}
+
+// NodeHosts is the read shape of GET /nodes/{node}/hosts. Pass Digest back
+// to UpdateHosts for concurrency-safe writes.
+type NodeHosts struct {
+	Data   string `json:"data"`
+	Digest string `json:"digest,omitempty"`
+}
+
+// NodeRRDImage is the response shape of GET /nodes/{node}/rrd — and the
+// matching storage variant. The filename lives in PVE's rrdcached directory.
+type NodeRRDImage struct {
+	Filename string `json:"filename"`
+}
+
+// NodeURLMetadata is the response shape of GET /nodes/{node}/query-url-metadata.
+// All fields are optional; PVE leaves them blank when the upstream HEAD
+// response omits the corresponding header.
+type NodeURLMetadata struct {
+	Filename string `json:"filename,omitempty"`
+	MimeType string `json:"mimetype,omitempty"`
+	Size     int64  `json:"size,omitempty"`
+}
+
+// StorageIdentity is the response shape of GET /nodes/{node}/storage/{storage}/identity.
+// ID is content-addressed for plugins that support it (e.g. PBS datastore
+// fingerprint), else the storage name. Type is the plugin kind.
+type StorageIdentity struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}


### PR DESCRIPTION
## Summary

Wraps the 22 small "loose" `/nodes/{node}/*` endpoints — surfaces that didn't warrant their own file/area but were dragging coverage:

**Node admin (`nodes_admin.go`)**
- Config CRUD: `GetConfig`, `GetConfigProperty`, `UpdateConfig`
- `/etc/hosts`: `Hosts`, `UpdateHosts` (digest-based concurrency)
- Power: `Reboot`, `Shutdown`
- Logs: `Journal`, `Syslog`, `Netstat`
- Batch + consoles: `Execute`, `VNCShell`, `SpiceShell`
- Tasks list: `Tasks(opts)` — pre-wires `client` on each `*Task` for chaining
- `RevertNetworkChanges`

**Metrics / queries (`nodes_metrics.go`)**
- `RRD`, `RRDData`
- `QueryURLMetadata`, `QueryOCIRepoTags`, `VzdumpDefaults`

**Inline additions**
- `Node.FirewallGetRule(pos)`, `Node.FirewallLog(opts)` in `nodes.go`
- `Storage.Identity`, `Storage.RRD` in `storage.go`

Skipped: `GET /nodes/{node}/storage/{storage}/file-restore/download` (binary content, needs a separate download mechanism — different shape than the rest).

Coverage: 475/675 -> 497/675 (70.4% -> 73.6%).

## Test plan

- [x] ``go build ./...``
- [x] ``go test -count=1 .`` (full unit suite, 2.6s)
- [x] 22 new tests in ``nodes_loose_test.go``, all passing
- [x] gock mocks in ``tests/mocks/pve9x/node_loose.go``
- [x] ``mage endpoints:coverage`` confirms uptick

## Notes

- ``NodeConfigOptions`` uses ``*int`` for ``BallooningTarget`` / ``StartAllOnBootDelay`` because their PVE defaults (80, 0) differ from Go's zero in a way ``omitempty`` would silently override.
- ``Execute`` returns ``[]map[string]any`` — each command can be any API endpoint so a typed struct would be brittle.
- ``Netstat`` and ``VzdumpDefaults`` likewise return loose ``map[string]any`` since PVE's schemas declare them open-ended.