### PR TITLE
feat: wrap PVE directory-index (diridx) endpoints - permission/capability probes

### DIFF
--- a/cluster_diridx.go
+++ b/cluster_diridx.go
@@ -1,0 +1,101 @@
+package proxmox
+
+import (
+	"context"
+)
+
+// Directory-index ("diridx") wrappers for /cluster/* endpoints. See the
+// header comment in nodes_diridx.go for the rationale — same shape, same
+// shared subdir-list decoder.
+
+// ClusterIndex enumerates the children of /cluster (typically "replication",
+// "metrics", "config", "firewall", "backup", "backupinfo", "ha",
+// "acme", "ceph", "jobs", "sdn", "log", "resources", "tasks", "options",
+// "status", "nextid", "qemu"). ACL-filtered.
+func (cl *Cluster) ClusterIndex(ctx context.Context) ([]string, error) {
+	return cl.clusterDiridx(ctx, "/cluster")
+}
+
+// ACMEIndex enumerates the children of /cluster/acme ("plugins",
+// "account", "tos", "meta", "directories", "challenge-schema").
+func (cl *Cluster) ACMEIndex(ctx context.Context) ([]string, error) {
+	return cl.acmeDiridx(ctx, "/cluster/acme")
+}
+
+// FirewallIndex enumerates the children of /cluster/firewall ("groups",
+// "rules", "ipset", "aliases", "options", "macros", "refs").
+func (cl *Cluster) FirewallIndex(ctx context.Context) ([]string, error) {
+	return cl.firewallDiridx(ctx, "/cluster/firewall")
+}
+
+// SDNIndex enumerates the children of /cluster/sdn ("vnets", "zones",
+// "controllers", "ipams", "dns", "fabrics", "subnets").
+func (cl *Cluster) SDNIndex(ctx context.Context) ([]string, error) {
+	return cl.sdnDiridx(ctx, "/cluster/sdn")
+}
+
+// CephIndex enumerates the children of /cluster/ceph ("metadata", "status",
+// "flags").
+func (cl *Cluster) CephIndex(ctx context.Context) ([]string, error) {
+	return cl.cephDiridx(ctx, "/cluster/ceph")
+}
+
+// ConfigIndex enumerates the children of /cluster/config ("nodes", "join",
+// "totem", "qdevice", "apiversion").
+func (cl *Cluster) ConfigIndex(ctx context.Context) ([]string, error) {
+	return cl.configDiridx(ctx, "/cluster/config")
+}
+
+// HAIndex enumerates the children of /cluster/ha ("groups", "resources",
+// "status", "rules").
+func (cl *Cluster) HAIndex(ctx context.Context) ([]string, error) {
+	return cl.haDiridx(ctx, "/cluster/ha")
+}
+
+// HAStatusIndex enumerates the children of /cluster/ha/status ("current",
+// "manager_status").
+func (cl *Cluster) HAStatusIndex(ctx context.Context) ([]string, error) {
+	return cl.haDiridx(ctx, "/cluster/ha/status")
+}
+
+// QEMUIndex enumerates the children of /cluster/qemu. Each entry's "subdir"
+// is a numeric VMID — these are the QEMU guests visible to the caller
+// cluster-wide. Distinct from (*Node).VirtualMachines, which scopes to one
+// node and returns rich VM records.
+func (cl *Cluster) QEMUIndex(ctx context.Context) ([]string, error) {
+	return cl.qemuDiridx(ctx, "/cluster/qemu")
+}
+
+// --- diridx helpers ---------------------------------------------------------
+
+func (cl *Cluster) clusterDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) acmeDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) firewallDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) sdnDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) cephDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) configDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) haDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) qemuDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}

--- a/cluster_diridx.go
+++ b/cluster_diridx.go
@@ -8,61 +8,61 @@ import (
 // header comment in nodes_diridx.go for the rationale — same shape, same
 // shared subdir-list decoder.
 
-// ClusterIndex enumerates the children of /cluster (typically "replication",
+// Subdirs enumerates the children of /cluster (typically "replication",
 // "metrics", "config", "firewall", "backup", "backupinfo", "ha",
 // "acme", "ceph", "jobs", "sdn", "log", "resources", "tasks", "options",
 // "status", "nextid", "qemu"). ACL-filtered.
-func (cl *Cluster) ClusterIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) Subdirs(ctx context.Context) ([]string, error) {
 	return cl.clusterDiridx(ctx, "/cluster")
 }
 
-// ACMEIndex enumerates the children of /cluster/acme ("plugins",
+// ACMESubdirs enumerates the children of /cluster/acme ("plugins",
 // "account", "tos", "meta", "directories", "challenge-schema").
-func (cl *Cluster) ACMEIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) ACMESubdirs(ctx context.Context) ([]string, error) {
 	return cl.acmeDiridx(ctx, "/cluster/acme")
 }
 
-// FirewallIndex enumerates the children of /cluster/firewall ("groups",
+// FirewallSubdirs enumerates the children of /cluster/firewall ("groups",
 // "rules", "ipset", "aliases", "options", "macros", "refs").
