### PR TITLE
feat(mage): teach endpoints:coverage about diridx helpers, Upload, and by-design exclusions

### DIFF
--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -23,6 +23,44 @@ const (
 	cacheDir    = ".cache/pve-api"
 )
 
+// intentionallyExcluded enumerates PVE endpoints we deliberately do not wrap
+// in Go, with the rationale for each. Coverage stats subtract these from the
+// denominator so the % reflects design intent rather than a mechanical count
+// that would never reach 100.
+//
+// Keys are `key(method, normalizedPath)` form — lowercase verb + space + path
+// with `{var}`/`%s` segments collapsed to `{}`. See `normalizePath` + `key`.
+//
+// **What does NOT belong here:** directory-index ("diridx") GETs that simply
+// enumerate subresources (`[{"subdir":"x"}, ...]`). They look useless at first
+// glance, but PVE filters the response by the caller's ACLs, so they're a
+// supported permission-introspection / capability-discovery probe. We wrap
+// them; see (*Node).sdnDiridx and (*Node).capabilitiesDiridx for the helper
+// shape and the *Index family of methods that call into them.
+//
+// **What belongs here:** endpoints whose shape doesn't fit the generic
+// `Get/Post/Put/Delete(ctx, path, ...)` wrapper at all and that a caller would
+// need a custom code path for anyway. Two cases today:
+//
+//   - mtunnelwebsocket — the library exposes a URL-builder
+//     (`MigrationTunnelWebSocketPath`) that returns the signed URL with
+//     ticket; the caller plumbs that into their own websocket dialer. There
+//     is no in-library HTTP call to scan, and the canonical "wrapper" is the
+//     path helper, not a GET.
+//
+//   - file-restore/download — streams a tar of restored files. Doesn't fit
+//     the JSON-decoding `Get` helper; needs an `io.Reader` flow we haven't
+//     plumbed.
+//
+// Adding a new entry requires updating both the map AND the call site that
+// proves the wrapper exists in some non-scannable form. Removing an entry is
+// preferable when we add a real wrapper.
+var intentionallyExcluded = map[string]string{
+	"get /nodes/{}/qemu/{}/mtunnelwebsocket":           "URL-builder helper (MigrationTunnelWebSocketPath); caller drives the websocket dialer",
+	"get /nodes/{}/lxc/{}/mtunnelwebsocket":            "URL-builder helper (MigrationTunnelWebSocketPath); caller drives the websocket dialer",
+	"get /nodes/{}/storage/{}/file-restore/download":   "streaming binary download; needs custom io.Reader plumbing, not the JSON Get helper",
+}
+
 type methodInfo struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
@@ -131,6 +169,16 @@ func Coverage() error {
 		schemaByArea[a][k] = struct{}{}
 	}
 
+	// Reconcile the excluded list against the live schema. An entry that no
+	// longer exists upstream (PVE removed/renamed the endpoint) is a real bug
+	// in the exclusion table, not a silent no-op — fail loudly so the table
+	// stays accurate.
+	for k := range intentionallyExcluded {
+		if _, ok := schemaKey[k]; !ok {
+			return fmt.Errorf("intentionallyExcluded entry %q is not in the upstream schema — update or remove it", k)
+		}
+	}
+
 	calls, err := scanCallSites(".")
 	if err != nil {
 		return err
@@ -157,11 +205,17 @@ func Coverage() error {
 	})
 
 	var uncovered []string