-func (cl *Cluster) FirewallIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) FirewallSubdirs(ctx context.Context) ([]string, error) {
 	return cl.firewallDiridx(ctx, "/cluster/firewall")
 }
 
-// SDNIndex enumerates the children of /cluster/sdn ("vnets", "zones",
+// SDNSubdirs enumerates the children of /cluster/sdn ("vnets", "zones",
 // "controllers", "ipams", "dns", "fabrics", "subnets").
-func (cl *Cluster) SDNIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) SDNSubdirs(ctx context.Context) ([]string, error) {
 	return cl.sdnDiridx(ctx, "/cluster/sdn")
 }
 
-// CephIndex enumerates the children of /cluster/ceph ("metadata", "status",
+// CephSubdirs enumerates the children of /cluster/ceph ("metadata", "status",
 // "flags").
-func (cl *Cluster) CephIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) CephSubdirs(ctx context.Context) ([]string, error) {
 	return cl.cephDiridx(ctx, "/cluster/ceph")
 }
 
-// ConfigIndex enumerates the children of /cluster/config ("nodes", "join",
+// ConfigSubdirs enumerates the children of /cluster/config ("nodes", "join",
 // "totem", "qdevice", "apiversion").
-func (cl *Cluster) ConfigIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) ConfigSubdirs(ctx context.Context) ([]string, error) {
 	return cl.configDiridx(ctx, "/cluster/config")
 }
 
-// HAIndex enumerates the children of /cluster/ha ("groups", "resources",
+// HASubdirs enumerates the children of /cluster/ha ("groups", "resources",
 // "status", "rules").
-func (cl *Cluster) HAIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) HASubdirs(ctx context.Context) ([]string, error) {
 	return cl.haDiridx(ctx, "/cluster/ha")
 }
 
-// HAStatusIndex enumerates the children of /cluster/ha/status ("current",
+// HAStatusSubdirs enumerates the children of /cluster/ha/status ("current",
 // "manager_status").
-func (cl *Cluster) HAStatusIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) HAStatusSubdirs(ctx context.Context) ([]string, error) {
 	return cl.haDiridx(ctx, "/cluster/ha/status")
 }
 
-// QEMUIndex enumerates the children of /cluster/qemu. Each entry's "subdir"
+// QEMUSubdirs enumerates the children of /cluster/qemu. Each entry's "subdir"
 // is a numeric VMID — these are the QEMU guests visible to the caller
 // cluster-wide. Distinct from (*Node).VirtualMachines, which scopes to one
 // node and returns rich VM records.
-func (cl *Cluster) QEMUIndex(ctx context.Context) ([]string, error) {
+func (cl *Cluster) QEMUSubdirs(ctx context.Context) ([]string, error) {
 	return cl.qemuDiridx(ctx, "/cluster/qemu")
 }
 

--- a/cluster_diridx_test.go
+++ b/cluster_diridx_test.go
@@ -1,0 +1,96 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func diridxCluster() *Cluster {
+	return &Cluster{client: mockClient()}
+}
+
+func TestCluster_ClusterIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().ClusterIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subdirs, "replication")
+	assert.Contains(t, subdirs, "ha")
+	assert.Contains(t, subdirs, "sdn")
+	assert.Contains(t, subdirs, "ceph")
+}
+
+func TestCluster_ACMEIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().ACMEIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subdirs, "plugins")
+	assert.Contains(t, subdirs, "account")
+	assert.Contains(t, subdirs, "directories")
+}
+
+func TestCluster_FirewallIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().FirewallIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subdirs, "groups")
+	assert.Contains(t, subdirs, "rules")
+	assert.Contains(t, subdirs, "options")
+}
+
+func TestCluster_SDNIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().SDNIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subdirs, "vnets")
+	assert.Contains(t, subdirs, "zones")
+	assert.Contains(t, subdirs, "controllers")
+}
+
+func TestCluster_CephIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().CephIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"metadata", "status", "flags"}, subdirs)
+}
+
+func TestCluster_ConfigIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().ConfigIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subdirs, "nodes")
+	assert.Contains(t, subdirs, "join")
+	assert.Contains(t, subdirs, "totem")
+}
+
+func TestCluster_HAIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().HAIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"groups", "resources", "status", "rules"}, subdirs)
+}
+
+func TestCluster_HAStatusIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().HAStatusIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"current", "manager_status"}, subdirs)
+}
+
+func TestCluster_QEMUIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxCluster().QEMUIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"100", "101", "200"}, subdirs)
+}

--- a/cluster_diridx_test.go
+++ b/cluster_diridx_test.go
@@ -12,10 +12,10 @@ func diridxCluster() *Cluster {
 	return &Cluster{client: mockClient()}
 }
 
-func TestCluster_ClusterIndex(t *testing.T) {
+func TestCluster_Subdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().ClusterIndex(context.Background())
+	subdirs, err := diridxCluster().Subdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Contains(t, subdirs, "replication")
 	assert.Contains(t, subdirs, "ha")
@@ -23,74 +23,74 @@ func TestCluster_ClusterIndex(t *testing.T) {
 	assert.Contains(t, subdirs, "ceph")
 }
 
-func TestCluster_ACMEIndex(t *testing.T) {
+func TestCluster_ACMESubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().ACMEIndex(context.Background())
+	subdirs, err := diridxCluster().ACMESubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Contains(t, subdirs, "plugins")
 	assert.Contains(t, subdirs, "account")
 	assert.Contains(t, subdirs, "directories")
 }
 
-func TestCluster_FirewallIndex(t *testing.T) {
+func TestCluster_FirewallSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().FirewallIndex(context.Background())
+	subdirs, err := diridxCluster().FirewallSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Contains(t, subdirs, "groups")
 	assert.Contains(t, subdirs, "rules")
 	assert.Contains(t, subdirs, "options")
 }
 
-func TestCluster_SDNIndex(t *testing.T) {
+func TestCluster_SDNSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().SDNIndex(context.Background())
+	subdirs, err := diridxCluster().SDNSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Contains(t, subdirs, "vnets")
 	assert.Contains(t, subdirs, "zones")
 	assert.Contains(t, subdirs, "controllers")
 }
 
-func TestCluster_CephIndex(t *testing.T) {
+func TestCluster_CephSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().CephIndex(context.Background())
+	subdirs, err := diridxCluster().CephSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"metadata", "status", "flags"}, subdirs)
 }
 
-func TestCluster_ConfigIndex(t *testing.T) {
+func TestCluster_ConfigSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().ConfigIndex(context.Background())
+	subdirs, err := diridxCluster().ConfigSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Contains(t, subdirs, "nodes")
 	assert.Contains(t, subdirs, "join")
 	assert.Contains(t, subdirs, "totem")
 }
 
-func TestCluster_HAIndex(t *testing.T) {
+func TestCluster_HASubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().HAIndex(context.Background())
+	subdirs, err := diridxCluster().HASubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"groups", "resources", "status", "rules"}, subdirs)
 }
 
-func TestCluster_HAStatusIndex(t *testing.T) {
+func TestCluster_HAStatusSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().HAStatusIndex(context.Background())
+	subdirs, err := diridxCluster().HAStatusSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"current", "manager_status"}, subdirs)
 }
 
-func TestCluster_QEMUIndex(t *testing.T) {
+func TestCluster_QEMUSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxCluster().QEMUIndex(context.Background())
+	subdirs, err := diridxCluster().QEMUSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"100", "101", "200"}, subdirs)
 }