+	excludedHits := 0
 	for _, e := range schema {
 		k := key(e.Method, normalizePath(e.Path))
-		if _, ok := covered[k]; !ok {
-			uncovered = append(uncovered, fmt.Sprintf("%-7s %s", e.Method, e.Path))
+		if _, ok := covered[k]; ok {
+			continue
 		}
+		if _, ok := intentionallyExcluded[k]; ok {
+			excludedHits++
+			continue
+		}
+		uncovered = append(uncovered, fmt.Sprintf("%-7s %s", e.Method, e.Path))
 	}
 	sort.Strings(uncovered)
 	if err := os.WriteFile(
@@ -173,8 +227,8 @@ func Coverage() error {
 	}
 
 	type areaRow struct {
-		area               string
-		total, cov, missed int
+		area                         string
+		total, cov, excluded, missed int
 	}
 	var rows []areaRow
 	for area, keys := range schemaByArea {
@@ -182,9 +236,13 @@ func Coverage() error {
 		for k := range keys {
 			if _, ok := covered[k]; ok {
 				row.cov++
+				continue
+			}
+			if _, ok := intentionallyExcluded[k]; ok {
+				row.excluded++
 			}
 		}
-		row.missed = row.total - row.cov
+		row.missed = row.total - row.cov - row.excluded
 		rows = append(rows, row)
 	}
 	sort.Slice(rows, func(i, j int) bool {
@@ -195,10 +253,15 @@ func Coverage() error {
 	})
 
 	var areaBuf bytes.Buffer
-	fmt.Fprintf(&areaBuf, "%-25s %8s %8s %8s %8s\n", "area", "covered", "total", "missing", "pct")
+	fmt.Fprintf(&areaBuf, "%-25s %8s %8s %8s %8s %8s\n", "area", "covered", "total", "excluded", "missing", "pct")
 	for _, r := range rows {
-		fmt.Fprintf(&areaBuf, "%-25s %8d %8d %8d %7.1f%%\n",
-			r.area, r.cov, r.total, r.missed, pct(r.cov, r.total))
+		// pct is covered / (total - excluded) so excluded endpoints don't
+		// drag the area's number down. covered/total without that adjustment
+		// would punish areas that have endpoints we've deliberately decided
+		// not to wrap (e.g. streaming downloads).
+		denom := r.total - r.excluded
+		fmt.Fprintf(&areaBuf, "%-25s %8d %8d %8d %8d %7.1f%%\n",
+			r.area, r.cov, r.total, r.excluded, r.missed, pct(r.cov, denom))
 	}
 	if err := os.WriteFile(
 		filepath.Join(cacheDir, "coverage_by_area.txt"),
@@ -212,8 +275,14 @@ func Coverage() error {
 	fmt.Printf("  schema endpoints   : %d\n", len(schema))
 	fmt.Printf("  call sites scanned : %d (matched=%d, no-match=%d → match rate %.1f%%)\n",
 		len(calls), matched, missed, pct(matched, len(calls)))
-	fmt.Printf("  unique covered     : %d / %d  →  %.1f%%\n",
-		len(covered), len(schema), pct(len(covered), len(schema)))
+	// "Considered" is total minus the deliberately-unwrappable endpoints
+	// (URL-builder helpers, streaming binary downloads, etc.). Reporting the
+	// covered % against this denominator answers "of the endpoints we set
+	// out to wrap, how many have we wrapped" rather than against a moving
+	// upstream target that includes things we never intended to cover.
+	considered := len(schema) - excludedHits
+	fmt.Printf("  unique covered     : %d / %d  →  %.1f%%  (excluded by design: %d)\n",
+		len(covered), considered, pct(len(covered), considered), excludedHits)
 	fmt.Println()
 	fmt.Print(areaBuf.String())
 	if len(unmatched) > 0 {
@@ -324,6 +393,34 @@ func scanCallSites(root string) ([]extractedCall, error) {
 					File:   filepath.ToSlash(path),
 					Line:   line,
 				})
+				continue
+			}
+
+			if dm := diridxRE.FindStringSubmatch(text); dm != nil {
+				pathLit := resolvePath(dm[1], urlVars, pathVars)
+				if pathLit == "" {
+					continue
+				}
+				out = append(out, extractedCall{
+					Method: "GET",
+					Path:   normalizePath(pathLit),
+					File:   filepath.ToSlash(path),
+					Line:   line,
+				})
+				continue
+			}
+
+			if um := uploadRE.FindStringSubmatch(text); um != nil {
+				pathLit := resolvePath(um[1], urlVars, pathVars)
+				if pathLit == "" {
+					continue
+				}
+				out = append(out, extractedCall{
+					Method: "POST",
+					Path:   normalizePath(pathLit),
+					File:   filepath.ToSlash(path),
+					Line:   line,
+				})
 			}
 		}
 		return s.Err()
@@ -377,8 +474,22 @@ var (
 	// extra body/query interface but the path is still the first non-ctx arg,
 	// so the same extractor handles both. The `(?:WithParams)?` is
 	// non-capturing — group 1 always returns the bare HTTP verb.
-	callRE      = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)(?:WithParams)?\s*\(\s*ctx\s*,\s*(.*?)$`)
-	wsCallRE    = regexp.MustCompile(`\b\w+\.(VNCWebSocket|TermWebSocket)\s*\(\s*(.*?)$`)
+	callRE   = regexp.MustCompile(`\b\w+\.(Get|Post|Put|Delete)(?:WithParams)?\s*\(\s*ctx\s*,\s*(.*?)$`)
+	wsCallRE = regexp.MustCompile(`\b\w+\.(VNCWebSocket|TermWebSocket)\s*\(\s*(.*?)$`)
+	// Diridx helpers — internal package methods named `<X>Diridx` or `<X>diridx`
+	// that wrap a GET against a directory-index endpoint. They exist so several
+	// sibling diridx wrappers (e.g. (*Node).SDNIndex, SDNZoneIndex, …) can share
+	// the same `[{"subdir":"x"}, ...] → []string` unmarshalling. The actual HTTP
+	// verb is always GET; scanner treats every diridx-helper call site as a GET
+	// against the first non-ctx argument path.
+	diridxRE = regexp.MustCompile(`\b\w+\.\w*[Dd]iridx\s*\(\s*ctx\s*,\s*(.*?)$`)
+	// Upload — the `*Client.Upload` helper wraps multipart POST. Its signature
+	// is `Upload(path, ...)` (no ctx; the helper builds its own request). The
+	// `client.` qualifier is required to avoid matching the unrelated method
+	// `(*Storage).Upload(content, filename string)` whose first arg is a
+	// content-type, not a path. Scanner treats every `<x>.client.Upload`
+	// call site as a POST against the first argument path.
+	uploadRE = regexp.MustCompile(`\bclient\.Upload\s*\(\s*(.*?)$`)
 	sprintfRE   = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
 	urlAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*url\.URL\{\s*Path:\s*(.+)\}`)
 	// `<var> := fmt.Sprintf("/…", …)` or `<var> := "/…"` — bindings that later


### PR DESCRIPTION
## Why

`mage endpoints:coverage` was undercounting our wrappers because the static scanner only recognized direct `<x>.Get|Post|Put|Delete(ctx, path)` call sites. Wrappers built via shared helpers (`sdnDiridx`, `capabilitiesDiridx`) and the multipart `Upload` helper looked uncovered even though they ship. The reported 81.0% included roughly 9 false-negatives plus a few endpoints that genuinely can't be expressed as a `Get/Post/...` call (URL-builder helpers, streaming binary downloads).

## What

Three small additions to `mage/endpoints/endpoints.go`:

1. **Diridx helper recognizer** — `<x>.<Name>[Dd]iridx(ctx, path, ...)` is counted as a GET. Picks up `(*Node).sdnDiridx`, `(*Node).capabilitiesDiridx`, and any future sibling.
2. **Upload recognizer** — `<x>.client.Upload(path, ...)` is counted as a POST. The `client.` qualifier is required to avoid matching the unrelated `(*Storage).Upload(content, filename)` method whose first arg is a content-type string.
3. **`intentionallyExcluded` map** — a curated set of endpoints that cannot or should not be expressed as a generic `Get/Post/Put/Delete` wrapper. Subtracted from the denominator so the % reflects design intent. Currently:
   - `GET /nodes/{}/qemu/{}/mtunnelwebsocket` — URL-builder helper (`MigrationTunnelWebSocketPath`); caller drives their own websocket dialer
   - `GET /nodes/{}/lxc/{}/mtunnelwebsocket` — same
   - `GET /nodes/{}/storage/{}/file-restore/download` — streaming binary download; doesn't fit the JSON `Get` helper

The map's docstring spells out what does (and does **not**) qualify. Directory-index ("diridx") GETs are explicitly **not** excluded — they're ACL-filtered by PVE and serve as a permission/capability probe, so they're worth wrapping; PR #TBD-diridx adds those.

Stale entries fail loudly: every coverage run reconciles `intentionallyExcluded` against the live upstream schema and errors out if an entry no longer exists, so the table can't silently mask a renamed/removed endpoint.

The report now has an `excluded` column and computes per-area % against `total - excluded`.

## Effect on coverage stats

Before:
```
unique covered     : 547 / 675  →  81.0%
nodes/qemu          96 / 97   99.0%
nodes/lxc           61 / 62   98.4%
nodes/sdn            8 / 12   66.7%
nodes/capabilities   4 / 6    66.7%
```

After:
```
unique covered     : 553 / 672  →  82.3%  (excluded by design: 3)
nodes/qemu          96 / 97  excl=1  100.0%
nodes/lxc           61 / 62  excl=1  100.0%
nodes/sdn           12 / 12          100.0%
nodes/capabilities   6 / 6           100.0%
```

Match rate against detected call sites: 99.8% → 100% (no unresolved sites).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `mage endpoints:coverage` — match rate 100%, no false-negatives in the previously-blind areas, excluded count printed