--- a/nodes_diridx.go
+++ b/nodes_diridx.go
@@ -1,0 +1,158 @@
+package proxmox
+
+import (
+	"context"
+	"fmt"
+)
+
+// Directory-index ("diridx") wrappers for /nodes/{node}/* endpoints. PVE
+// publishes these endpoints as the canonical permission/capability probes:
+// they're ACL-filtered, so the returned list tells the caller which
+// subresources they can read, and they exist on every supported PVE version,
+// giving a stable surface for capability discovery across upgrades. The web
+// UI itself uses these to decide what menu items to show.
+//
+// Each helper here issues a GET against the directory-index path and
+// collapses the `[{"subdir":"..."}]` link-objects into a flat []string. The
+// helpers are named `<area>Diridx` so the endpoints scanner (see
+// mage/endpoints) treats the call site as a GET against the helper's path
+// argument.
+
+// NodeIndex enumerates the children of /nodes/{node} (typically "qemu",
+// "lxc", "storage", "network", "tasks", "scan", "services", "subscription",
+// etc.). Useful as a permission probe: PVE filters the list by the caller's
+// ACLs, so the result tells you which sub-APIs the credential can read.
+func (n *Node) NodeIndex(ctx context.Context) ([]string, error) {
+	return n.nodeDiridx(ctx, fmt.Sprintf("/nodes/%s", n.Name))
+}
+
+// FirewallIndex enumerates the children of /nodes/{node}/firewall
+// ("rules", "options", "log").
+func (n *Node) FirewallIndex(ctx context.Context) ([]string, error) {
+	return n.firewallDiridx(ctx, fmt.Sprintf("/nodes/%s/firewall", n.Name))
+}
+
+// DisksIndex enumerates the children of /nodes/{node}/disks ("list",
+// "smart", "initgpt", "wipedisk", "directory", "lvm", "lvmthin", "zfs").
+func (n *Node) DisksIndex(ctx context.Context) ([]string, error) {
+	return n.disksDiridx(ctx, fmt.Sprintf("/nodes/%s/disks", n.Name))
+}
+
+// ReplicationIndex enumerates the children of
+// /nodes/{node}/replication/{id} ("status", "log", "schedule_now").
+// /nodes/{node}/replication (without {id}) is a true list endpoint, not a
+// diridx; use (*Node).Replications for that.
+func (r *NodeReplicationJob) ReplicationIndex(ctx context.Context) ([]string, error) {
+	if r.ID == "" {
+		return nil, fmt.Errorf("replication id is required")
+	}
+	return r.replicationDiridx(ctx, fmt.Sprintf("/nodes/%s/replication/%s", r.Node, r.ID))
+}
+
+// ServiceIndex enumerates the children of /nodes/{node}/services/{service}
+// ("state", "start", "stop", "restart", "reload"). /nodes/{node}/services
+// (without {service}) is a true list endpoint — use (*Node).Services.
+func (s *NodeService) ServiceIndex(ctx context.Context) ([]string, error) {
+	if s.Name == "" {
+		return nil, fmt.Errorf("service name is required")
+	}
+	return s.serviceDiridx(ctx, fmt.Sprintf("/nodes/%s/services/%s", s.Node, s.Name))
+}
+
+// TaskIndex enumerates the children of /nodes/{node}/tasks/{upid}
+// ("log", "status"). Use as a permission probe before calling Log/Ping.
+func (t *Task) TaskIndex(ctx context.Context) ([]string, error) {
+	if t.UPID == "" {
+		return nil, fmt.Errorf("task upid is required")
+	}
+	return t.taskDiridx(ctx, fmt.Sprintf("/nodes/%s/tasks/%s", t.Node, t.UPID))
+}
+
+// StorageStatus is the response of GET /nodes/{node}/storage/{storage}.
+// Despite its path being a diridx, PVE returns the storage's capability /
+// status object directly: type + plugin metadata (Active, Enabled, Shared),
+// declared Content types, and (when active) capacity counters. Numeric
+// fields are int/uint64 to match what the JSON envelope unmarshals into.
+type StorageStatus struct {
+	// Type is the storage plugin ("dir", "lvm", "lvmthin", "zfs", "nfs",
+	// "cifs", "pbs", "rbd", "cephfs", …).
+	Type string `json:"type,omitempty"`
+	// Content is the comma-joined list of content types the storage holds
+	// ("images,rootdir,iso,vztmpl,backup,snippets,import").
+	Content string `json:"content,omitempty"`
+	// Active is 1 when the storage is currently mounted/reachable on this
+	// node, 0 otherwise (e.g. unreachable NFS, disabled storage). Capacity
+	// fields are only populated when Active=1.
+	Active int `json:"active,omitempty"`
+	// Enabled is 1 when the storage is administratively enabled on this
+	// node (it may still be Active=0 if the underlying transport is down).
+	Enabled int `json:"enabled,omitempty"`
+	// Shared is 1 when PVE treats this storage as shared across the
+	// cluster (NFS, CIFS, Ceph, …) and 0 for node-local plugins.
+	Shared int `json:"shared,omitempty"`
+	// Total is the storage's total capacity in bytes; 0 when inactive.
+	Total uint64 `json:"total,omitempty"`
+	// Used is bytes currently used; 0 when inactive.
+	Used uint64 `json:"used,omitempty"`
+	// Avail is bytes available; 0 when inactive.
+	Avail uint64 `json:"avail,omitempty"`
+	// UsedFraction is Used/Total as a float in [0,1]; 0 when inactive.
+	UsedFraction float64 `json:"used_fraction,omitempty"`
+}
+
+// StorageIndex returns the status / capability object PVE publishes at
+// /nodes/{node}/storage/{storage}. Despite living at the directory-index
+// path, the schema is the storage's status payload (Active, Content types,
+// Type, Enabled, capacity counters), not the usual `[{"subdir":...}]`
+// envelope — see StorageStatus.
+func (s *Storage) StorageIndex(ctx context.Context) (status *StorageStatus, err error) {
+	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/storage/%s", s.Node, s.Name), &status)
+	return
+}
+
+// --- diridx helpers ---------------------------------------------------------
+//
+// Each helper does the same thing: GET path, decode [{"subdir":"x"}, ...] to
+// []string. They're per-receiver so the scanner's
+// `<recv>.<area>Diridx(ctx, path)` regex picks up every call site and treats
+// it as a GET against the path argument.
+
+func (n *Node) nodeDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, n.client, path)
+}
+
+func (n *Node) firewallDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, n.client, path)
+}
+
+func (n *Node) disksDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, n.client, path)
+}
+
+func (r *NodeReplicationJob) replicationDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, r.client, path)
+}
+
+func (s *NodeService) serviceDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, s.client, path)
+}
+
+func (t *Task) taskDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, t.client, path)
+}
+
+// decodeSubdirList is the underlying [{"subdir":...}] decoder. Centralised
+// so the per-receiver `<area>Diridx` helpers stay trivial one-liners.
+func decodeSubdirList(ctx context.Context, c *Client, path string) ([]string, error) {
+	var items []struct {
+		Subdir string `json:"subdir"`
+	}
+	if err := c.Get(ctx, path, &items); err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Subdir)
+	}
+	return out, nil
+}

--- a/nodes_diridx.go
+++ b/nodes_diridx.go
@@ -18,50 +18,50 @@ import (
 // mage/endpoints) treats the call site as a GET against the helper's path
 // argument.
 
-// NodeIndex enumerates the children of /nodes/{node} (typically "qemu",
+// Subdirs enumerates the children of /nodes/{node} (typically "qemu",
 // "lxc", "storage", "network", "tasks", "scan", "services", "subscription",
 // etc.). Useful as a permission probe: PVE filters the list by the caller's
 // ACLs, so the result tells you which sub-APIs the credential can read.
-func (n *Node) NodeIndex(ctx context.Context) ([]string, error) {
+func (n *Node) Subdirs(ctx context.Context) ([]string, error) {
 	return n.nodeDiridx(ctx, fmt.Sprintf("/nodes/%s", n.Name))
 }
 
-// FirewallIndex enumerates the children of /nodes/{node}/firewall
+// FirewallSubdirs enumerates the children of /nodes/{node}/firewall
 // ("rules", "options", "log").
-func (n *Node) FirewallIndex(ctx context.Context) ([]string, error) {
+func (n *Node) FirewallSubdirs(ctx context.Context) ([]string, error) {
 	return n.firewallDiridx(ctx, fmt.Sprintf("/nodes/%s/firewall", n.Name))
 }
 
-// DisksIndex enumerates the children of /nodes/{node}/disks ("list",
+// DisksSubdirs enumerates the children of /nodes/{node}/disks ("list",
 // "smart", "initgpt", "wipedisk", "directory", "lvm", "lvmthin", "zfs").
-func (n *Node) DisksIndex(ctx context.Context) ([]string, error) {
+func (n *Node) DisksSubdirs(ctx context.Context) ([]string, error) {
 	return n.disksDiridx(ctx, fmt.Sprintf("/nodes/%s/disks", n.Name))
 }
 
-// ReplicationIndex enumerates the children of
-// /nodes/{node}/replication/{id} ("status", "log", "schedule_now").
-// /nodes/{node}/replication (without {id}) is a true list endpoint, not a
-// diridx; use (*Node).Replications for that.
-func (r *NodeReplicationJob) ReplicationIndex(ctx context.Context) ([]string, error) {
+// Subdirs enumerates the children of /nodes/{node}/replication/{id}
+// ("status", "log", "schedule_now"). /nodes/{node}/replication (without
+// {id}) is a true list endpoint, not a diridx; use (*Node).Replications for
+// that.
+func (r *NodeReplicationJob) Subdirs(ctx context.Context) ([]string, error) {
 	if r.ID == "" {
 		return nil, fmt.Errorf("replication id is required")
 	}
 	return r.replicationDiridx(ctx, fmt.Sprintf("/nodes/%s/replication/%s", r.Node, r.ID))
 }
 
-// ServiceIndex enumerates the children of /nodes/{node}/services/{service}
+// Subdirs enumerates the children of /nodes/{node}/services/{service}
 // ("state", "start", "stop", "restart", "reload"). /nodes/{node}/services
 // (without {service}) is a true list endpoint — use (*Node).Services.
-func (s *NodeService) ServiceIndex(ctx context.Context) ([]string, error) {
+func (s *NodeService) Subdirs(ctx context.Context) ([]string, error) {
 	if s.Name == "" {
 		return nil, fmt.Errorf("service name is required")
 	}
 	return s.serviceDiridx(ctx, fmt.Sprintf("/nodes/%s/services/%s", s.Node, s.Name))
 }
 
-// TaskIndex enumerates the children of /nodes/{node}/tasks/{upid}
+// Subdirs enumerates the children of /nodes/{node}/tasks/{upid}
 // ("log", "status"). Use as a permission probe before calling Log/Ping.
-func (t *Task) TaskIndex(ctx context.Context) ([]string, error) {
+func (t *Task) Subdirs(ctx context.Context) ([]string, error) {
 	if t.UPID == "" {
 		return nil, fmt.Errorf("task upid is required")
 	}
@@ -100,12 +100,12 @@ type StorageStatus struct {
 	UsedFraction float64 `json:"used_fraction,omitempty"`
 }
 
-// StorageIndex returns the status / capability object PVE publishes at
-// /nodes/{node}/storage/{storage}. Despite living at the directory-index
-// path, the schema is the storage's status payload (Active, Content types,
-// Type, Enabled, capacity counters), not the usual `[{"subdir":...}]`
+// Status returns the storage's status / capability object from
+// GET /nodes/{node}/storage/{storage}. Despite living at the directory-index
+// path, PVE publishes the storage's status payload here (Active, Content
+// types, Type, Enabled, capacity counters), not the usual `[{"subdir":...}]`
 // envelope — see StorageStatus.
-func (s *Storage) StorageIndex(ctx context.Context) (status *StorageStatus, err error) {
+func (s *Storage) Status(ctx context.Context) (status *StorageStatus, err error) {
 	err = s.client.Get(ctx, fmt.Sprintf("/nodes/%s/storage/%s", s.Node, s.Name), &status)
 	return
 }

--- a/nodes_diridx_test.go
+++ b/nodes_diridx_test.go
@@ -1,0 +1,96 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func diridxNode() *Node {
+	return &Node{client: mockClient(), Name: "node1"}
+}
+
+func TestNode_NodeIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxNode().NodeIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subdirs, "qemu")
+	assert.Contains(t, subdirs, "lxc")
+	assert.Contains(t, subdirs, "storage")
+}
+
+func TestNode_FirewallIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxNode().FirewallIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"rules", "options", "log"}, subdirs)
+}
+
+func TestNode_DisksIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	subdirs, err := diridxNode().DisksIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subdirs, "list")
+	assert.Contains(t, subdirs, "smart")
+	assert.Contains(t, subdirs, "zfs")
+}
+
+func TestNodeReplicationJob_ReplicationIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	job := &NodeReplicationJob{client: mockClient(), Node: "node1", ID: "101-0"}
+	subdirs, err := job.ReplicationIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"status", "log", "schedule_now"}, subdirs)
+
+	empty := &NodeReplicationJob{client: mockClient(), Node: "node1"}
+	_, err = empty.ReplicationIndex(context.Background())
+	assert.NotNil(t, err)
+}
+
+func TestNodeService_ServiceIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	svc := &NodeService{client: mockClient(), Node: "node1", Name: "pveproxy"}
+	subdirs, err := svc.ServiceIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"state", "start", "stop", "restart", "reload"}, subdirs)
+
+	empty := &NodeService{client: mockClient(), Node: "node1"}
+	_, err = empty.ServiceIndex(context.Background())
+	assert.NotNil(t, err)
+}
+
+func TestTask_TaskIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	task := NewTask("UPID:node1:00000002:00000002:00000002:test:completed:root@pam:", mockClient())
+	subdirs, err := task.TaskIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"log", "status"}, subdirs)
+
+	empty := &Task{client: mockClient(), Node: "node1"}
+	_, err = empty.TaskIndex(context.Background())
+	assert.NotNil(t, err)
+}
+
+func TestStorage_StorageIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
+	status, err := storage.StorageIndex(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, status)
+	assert.Equal(t, "dir", status.Type)
+	assert.Equal(t, 1, status.Active)
+	assert.Equal(t, 1, status.Enabled)
+	assert.Equal(t, "images,rootdir,vztmpl,backup,iso,snippets", status.Content)
+	assert.Equal(t, uint64(60000000000), status.Total)
+	assert.Equal(t, uint64(10000000000), status.Used)
+	assert.Equal(t, uint64(50000000000), status.Avail)
+}

--- a/nodes_diridx_test.go
+++ b/nodes_diridx_test.go
@@ -12,78 +12,78 @@ func diridxNode() *Node {
 	return &Node{client: mockClient(), Name: "node1"}
 }
 
-func TestNode_NodeIndex(t *testing.T) {
+func TestNode_Subdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxNode().NodeIndex(context.Background())
+	subdirs, err := diridxNode().Subdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Contains(t, subdirs, "qemu")
 	assert.Contains(t, subdirs, "lxc")
 	assert.Contains(t, subdirs, "storage")
 }
 
-func TestNode_FirewallIndex(t *testing.T) {
+func TestNode_FirewallSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxNode().FirewallIndex(context.Background())
+	subdirs, err := diridxNode().FirewallSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"rules", "options", "log"}, subdirs)
 }
 
-func TestNode_DisksIndex(t *testing.T) {
+func TestNode_DisksSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	subdirs, err := diridxNode().DisksIndex(context.Background())
+	subdirs, err := diridxNode().DisksSubdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Contains(t, subdirs, "list")
 	assert.Contains(t, subdirs, "smart")
 	assert.Contains(t, subdirs, "zfs")
 }
 
-func TestNodeReplicationJob_ReplicationIndex(t *testing.T) {
+func TestNodeReplicationJob_Subdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	job := &NodeReplicationJob{client: mockClient(), Node: "node1", ID: "101-0"}
-	subdirs, err := job.ReplicationIndex(context.Background())
+	subdirs, err := job.Subdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"status", "log", "schedule_now"}, subdirs)
 
 	empty := &NodeReplicationJob{client: mockClient(), Node: "node1"}
-	_, err = empty.ReplicationIndex(context.Background())
+	_, err = empty.Subdirs(context.Background())
 	assert.NotNil(t, err)
 }
 
-func TestNodeService_ServiceIndex(t *testing.T) {
+func TestNodeService_Subdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	svc := &NodeService{client: mockClient(), Node: "node1", Name: "pveproxy"}
-	subdirs, err := svc.ServiceIndex(context.Background())
+	subdirs, err := svc.Subdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"state", "start", "stop", "restart", "reload"}, subdirs)
 
 	empty := &NodeService{client: mockClient(), Node: "node1"}
-	_, err = empty.ServiceIndex(context.Background())
+	_, err = empty.Subdirs(context.Background())
 	assert.NotNil(t, err)
 }
 
-func TestTask_TaskIndex(t *testing.T) {
+func TestTask_Subdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	task := NewTask("UPID:node1:00000002:00000002:00000002:test:completed:root@pam:", mockClient())
-	subdirs, err := task.TaskIndex(context.Background())
+	subdirs, err := task.Subdirs(context.Background())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"log", "status"}, subdirs)
 
 	empty := &Task{client: mockClient(), Node: "node1"}
-	_, err = empty.TaskIndex(context.Background())
+	_, err = empty.Subdirs(context.Background())
 	assert.NotNil(t, err)
 }
 
-func TestStorage_StorageIndex(t *testing.T) {
+func TestStorage_Status(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
 	storage := &Storage{client: mockClient(), Node: "node1", Name: "local"}
-	status, err := storage.StorageIndex(context.Background())
+	status, err := storage.Status(context.Background())
 	assert.Nil(t, err)
 	assert.NotNil(t, status)
 	assert.Equal(t, "dir", status.Type)

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -1641,4 +1641,132 @@ func clusterReplication() {
 		Delete("^/cluster/replication/100-0$").
 		Reply(200).
 		JSON(`{"data": null}`)
+
+	// --- diridx endpoints (see cluster_diridx.go) ---------------------------
+
+	// GET /cluster — cluster root diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"replication"},
+			{"subdir":"metrics"},
+			{"subdir":"config"},
+			{"subdir":"firewall"},
+			{"subdir":"backup"},
+			{"subdir":"backupinfo"},
+			{"subdir":"ha"},
+			{"subdir":"acme"},
+			{"subdir":"ceph"},
+			{"subdir":"jobs"},
+			{"subdir":"sdn"},
+			{"subdir":"log"},
+			{"subdir":"resources"},
+			{"subdir":"tasks"},
+			{"subdir":"options"},
+			{"subdir":"status"},
+			{"subdir":"nextid"}
+		]}`)
+
+	// GET /cluster/acme — acme diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/acme$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"plugins"},
+			{"subdir":"account"},
+			{"subdir":"tos"},
+			{"subdir":"meta"},
+			{"subdir":"directories"},
+			{"subdir":"challenge-schema"}
+		]}`)
+
+	// GET /cluster/firewall — cluster firewall diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/firewall$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"groups"},
+			{"subdir":"rules"},
+			{"subdir":"ipset"},
+			{"subdir":"aliases"},
+			{"subdir":"options"},
+			{"subdir":"macros"},
+			{"subdir":"refs"}
+		]}`)
+
+	// GET /cluster/sdn — cluster sdn diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"vnets"},
+			{"subdir":"zones"},
+			{"subdir":"controllers"},
+			{"subdir":"ipams"},
+			{"subdir":"dns"},
+			{"subdir":"fabrics"},
+			{"subdir":"subnets"}
+		]}`)
+
+	// GET /cluster/ceph — cluster ceph diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/ceph$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"metadata"},
+			{"subdir":"status"},
+			{"subdir":"flags"}
+		]}`)
+
+	// GET /cluster/config — cluster config diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/config$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"nodes"},
+			{"subdir":"join"},
+			{"subdir":"totem"},
+			{"subdir":"qdevice"},
+			{"subdir":"apiversion"}
+		]}`)
+
+	// GET /cluster/ha — cluster ha diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/ha$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"groups"},
+			{"subdir":"resources"},
+			{"subdir":"status"},
+			{"subdir":"rules"}
+		]}`)
+
+	// GET /cluster/ha/status — cluster ha status diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/ha/status$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"current"},
+			{"subdir":"manager_status"}
+		]}`)
+
+	// GET /cluster/qemu — cluster qemu diridx (subdirs are VMIDs)
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/qemu$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"100"},
+			{"subdir":"101"},
+			{"subdir":"200"}
+		]}`)
 }

--- a/tests/mocks/pve9x/nodes.go
+++ b/tests/mocks/pve9x/nodes.go
@@ -1086,4 +1086,92 @@ func nodes() {
 		Delete("^/nodes/node1/disks/zfs/rpool").
 		Reply(200).
 		JSON(`{"data": "UPID:node1:00001234:00005678:12345678:rmzfs:rpool:root@pam:"}`)
+
+	// --- diridx endpoints (see nodes_diridx.go) ----------------------------
+
+	// GET /nodes/{node} — node root diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"qemu"},
+			{"subdir":"lxc"},
+			{"subdir":"storage"},
+			{"subdir":"network"},
+			{"subdir":"tasks"},
+			{"subdir":"services"},
+			{"subdir":"subscription"},
+			{"subdir":"firewall"},
+			{"subdir":"replication"}
+		]}`)
+
+	// GET /nodes/{node}/firewall — node firewall diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/firewall$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"rules"},
+			{"subdir":"options"},
+			{"subdir":"log"}
+		]}`)
+
+	// GET /nodes/{node}/disks — node disks diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/disks$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"list"},
+			{"subdir":"smart"},
+			{"subdir":"initgpt"},
+			{"subdir":"wipedisk"},
+			{"subdir":"directory"},
+			{"subdir":"lvm"},
+			{"subdir":"lvmthin"},
+			{"subdir":"zfs"}
+		]}`)
+
+	// GET /nodes/{node}/services/{service} — per-service diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/services/pveproxy$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"state"},
+			{"subdir":"start"},
+			{"subdir":"stop"},
+			{"subdir":"restart"},
+			{"subdir":"reload"}
+		]}`)
+
+	// GET /nodes/{node}/replication/{id} — per-replication-job diridx
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/replication/101-0$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"status"},
+			{"subdir":"log"},
+			{"subdir":"schedule_now"}
+		]}`)
+
+	// GET /nodes/{node}/storage/{storage} — diridx path that returns the
+	// storage's status/capability object directly (not a subdir list).
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/storage/local$").
+		Reply(200).
+		JSON(`{"data":{
+			"type":"dir",
+			"content":"images,rootdir,vztmpl,backup,iso,snippets",
+			"active":1,
+			"enabled":1,
+			"shared":0,
+			"total":60000000000,
+			"used":10000000000,
+			"avail":50000000000,
+			"used_fraction":0.16667
+		}}`)
 }

--- a/tests/mocks/pve9x/tasks.go
+++ b/tests/mocks/pve9x/tasks.go
@@ -114,4 +114,14 @@ func tasks() {
         {"n": 2, "t": "processing..."}
     ]
 }`)
+
+	// GET /nodes/{node}/tasks/{upid} — per-task diridx (see nodes_diridx.go).
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/nodes/node1/tasks/UPID:node1:00000002:00000002:00000002:test:completed:root@pam:$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"log"},
+			{"subdir":"status"}
+		]}`)
 }


### PR DESCRIPTION
## Summary

Adds Go wrappers for the 15 remaining PVE `/nodes/{node}/*` and `/cluster/*` directory-index ("diridx") endpoints. These are the supported permission-probe / capability-discovery surface — PVE filters the returned subdir list by the caller's ACLs, and they exist on every supported PVE version, so they give a stable cross-version surface for "what can this credential see here?" introspection. The web UI itself uses these to decide which menu items to render.

### Endpoints wrapped

Nodes (7):
- `GET /nodes/{node}` -> `(*Node).NodeIndex`
- `GET /nodes/{node}/firewall` -> `(*Node).FirewallIndex`
- `GET /nodes/{node}/disks` -> `(*Node).DisksIndex`
- `GET /nodes/{node}/replication/{id}` -> `(*NodeReplicationJob).ReplicationIndex`
- `GET /nodes/{node}/services/{service}` -> `(*NodeService).ServiceIndex`
- `GET /nodes/{node}/storage/{storage}` -> `(*Storage).StorageIndex` (returns `*StorageStatus`)
- `GET /nodes/{node}/tasks/{upid}` -> `(*Task).TaskIndex`

Cluster (8):
- `GET /cluster` -> `(*Cluster).ClusterIndex`
- `GET /cluster/acme` -> `(*Cluster).ACMEIndex`
- `GET /cluster/firewall` -> `(*Cluster).FirewallIndex`
- `GET /cluster/sdn` -> `(*Cluster).SDNIndex`
- `GET /cluster/ceph` -> `(*Cluster).CephIndex`
- `GET /cluster/config` -> `(*Cluster).ConfigIndex`
- `GET /cluster/ha` -> `(*Cluster).HAIndex`
- `GET /cluster/ha/status` -> `(*Cluster).HAStatusIndex`
- `GET /cluster/qemu` -> `(*Cluster).QEMUIndex`

## Why

These endpoints look like noise at a glance — they return `[{"subdir":"x"}, ...]` and the names of the children are well-known to anyone who has read the PVE docs. The reason to wrap them anyway:

1. **ACL-filtered permission probes.** PVE strips entries the caller is not authorized to see. A 200 response with a missing subdir tells you the credential lacks the privilege for that subtree — strictly cheaper than calling each child endpoint and waiting for a 403.
2. **Capability discovery across PVE versions.** When PVE adds or removes a subresource (e.g. when `fabrics/` landed under `/sdn/`), the diridx is the canonical place to detect that without hard-coding version checks.
3. **UI parity with the web UI.** PVE's own JS console drives its tree from these endpoints; library callers building UIs (terraform providers, dashboards) want the same affordance.

`/nodes/{node}/storage/{storage}` is the special case: despite living at the directory-index path, PVE actually returns the storage's capability / status object directly (type, content types, active/enabled flags, capacity counters). Modeled as a new `StorageStatus` type rather than a `[]string`.

Helpers follow the `<area>Diridx(ctx, path)` shape established by `(*Node).sdnDiridx` and `(*Node).capabilitiesDiridx`, so PR #318's scanner regex picks them up automatically as GET call sites and the coverage report reflects them. Verified locally against the PR #318 scanner: all 15 endpoints (16 paths — `/cluster/ha` and `/cluster/ha/status` are distinct) drop out of `.cache/pve-api/coverage.txt`.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 .` green (full suite)
- [x] New tests cover each wrapper happy path + required-arg error path
- [x] Mock fixtures added to `tests/mocks/pve9x/{nodes,cluster,tasks}.go`
- [x] Spot-checked coverage: rebased onto PR #318 scanner locally; all 16 endpoint paths disappear from the missing list