### PR TITLE
feat(cluster): wrap /cluster/sdn — controllers, dns, fabrics, ipams, prefix-lists, route-maps, vnets/firewall+ips+subnets

### DIFF
--- a/cluster_sdn.go
+++ b/cluster_sdn.go
@@ -20,11 +20,23 @@ func (cl *Cluster) SDNApply(ctx context.Context) (*Task, error) {
 }
 
 func (cl *Cluster) SDNVNets(ctx context.Context) (vnets []*VNet, err error) {
-	return vnets, cl.client.Get(ctx, "/cluster/sdn/vnets", &vnets)
+	if err = cl.client.Get(ctx, "/cluster/sdn/vnets", &vnets); err != nil {
+		return nil, err
+	}
+	for _, v := range vnets {
+		v.client = cl.client
+	}
+	return
 }
 
 func (cl *Cluster) SDNVNet(ctx context.Context, name string) (vnet *VNet, err error) {
-	return vnet, cl.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s", name), &vnet)
+	if err = cl.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s", name), &vnet); err != nil {
+		return nil, err
+	}
+	if vnet != nil {
+		vnet.client = cl.client
+	}
+	return
 }
 
 func (cl *Cluster) NewSDNVNet(ctx context.Context, vnet *VNetOptions) error {

--- a/cluster_sdn_controllers.go
+++ b/cluster_sdn_controllers.go
@@ -1,0 +1,84 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// SDNControllers lists configured SDN controllers. typ filters by plugin type
+// (e.g. "bgp", "evpn"); pass "" for all.
+//
+// GET /cluster/sdn/controllers
+func (cl *Cluster) SDNControllers(ctx context.Context, typ string) (controllers []*SDNController, err error) {
+	path := "/cluster/sdn/controllers"
+	if typ != "" {
+		q := url.Values{}
+		q.Set("type", typ)
+		path = path + "?" + q.Encode()
+	}
+	if err = cl.client.Get(ctx, path, &controllers); err != nil {
+		return nil, err
+	}
+	for _, c := range controllers {
+		c.client = cl.client
+	}
+	return
+}
+
+// SDNController returns a handle for a single SDN controller. No API call is
+// made; use the returned handle's Read to populate it.
+//
+// GET /cluster/sdn/controllers/{controller}
+func (cl *Cluster) SDNController(name string) *SDNController {
+	return &SDNController{client: cl.client, Controller: name}
+}
+
+// NewSDNController creates a new SDN controller object. opts.Controller and
+// opts.Type are required.
+//
+// POST /cluster/sdn/controllers
+func (cl *Cluster) NewSDNController(ctx context.Context, opts *SDNControllerOptions) error {
+	if opts == nil || opts.Controller == "" {
+		return errors.New("sdn controller name is required")
+	}
+	if opts.Type == "" {
+		return errors.New("sdn controller type is required")
+	}
+	return cl.client.Post(ctx, "/cluster/sdn/controllers", opts, nil)
+}
+
+// Read populates the receiver with the current configuration of the controller.
+//
+// GET /cluster/sdn/controllers/{controller}
+func (c *SDNController) Read(ctx context.Context) error {
+	if c.Controller == "" {
+		return errors.New("sdn controller name is required")
+	}
+	return c.client.Get(ctx, fmt.Sprintf("/cluster/sdn/controllers/%s", c.Controller), c)
+}
+
+// Update mutates an existing controller. opts.Delete may be a comma-separated
+// list of keys to reset to PVE defaults.
+//
+// PUT /cluster/sdn/controllers/{controller}
+func (c *SDNController) Update(ctx context.Context, opts *SDNControllerOptions) error {
+	if c.Controller == "" {
+		return errors.New("sdn controller name is required")
+	}
+	if opts == nil {
+		opts = &SDNControllerOptions{}
+	}
+	return c.client.Put(ctx, fmt.Sprintf("/cluster/sdn/controllers/%s", c.Controller), opts, nil)
+}
+
+// Delete removes the SDN controller.
+//
+// DELETE /cluster/sdn/controllers/{controller}
+func (c *SDNController) Delete(ctx context.Context) error {
+	if c.Controller == "" {
+		return errors.New("sdn controller name is required")
+	}
+	return c.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/controllers/%s", c.Controller), nil)
+}

--- a/cluster_sdn_controllers_test.go
+++ b/cluster_sdn_controllers_test.go
@@ -1,0 +1,62 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNControllers(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	controllers, err := cluster.SDNControllers(context.Background(), "")
+	assert.Nil(t, err)
+	assert.Len(t, controllers, 2)
+	assert.Equal(t, "ctrl1", controllers[0].Controller)
+	assert.Equal(t, "evpn", controllers[0].Type)
+}
+
+func TestCluster_SDNController(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	c := cluster.SDNController("ctrl1")
+	assert.NotNil(t, c)
+	err := c.Read(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, uint32(65000), c.ASN)
+	assert.Equal(t, "VTEP", c.PeerGroupName)
+}
+
+func TestCluster_NewSDNController(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNController(context.Background(), &SDNControllerOptions{Controller: "ctrl3", Type: "bgp", ASN: 65002})
+	assert.Nil(t, err)
+
+	err = cluster.NewSDNController(context.Background(), nil)
+	assert.NotNil(t, err)
+
+	err = cluster.NewSDNController(context.Background(), &SDNControllerOptions{Controller: "ctrl3"})
+	assert.NotNil(t, err)
+}
+
+func TestSDNController_UpdateDelete(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	c := cluster.SDNController("ctrl1")
+	err := c.Update(context.Background(), &SDNControllerOptions{ASN: 65010})
+	assert.Nil(t, err)
+
+	err = c.Delete(context.Background())
+	assert.Nil(t, err)
+}

--- a/cluster_sdn_dns.go
+++ b/cluster_sdn_dns.go
@@ -1,0 +1,82 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// SDNDNSList lists configured SDN DNS plugins. typ filters by plugin type
+// (currently only "powerdns" is supported by PVE); pass "" for all.
+//
+// GET /cluster/sdn/dns
+func (cl *Cluster) SDNDNSList(ctx context.Context, typ string) (dns []*SDNDNS, err error) {
+	path := "/cluster/sdn/dns"
+	if typ != "" {
+		q := url.Values{}
+		q.Set("type", typ)
+		path = path + "?" + q.Encode()
+	}
+	if err = cl.client.Get(ctx, path, &dns); err != nil {
+		return nil, err
+	}
+	for _, d := range dns {
+		d.client = cl.client
+	}
+	return
+}
+
+// SDNDNS returns a handle for a single SDN DNS plugin. No API call is made.
+//
+// GET /cluster/sdn/dns/{dns}
+func (cl *Cluster) SDNDNS(name string) *SDNDNS {
+	return &SDNDNS{client: cl.client, DNS: name}
+}
+
+// NewSDNDNS creates a new SDN DNS plugin. opts.DNS, opts.Type, opts.URL and
+// opts.Key are required.
+//
+// POST /cluster/sdn/dns
+func (cl *Cluster) NewSDNDNS(ctx context.Context, opts *SDNDNSOptions) error {
+	if opts == nil || opts.DNS == "" {
+		return errors.New("sdn dns name is required")
+	}
+	if opts.Type == "" {
+		return errors.New("sdn dns type is required")
+	}
+	return cl.client.Post(ctx, "/cluster/sdn/dns", opts, nil)
+}
+
+// Read populates the receiver with the current configuration.
+//
+// GET /cluster/sdn/dns/{dns}
+func (d *SDNDNS) Read(ctx context.Context) error {
+	if d.DNS == "" {
+		return errors.New("sdn dns name is required")
+	}
+	return d.client.Get(ctx, fmt.Sprintf("/cluster/sdn/dns/%s", d.DNS), d)
+}
+
+// Update mutates an existing SDN DNS plugin configuration.
+//
+// PUT /cluster/sdn/dns/{dns}
+func (d *SDNDNS) Update(ctx context.Context, opts *SDNDNSOptions) error {
+	if d.DNS == "" {
+		return errors.New("sdn dns name is required")
+	}
+	if opts == nil {
+		opts = &SDNDNSOptions{}
+	}
+	return d.client.Put(ctx, fmt.Sprintf("/cluster/sdn/dns/%s", d.DNS), opts, nil)
+}
+
+// Delete removes the SDN DNS plugin.
+//
+// DELETE /cluster/sdn/dns/{dns}
+func (d *SDNDNS) Delete(ctx context.Context) error {
+	if d.DNS == "" {
+		return errors.New("sdn dns name is required")
+	}
+	return d.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/dns/%s", d.DNS), nil)
+}

--- a/cluster_sdn_dns_test.go
+++ b/cluster_sdn_dns_test.go
@@ -1,0 +1,46 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNDNSList(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	dns, err := cluster.SDNDNSList(context.Background(), "")
+	assert.Nil(t, err)
+	assert.Len(t, dns, 1)
+	assert.Equal(t, "pdns1", dns[0].DNS)
+}
+
+func TestSDNDNS_CRUD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	d := cluster.SDNDNS("pdns1")
+	assert.Nil(t, d.Read(context.Background()))
+	assert.Equal(t, "powerdns", d.Type)
+	assert.Equal(t, 3600, d.TTL)
+
+	assert.Nil(t, d.Update(context.Background(), &SDNDNSOptions{TTL: 7200}))
+	assert.Nil(t, d.Delete(context.Background()))
+}
+
+func TestCluster_NewSDNDNS(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNDNS(context.Background(), &SDNDNSOptions{DNS: "pdns2", Type: "powerdns", URL: "https://x", Key: "k"})
+	assert.Nil(t, err)
+
+	assert.NotNil(t, cluster.NewSDNDNS(context.Background(), nil))
+	assert.NotNil(t, cluster.NewSDNDNS(context.Background(), &SDNDNSOptions{DNS: "x"}))
+}

--- a/cluster_sdn_fabrics.go
+++ b/cluster_sdn_fabrics.go
@@ -1,0 +1,198 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// SDNFabricsIndex returns the directory entries under /cluster/sdn/fabrics
+// (currently {"fabric", "node", "all"} subdirs).
+//
+// GET /cluster/sdn/fabrics
+func (cl *Cluster) SDNFabricsIndex(ctx context.Context) (entries []map[string]any, err error) {
+	err = cl.client.Get(ctx, "/cluster/sdn/fabrics", &entries)
+	return
+}
+
+// SDNFabricsAll returns the combined view of all fabrics and their member
+// nodes — useful for rendering the whole SDN underlay in one call.
+//
+// GET /cluster/sdn/fabrics/all
+func (cl *Cluster) SDNFabricsAll(ctx context.Context) (all *SDNFabricsAll, err error) {
+	all = &SDNFabricsAll{}
+	err = cl.client.Get(ctx, "/cluster/sdn/fabrics/all", all)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range all.Fabrics {
+		f.client = cl.client
+	}
+	for _, n := range all.Nodes {
+		n.client = cl.client
+	}
+	return
+}
+
+// SDNFabrics lists configured fabrics. pending/running toggle the
+// returned configuration (PVE distinguishes pending changes from running config).
+//
+// GET /cluster/sdn/fabrics/fabric
+func (cl *Cluster) SDNFabrics(ctx context.Context, pending, running bool) (fabrics []*SDNFabric, err error) {
+	path := "/cluster/sdn/fabrics/fabric"
+	q := url.Values{}
+	if pending {
+		q.Set("pending", "1")
+	}
+	if running {
+		q.Set("running", "1")
+	}
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	if err = cl.client.Get(ctx, path, &fabrics); err != nil {
+		return nil, err
+	}
+	for _, f := range fabrics {
+		f.client = cl.client
+	}
+	return
+}
+
+// SDNFabric returns a handle for a single fabric. No API call is made.
+//
+// GET /cluster/sdn/fabrics/fabric/{id}
+func (cl *Cluster) SDNFabric(id string) *SDNFabric {
+	return &SDNFabric{client: cl.client, ID: id}
+}
+
+// NewSDNFabric creates a new fabric. opts.ID and opts.Protocol are required.
+//
+// POST /cluster/sdn/fabrics/fabric
+func (cl *Cluster) NewSDNFabric(ctx context.Context, opts *SDNFabricOptions) error {
+	if opts == nil || opts.ID == "" {
+		return errors.New("sdn fabric id is required")
+	}
+	if opts.Protocol == "" {
+		return errors.New("sdn fabric protocol is required")
+	}
+	return cl.client.Post(ctx, "/cluster/sdn/fabrics/fabric", opts, nil)
+}
+
+// Read populates the receiver with the current fabric configuration.
+//
+// GET /cluster/sdn/fabrics/fabric/{id}
+func (f *SDNFabric) Read(ctx context.Context) error {
+	if f.ID == "" {
+		return errors.New("sdn fabric id is required")
+	}
+	return f.client.Get(ctx, fmt.Sprintf("/cluster/sdn/fabrics/fabric/%s", f.ID), f)
+}
+
+// Update mutates a fabric configuration.
+//
+// PUT /cluster/sdn/fabrics/fabric/{id}
+func (f *SDNFabric) Update(ctx context.Context, opts *SDNFabricOptions) error {
+	if f.ID == "" {
+		return errors.New("sdn fabric id is required")
+	}
+	if opts == nil {
+		opts = &SDNFabricOptions{}
+	}
+	return f.client.Put(ctx, fmt.Sprintf("/cluster/sdn/fabrics/fabric/%s", f.ID), opts, nil)
+}
+
+// Delete removes the fabric.
+//
+// DELETE /cluster/sdn/fabrics/fabric/{id}
+func (f *SDNFabric) Delete(ctx context.Context) error {
+	if f.ID == "" {
+		return errors.New("sdn fabric id is required")
+	}
+	return f.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/fabrics/fabric/%s", f.ID), nil)
+}
+
+// Nodes lists nodes participating in this fabric.
+//
+// GET /cluster/sdn/fabrics/node/{fabric_id}
+func (f *SDNFabric) Nodes(ctx context.Context) (nodes []*SDNFabricNode, err error) {
+	if f.ID == "" {
+		return nil, errors.New("sdn fabric id is required")
+	}
+	if err = f.client.Get(ctx, fmt.Sprintf("/cluster/sdn/fabrics/node/%s", f.ID), &nodes); err != nil {
+		return nil, err
+	}
+	for _, n := range nodes {
+		n.client = f.client
+		n.FabricID = f.ID
+	}
+	return
+}
+
+// Node returns a handle for a single node in this fabric. No API call is made.
+//
+// GET /cluster/sdn/fabrics/node/{fabric_id}/{node_id}
+func (f *SDNFabric) Node(nodeID string) *SDNFabricNode {
+	return &SDNFabricNode{client: f.client, FabricID: f.ID, NodeID: nodeID}
+}
+
+// AddNode adds a node to this fabric. opts.NodeID is required.
+//
+// POST /cluster/sdn/fabrics/node/{fabric_id}
+func (f *SDNFabric) AddNode(ctx context.Context, opts *SDNFabricNodeOptions) error {
+	if f.ID == "" {
+		return errors.New("sdn fabric id is required")
+	}
+	if opts == nil || opts.NodeID == "" {
+		return errors.New("sdn fabric node id is required")
+	}
+	return f.client.Post(ctx, fmt.Sprintf("/cluster/sdn/fabrics/node/%s", f.ID), opts, nil)
+}
+
+// SDNFabricNodes lists all SDN fabric/node pairs across every fabric — the
+// flat alternative to per-fabric iteration via SDNFabric.Nodes.
+//
+// GET /cluster/sdn/fabrics/node
+func (cl *Cluster) SDNFabricNodes(ctx context.Context) (nodes []*SDNFabricNode, err error) {
+	if err = cl.client.Get(ctx, "/cluster/sdn/fabrics/node", &nodes); err != nil {
+		return nil, err
+	}
+	for _, n := range nodes {
+		n.client = cl.client
+	}
+	return
+}
+
+// Read populates the receiver with the current fabric-node configuration.
+//
+// GET /cluster/sdn/fabrics/node/{fabric_id}/{node_id}
+func (n *SDNFabricNode) Read(ctx context.Context) error {
+	if n.FabricID == "" || n.NodeID == "" {
+		return errors.New("sdn fabric and node id are required")
+	}
+	return n.client.Get(ctx, fmt.Sprintf("/cluster/sdn/fabrics/node/%s/%s", n.FabricID, n.NodeID), n)
+}
+
+// Update mutates a fabric-node configuration.
+//
+// PUT /cluster/sdn/fabrics/node/{fabric_id}/{node_id}
+func (n *SDNFabricNode) Update(ctx context.Context, opts *SDNFabricNodeOptions) error {
+	if n.FabricID == "" || n.NodeID == "" {
+		return errors.New("sdn fabric and node id are required")
+	}
+	if opts == nil {
+		opts = &SDNFabricNodeOptions{}
+	}
+	return n.client.Put(ctx, fmt.Sprintf("/cluster/sdn/fabrics/node/%s/%s", n.FabricID, n.NodeID), opts, nil)
+}
+
+// Delete removes the node from the fabric.
+//
+// DELETE /cluster/sdn/fabrics/node/{fabric_id}/{node_id}
+func (n *SDNFabricNode) Delete(ctx context.Context) error {
+	if n.FabricID == "" || n.NodeID == "" {
+		return errors.New("sdn fabric and node id are required")
+	}
+	return n.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/fabrics/node/%s/%s", n.FabricID, n.NodeID), nil)
+}

--- a/cluster_sdn_fabrics_test.go
+++ b/cluster_sdn_fabrics_test.go
@@ -1,0 +1,115 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNFabricsIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.SDNFabricsIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, entries, 3)
+}
+
+func TestCluster_SDNFabricsAll(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	all, err := cluster.SDNFabricsAll(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, all.Fabrics, 1)
+	assert.Len(t, all.Nodes, 1)
+	assert.Equal(t, "fab1", all.Fabrics[0].ID)
+}
+
+func TestCluster_SDNFabrics(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	fabrics, err := cluster.SDNFabrics(context.Background(), false, false)
+	assert.Nil(t, err)
+	assert.Len(t, fabrics, 2)
+}
+
+func TestSDNFabric_CRUD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	f := cluster.SDNFabric("fab1")
+	assert.Nil(t, f.Read(context.Background()))
+	assert.Equal(t, "openfabric", f.Protocol)
+
+	assert.Nil(t, f.Update(context.Background(), &SDNFabricOptions{HelloInterval: 5}))
+	assert.Nil(t, f.Delete(context.Background()))
+}
+
+func TestCluster_NewSDNFabric(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNFabric(context.Background(), &SDNFabricOptions{ID: "fab9", Protocol: "ospf"})
+	assert.Nil(t, err)
+
+	assert.NotNil(t, cluster.NewSDNFabric(context.Background(), nil))
+	assert.NotNil(t, cluster.NewSDNFabric(context.Background(), &SDNFabricOptions{ID: "x"}))
+}
+
+func TestSDNFabric_Nodes(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	f := cluster.SDNFabric("fab1")
+	nodes, err := f.Nodes(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, nodes, 2)
+	assert.Equal(t, "node1", nodes[0].NodeID)
+	assert.Equal(t, "fab1", nodes[0].FabricID)
+}
+
+func TestCluster_SDNFabricNodes(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	nodes, err := cluster.SDNFabricNodes(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, nodes, 2)
+}
+
+func TestSDNFabricNode_CRUD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	f := cluster.SDNFabric("fab1")
+	n := f.Node("node1")
+	assert.Nil(t, n.Read(context.Background()))
+	assert.Equal(t, "10.0.0.1", n.IP)
+
+	assert.Nil(t, n.Update(context.Background(), &SDNFabricNodeOptions{}))
+	assert.Nil(t, n.Delete(context.Background()))
+}
+
+func TestSDNFabric_AddNode(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	f := cluster.SDNFabric("fab1")
+	err := f.AddNode(context.Background(), &SDNFabricNodeOptions{NodeID: "node3"})
+	assert.Nil(t, err)
+
+	assert.NotNil(t, f.AddNode(context.Background(), nil))
+}

--- a/cluster_sdn_ipams.go
+++ b/cluster_sdn_ipams.go
@@ -1,0 +1,94 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// SDNIPAMs lists configured IPAM backends. typ filters by plugin type
+// ("netbox", "phpipam", "pve"); pass "" for all.
+//
+// GET /cluster/sdn/ipams
+func (cl *Cluster) SDNIPAMs(ctx context.Context, typ string) (ipams []*SDNIPAM, err error) {
+	path := "/cluster/sdn/ipams"
+	if typ != "" {
+		q := url.Values{}
+		q.Set("type", typ)
+		path = path + "?" + q.Encode()
+	}
+	if err = cl.client.Get(ctx, path, &ipams); err != nil {
+		return nil, err
+	}
+	for _, i := range ipams {
+		i.client = cl.client
+	}
+	return
+}
+
+// SDNIPAM returns a handle for a single IPAM backend. No API call is made.
+//
+// GET /cluster/sdn/ipams/{ipam}
+func (cl *Cluster) SDNIPAM(name string) *SDNIPAM {
+	return &SDNIPAM{client: cl.client, IPAM: name}
+}
+
+// NewSDNIPAM creates a new IPAM backend. opts.IPAM and opts.Type are required.
+//
+// POST /cluster/sdn/ipams
+func (cl *Cluster) NewSDNIPAM(ctx context.Context, opts *SDNIPAMOptions) error {
+	if opts == nil || opts.IPAM == "" {
+		return errors.New("sdn ipam name is required")
+	}
+	if opts.Type == "" {
+		return errors.New("sdn ipam type is required")
+	}
+	return cl.client.Post(ctx, "/cluster/sdn/ipams", opts, nil)
+}
+
+// Read populates the receiver with the current configuration.
+//
+// GET /cluster/sdn/ipams/{ipam}
+func (i *SDNIPAM) Read(ctx context.Context) error {
+	if i.IPAM == "" {
+		return errors.New("sdn ipam name is required")
+	}
+	return i.client.Get(ctx, fmt.Sprintf("/cluster/sdn/ipams/%s", i.IPAM), i)
+}
+
+// Update mutates an existing IPAM backend configuration.
+//
+// PUT /cluster/sdn/ipams/{ipam}
+func (i *SDNIPAM) Update(ctx context.Context, opts *SDNIPAMOptions) error {
+	if i.IPAM == "" {
+		return errors.New("sdn ipam name is required")
+	}
+	if opts == nil {
+		opts = &SDNIPAMOptions{}
+	}
+	return i.client.Put(ctx, fmt.Sprintf("/cluster/sdn/ipams/%s", i.IPAM), opts, nil)
+}
+
+// Delete removes the IPAM backend.
+//
+// DELETE /cluster/sdn/ipams/{ipam}
+func (i *SDNIPAM) Delete(ctx context.Context) error {
+	if i.IPAM == "" {
+		return errors.New("sdn ipam name is required")
+	}
+	return i.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/ipams/%s", i.IPAM), nil)
+}
+
+// Status returns the list of IP entries from this IPAM. The shape of each
+// entry is plugin-specific so it's returned as a free-form slice of maps; use
+// the typed IPAM struct (cluster/sdn types) for known fields.
+//
+// GET /cluster/sdn/ipams/{ipam}/status
+func (i *SDNIPAM) Status(ctx context.Context) (entries []map[string]any, err error) {
+	if i.IPAM == "" {
+		return nil, errors.New("sdn ipam name is required")
+	}
+	err = i.client.Get(ctx, fmt.Sprintf("/cluster/sdn/ipams/%s/status", i.IPAM), &entries)
+	return
+}

--- a/cluster_sdn_ipams_test.go
+++ b/cluster_sdn_ipams_test.go
@@ -1,0 +1,57 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNIPAMs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	ipams, err := cluster.SDNIPAMs(context.Background(), "")
+	assert.Nil(t, err)
+	assert.Len(t, ipams, 2)
+	assert.Equal(t, "pve", ipams[0].IPAM)
+}
+
+func TestSDNIPAM_ReadUpdateDelete(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	i := cluster.SDNIPAM("pve")
+	assert.Nil(t, i.Read(context.Background()))
+	assert.Equal(t, "pve", i.Type)
+
+	assert.Nil(t, i.Update(context.Background(), &SDNIPAMOptions{}))
+	assert.Nil(t, i.Delete(context.Background()))
+}
+
+func TestSDNIPAM_Status(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	i := cluster.SDNIPAM("pve")
+	entries, err := i.Status(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "vm100", entries[0]["hostname"])
+}
+
+func TestCluster_NewSDNIPAM(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNIPAM(context.Background(), &SDNIPAMOptions{IPAM: "netbox2", Type: "netbox", URL: "https://x"})
+	assert.Nil(t, err)
+
+	assert.NotNil(t, cluster.NewSDNIPAM(context.Background(), nil))
+	assert.NotNil(t, cluster.NewSDNIPAM(context.Background(), &SDNIPAMOptions{IPAM: "x"}))
+}

--- a/cluster_sdn_misc.go
+++ b/cluster_sdn_misc.go
@@ -1,0 +1,87 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"net/url"
+)
+
+// SDNIndex returns the directory entries under /cluster/sdn.
+//
+// GET /cluster/sdn
+func (cl *Cluster) SDNIndex(ctx context.Context) (entries []map[string]any, err error) {
+	err = cl.client.Get(ctx, "/cluster/sdn", &entries)
+	return
+}
+
+// SDNLock acquires the global SDN configuration lock. The returned token must
+// be passed as LockToken on subsequent mutating SDN endpoints (controllers,
+// fabrics, IPAMs, etc.) and on SDNRollback/SDNReleaseLock.
+//
+// allowPending lets the lock be acquired even if there are pending changes.
+//
+// POST /cluster/sdn/lock
+func (cl *Cluster) SDNLock(ctx context.Context, allowPending bool) (SDNLockToken, error) {
+	body := map[string]any{}
+	if allowPending {
+		body["allow-pending"] = 1
+	}
+	var token string
+	if err := cl.client.Post(ctx, "/cluster/sdn/lock", body, &token); err != nil {
+		return "", err
+	}
+	return SDNLockToken(token), nil
+}
+
+// SDNReleaseLock releases the global SDN configuration lock. Pass force=true
+// to release without providing the matching token (admin override).
+//
+// DELETE /cluster/sdn/lock
+func (cl *Cluster) SDNReleaseLock(ctx context.Context, token SDNLockToken, force bool) error {
+	path := "/cluster/sdn/lock"
+	q := url.Values{}
+	if token != "" {
+		q.Set("lock-token", string(token))
+	}
+	if force {
+		q.Set("force", "1")
+	}
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	return cl.client.Delete(ctx, path, nil)
+}
+
+// SDNRollback discards pending SDN configuration changes. token may be empty
+// when no lock is held. releaseLock controls whether the lock is released on
+// success (PVE default: true).
+//
+// POST /cluster/sdn/rollback
+func (cl *Cluster) SDNRollback(ctx context.Context, token SDNLockToken, releaseLock bool) error {
+	body := map[string]any{}
+	if token != "" {
+		body["lock-token"] = string(token)
+	}
+	if !releaseLock {
+		// PVE default is release-lock=1; only emit the override.
+		body["release-lock"] = 0
+	}
+	return cl.client.Post(ctx, "/cluster/sdn/rollback", body, nil)
+}
+
+// SDNDryRun returns the diff (FRR + /etc/network/interfaces.d/sdn) between the
+// current and pending SDN configuration on a specific node.
+//
+// GET /cluster/sdn/dry-run
+func (cl *Cluster) SDNDryRun(ctx context.Context, node string) (*SDNDryRun, error) {
+	if node == "" {
+		return nil, errors.New("node is required")
+	}
+	q := url.Values{}
+	q.Set("node", node)
+	out := &SDNDryRun{}
+	if err := cl.client.Get(ctx, "/cluster/sdn/dry-run?"+q.Encode(), out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/cluster_sdn_misc_test.go
+++ b/cluster_sdn_misc_test.go
@@ -1,0 +1,64 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.SDNIndex(context.Background())
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entries)
+}
+
+func TestCluster_SDNLock(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	token, err := cluster.SDNLock(context.Background(), false)
+	assert.Nil(t, err)
+	assert.Equal(t, SDNLockToken("tok-abc123"), token)
+}
+
+func TestCluster_SDNReleaseLock(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.SDNReleaseLock(context.Background(), SDNLockToken("tok-abc123"), false)
+	assert.Nil(t, err)
+
+	err = cluster.SDNReleaseLock(context.Background(), "", true)
+	assert.Nil(t, err)
+}
+
+func TestCluster_SDNRollback(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	assert.Nil(t, cluster.SDNRollback(context.Background(), SDNLockToken("tok-abc123"), true))
+	assert.Nil(t, cluster.SDNRollback(context.Background(), "", false))
+}
+
+func TestCluster_SDNDryRun(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	diff, err := cluster.SDNDryRun(context.Background(), "node1")
+	assert.Nil(t, err)
+	assert.Contains(t, diff.FRRDiff, "bgp 65000")
+	assert.Contains(t, diff.InterfacesDiff, "vnet1")
+
+	_, err = cluster.SDNDryRun(context.Background(), "")
+	assert.NotNil(t, err)
+}

--- a/cluster_sdn_prefix_lists.go
+++ b/cluster_sdn_prefix_lists.go
@@ -1,0 +1,161 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// SDNPrefixLists lists configured prefix-lists. pending/running toggle which
+// configuration is returned; verbose=false returns just IDs.
+//
+// GET /cluster/sdn/prefix-lists
+func (cl *Cluster) SDNPrefixLists(ctx context.Context, pending, running, verbose bool) (lists []*SDNPrefixList, err error) {
+	path := "/cluster/sdn/prefix-lists"
+	q := url.Values{}
+	if pending {
+		q.Set("pending", "1")
+	}
+	if running {
+		q.Set("running", "1")
+	}
+	if verbose {
+		q.Set("verbose", "1")
+	}
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	if err = cl.client.Get(ctx, path, &lists); err != nil {
+		return nil, err
+	}
+	for _, l := range lists {
+		l.client = cl.client
+	}
+	return
+}
+
+// SDNPrefixList returns a handle for a single prefix-list. No API call is made.
+//
+// GET /cluster/sdn/prefix-lists/{id}
+func (cl *Cluster) SDNPrefixList(id string) *SDNPrefixList {
+	return &SDNPrefixList{client: cl.client, ID: id}
+}
+
+// NewSDNPrefixList creates a new prefix-list. opts.ID is required.
+//
+// POST /cluster/sdn/prefix-lists
+func (cl *Cluster) NewSDNPrefixList(ctx context.Context, opts *SDNPrefixListOptions) error {
+	if opts == nil || opts.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	return cl.client.Post(ctx, "/cluster/sdn/prefix-lists", opts, nil)
+}
+
+// Read populates the receiver with the prefix-list configuration including
+// entries.
+//
+// GET /cluster/sdn/prefix-lists/{id}
+func (l *SDNPrefixList) Read(ctx context.Context) error {
+	if l.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	return l.client.Get(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s", l.ID), l)
+}
+
+// Update mutates the prefix-list. Pass a fresh Entries slice to replace the
+// current set.
+//
+// PUT /cluster/sdn/prefix-lists/{id}
+func (l *SDNPrefixList) Update(ctx context.Context, opts *SDNPrefixListOptions) error {
+	if l.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	if opts == nil {
+		opts = &SDNPrefixListOptions{}
+	}
+	return l.client.Put(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s", l.ID), opts, nil)
+}
+
+// Delete removes the prefix-list.
+//
+// DELETE /cluster/sdn/prefix-lists/{id}
+func (l *SDNPrefixList) Delete(ctx context.Context) error {
+	if l.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	return l.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s", l.ID), nil)
+}
+
+// ListEntries lists the entries within this prefix-list.
+//
+// GET /cluster/sdn/prefix-lists/{id}/entries
+func (l *SDNPrefixList) ListEntries(ctx context.Context) (entries []*SDNPrefixListEntry, err error) {
+	if l.ID == "" {
+		return nil, errors.New("sdn prefix-list id is required")
+	}
+	if err = l.client.Get(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s/entries", l.ID), &entries); err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		e.client = l.client
+		e.ID = l.ID
+	}
+	return
+}
+
+// Entry returns a handle for a single entry in this prefix-list keyed by seq.
+// No API call is made.
+//
+// GET /cluster/sdn/prefix-lists/{id}/entries/{url_seq}
+func (l *SDNPrefixList) Entry(seq uint32) *SDNPrefixListEntry {
+	return &SDNPrefixListEntry{client: l.client, ID: l.ID, Seq: seq}
+}
+
+// AddEntry creates a new entry in this prefix-list. opts.Action and opts.Prefix
+// are required.
+//
+// POST /cluster/sdn/prefix-lists/{id}/entries
+func (l *SDNPrefixList) AddEntry(ctx context.Context, opts *SDNPrefixListEntryOptions) error {
+	if l.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	if opts == nil || opts.Action == "" || opts.Prefix == "" {
+		return errors.New("sdn prefix-list entry action and prefix are required")
+	}
+	return l.client.Post(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s/entries", l.ID), opts, nil)
+}
+
+// Read populates the receiver with the entry configuration.
+//
+// GET /cluster/sdn/prefix-lists/{id}/entries/{url_seq}
+func (e *SDNPrefixListEntry) Read(ctx context.Context) error {
+	if e.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	return e.client.Get(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s/entries/%s", e.ID, strconv.FormatUint(uint64(e.Seq), 10)), e)
+}
+
+// Update mutates the prefix-list entry.
+//
+// PUT /cluster/sdn/prefix-lists/{id}/entries/{url_seq}
+func (e *SDNPrefixListEntry) Update(ctx context.Context, opts *SDNPrefixListEntryOptions) error {
+	if e.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	if opts == nil {
+		opts = &SDNPrefixListEntryOptions{}
+	}
+	return e.client.Put(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s/entries/%s", e.ID, strconv.FormatUint(uint64(e.Seq), 10)), opts, nil)
+}
+
+// Delete removes the prefix-list entry.
+//
+// DELETE /cluster/sdn/prefix-lists/{id}/entries/{url_seq}
+func (e *SDNPrefixListEntry) Delete(ctx context.Context) error {
+	if e.ID == "" {
+		return errors.New("sdn prefix-list id is required")
+	}
+	return e.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/prefix-lists/%s/entries/%s", e.ID, strconv.FormatUint(uint64(e.Seq), 10)), nil)
+}

--- a/cluster_sdn_prefix_lists_test.go
+++ b/cluster_sdn_prefix_lists_test.go
@@ -1,0 +1,82 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNPrefixLists(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	lists, err := cluster.SDNPrefixLists(context.Background(), false, false, false)
+	assert.Nil(t, err)
+	assert.Len(t, lists, 2)
+	assert.Equal(t, "pl1", lists[0].ID)
+}
+
+func TestSDNPrefixList_CRUD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	l := cluster.SDNPrefixList("pl1")
+	assert.Nil(t, l.Read(context.Background()))
+	assert.Len(t, l.Entries, 1)
+
+	assert.Nil(t, l.Update(context.Background(), &SDNPrefixListOptions{}))
+	assert.Nil(t, l.Delete(context.Background()))
+}
+
+func TestCluster_NewSDNPrefixList(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNPrefixList(context.Background(), &SDNPrefixListOptions{ID: "pl3"})
+	assert.Nil(t, err)
+	assert.NotNil(t, cluster.NewSDNPrefixList(context.Background(), nil))
+}
+
+func TestSDNPrefixList_Entries(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	l := cluster.SDNPrefixList("pl1")
+	entries, err := l.ListEntries(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "pl1", entries[0].ID)
+}
+
+func TestSDNPrefixListEntry_CRUD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	l := cluster.SDNPrefixList("pl1")
+	e := l.Entry(10)
+	assert.Nil(t, e.Read(context.Background()))
+	assert.Equal(t, "permit", e.Action)
+
+	assert.Nil(t, e.Update(context.Background(), &SDNPrefixListEntryOptions{Action: "deny"}))
+	assert.Nil(t, e.Delete(context.Background()))
+}
+
+func TestSDNPrefixList_AddEntry(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	l := cluster.SDNPrefixList("pl1")
+	err := l.AddEntry(context.Background(), &SDNPrefixListEntryOptions{Action: "permit", Prefix: "10.0.5.0/24"})
+	assert.Nil(t, err)
+
+	assert.NotNil(t, l.AddEntry(context.Background(), nil))
+	assert.NotNil(t, l.AddEntry(context.Background(), &SDNPrefixListEntryOptions{Action: "permit"}))
+}

--- a/cluster_sdn_route_maps.go
+++ b/cluster_sdn_route_maps.go
@@ -1,0 +1,131 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// SDNRouteMaps lists configured SDN route-maps. running=true returns the
+// running config rather than pending.
+//
+// GET /cluster/sdn/route-maps
+func (cl *Cluster) SDNRouteMaps(ctx context.Context, running bool) (maps []*SDNRouteMapID, err error) {
+	path := "/cluster/sdn/route-maps"
+	if running {
+		path += "?running=1"
+	}
+	err = cl.client.Get(ctx, path, &maps)
+	return
+}
+
+// SDNRouteMapEntries lists every route-map entry across all route-maps.
+// pending/running toggle the returned configuration view.
+//
+// GET /cluster/sdn/route-maps/entries
+func (cl *Cluster) SDNRouteMapEntries(ctx context.Context, pending, running bool) (entries []*SDNRouteMapEntry, err error) {
+	path := "/cluster/sdn/route-maps/entries"
+	q := url.Values{}
+	if pending {
+		q.Set("pending", "1")
+	}
+	if running {
+		q.Set("running", "1")
+	}
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	if err = cl.client.Get(ctx, path, &entries); err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		e.client = cl.client
+	}
+	return
+}
+
+// SDNRouteMapEntriesFor lists the entries belonging to a single named
+// route-map.
+//
+// GET /cluster/sdn/route-maps/entries/{route-map-id}
+func (cl *Cluster) SDNRouteMapEntriesFor(ctx context.Context, routeMapID string, pending, running bool) (entries []*SDNRouteMapEntry, err error) {
+	if routeMapID == "" {
+		return nil, errors.New("route-map id is required")
+	}
+	path := fmt.Sprintf("/cluster/sdn/route-maps/entries/%s", routeMapID)
+	q := url.Values{}
+	if pending {
+		q.Set("pending", "1")
+	}
+	if running {
+		q.Set("running", "1")
+	}
+	if len(q) > 0 {
+		path = path + "?" + q.Encode()
+	}
+	if err = cl.client.Get(ctx, path, &entries); err != nil {
+		return nil, err
+	}
+	for _, e := range entries {
+		e.client = cl.client
+		e.RouteMapID = routeMapID
+	}
+	return
+}
+
+// SDNRouteMapEntry returns a handle for one entry in a route-map keyed by
+// (route-map-id, order). No API call is made.
+//
+// GET /cluster/sdn/route-maps/entries/{route-map-id}/entry/{order}
+func (cl *Cluster) SDNRouteMapEntry(routeMapID string, order uint16) *SDNRouteMapEntry {
+	return &SDNRouteMapEntry{client: cl.client, RouteMapID: routeMapID, Order: order}
+}
+
+// NewSDNRouteMapEntry creates a new entry in a route-map. opts.RouteMapID,
+// opts.Order, and opts.Action are required.
+//
+// POST /cluster/sdn/route-maps/entries
+func (cl *Cluster) NewSDNRouteMapEntry(ctx context.Context, opts *SDNRouteMapEntryOptions) error {
+	if opts == nil || opts.RouteMapID == "" {
+		return errors.New("route-map id is required")
+	}
+	if opts.Action == "" {
+		return errors.New("route-map entry action is required")
+	}
+	return cl.client.Post(ctx, "/cluster/sdn/route-maps/entries", opts, nil)
+}
+
+// Read populates the receiver with the route-map entry configuration.
+//
+// GET /cluster/sdn/route-maps/entries/{route-map-id}/entry/{order}
+func (e *SDNRouteMapEntry) Read(ctx context.Context) error {
+	if e.RouteMapID == "" {
+		return errors.New("route-map id is required")
+	}
+	return e.client.Get(ctx, fmt.Sprintf("/cluster/sdn/route-maps/entries/%s/entry/%s", e.RouteMapID, strconv.FormatUint(uint64(e.Order), 10)), e)
+}
+
+// Update mutates the route-map entry.
+//
+// PUT /cluster/sdn/route-maps/entries/{route-map-id}/entry/{order}
+func (e *SDNRouteMapEntry) Update(ctx context.Context, opts *SDNRouteMapEntryOptions) error {
+	if e.RouteMapID == "" {
+		return errors.New("route-map id is required")
+	}
+	if opts == nil {
+		opts = &SDNRouteMapEntryOptions{}
+	}
+	return e.client.Put(ctx, fmt.Sprintf("/cluster/sdn/route-maps/entries/%s/entry/%s", e.RouteMapID, strconv.FormatUint(uint64(e.Order), 10)), opts, nil)
+}
+
+// Delete removes the route-map entry.
+//
+// DELETE /cluster/sdn/route-maps/entries/{route-map-id}/entry/{order}
+func (e *SDNRouteMapEntry) Delete(ctx context.Context) error {
+	if e.RouteMapID == "" {
+		return errors.New("route-map id is required")
+	}
+	return e.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/route-maps/entries/%s/entry/%s", e.RouteMapID, strconv.FormatUint(uint64(e.Order), 10)), nil)
+}

--- a/cluster_sdn_route_maps_test.go
+++ b/cluster_sdn_route_maps_test.go
@@ -1,0 +1,70 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNRouteMaps(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	maps, err := cluster.SDNRouteMaps(context.Background(), false)
+	assert.Nil(t, err)
+	assert.Len(t, maps, 2)
+	assert.Equal(t, "rm1", maps[0].ID)
+}
+
+func TestCluster_SDNRouteMapEntries(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.SDNRouteMapEntries(context.Background(), false, false)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+}
+
+func TestCluster_SDNRouteMapEntriesFor(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.SDNRouteMapEntriesFor(context.Background(), "rm1", false, false)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "rm1", entries[0].RouteMapID)
+
+	_, err = cluster.SDNRouteMapEntriesFor(context.Background(), "", false, false)
+	assert.NotNil(t, err)
+}
+
+func TestSDNRouteMapEntry_CRUD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	e := cluster.SDNRouteMapEntry("rm1", 10)
+	assert.Nil(t, e.Read(context.Background()))
+	assert.Equal(t, "permit", e.Action)
+	assert.Len(t, e.Match, 1)
+
+	assert.Nil(t, e.Update(context.Background(), &SDNRouteMapEntryOptions{Action: "deny"}))
+	assert.Nil(t, e.Delete(context.Background()))
+}
+
+func TestCluster_NewSDNRouteMapEntry(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNRouteMapEntry(context.Background(), &SDNRouteMapEntryOptions{RouteMapID: "rm1", Order: 30, Action: "permit"})
+	assert.Nil(t, err)
+
+	assert.NotNil(t, cluster.NewSDNRouteMapEntry(context.Background(), nil))
+	assert.NotNil(t, cluster.NewSDNRouteMapEntry(context.Background(), &SDNRouteMapEntryOptions{RouteMapID: "rm1"}))
+}

--- a/cluster_sdn_vnet_firewall.go
+++ b/cluster_sdn_vnet_firewall.go
@@ -1,0 +1,108 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// FirewallIndex returns the per-VNet firewall directory entries
+// ({"options", "rules"}).
+//
+// GET /cluster/sdn/vnets/{vnet}/firewall
+func (v *VNet) FirewallIndex(ctx context.Context) (entries []map[string]any, err error) {
+	if v.Name == "" {
+		return nil, errors.New("vnet name is required")
+	}
+	err = v.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall", v.Name), &entries)
+	return
+}
+
+// FirewallOptions reads the per-VNet firewall toggle/policy/log-level.
+//
+// GET /cluster/sdn/vnets/{vnet}/firewall/options
+func (v *VNet) FirewallOptions(ctx context.Context) (*SDNVNetFirewallOptions, error) {
+	if v.Name == "" {
+		return nil, errors.New("vnet name is required")
+	}
+	out := &SDNVNetFirewallOptions{}
+	if err := v.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall/options", v.Name), out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// FirewallOptionsUpdate mutates the per-VNet firewall options.
+//
+// PUT /cluster/sdn/vnets/{vnet}/firewall/options
+func (v *VNet) FirewallOptionsUpdate(ctx context.Context, opts *SDNVNetFirewallOptionsUpdate) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	if opts == nil {
+		opts = &SDNVNetFirewallOptionsUpdate{}
+	}
+	return v.client.Put(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall/options", v.Name), opts, nil)
+}
+
+// FirewallRules lists the firewall rules on this VNet.
+//
+// GET /cluster/sdn/vnets/{vnet}/firewall/rules
+func (v *VNet) FirewallRules(ctx context.Context) (rules []*SDNVNetFirewallRule, err error) {
+	if v.Name == "" {
+		return nil, errors.New("vnet name is required")
+	}
+	err = v.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall/rules", v.Name), &rules)
+	return
+}
+
+// FirewallRule reads a single firewall rule on this VNet by position.
+//
+// GET /cluster/sdn/vnets/{vnet}/firewall/rules/{pos}
+func (v *VNet) FirewallRule(ctx context.Context, pos int) (*SDNVNetFirewallRule, error) {
+	if v.Name == "" {
+		return nil, errors.New("vnet name is required")
+	}
+	rule := &SDNVNetFirewallRule{}
+	if err := v.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall/rules/%d", v.Name, pos), rule); err != nil {
+		return nil, err
+	}
+	return rule, nil
+}
+
+// NewFirewallRule creates a new firewall rule on this VNet. opts.Type and
+// opts.Action are required.
+//
+// POST /cluster/sdn/vnets/{vnet}/firewall/rules
+func (v *VNet) NewFirewallRule(ctx context.Context, opts *SDNVNetFirewallRuleOptions) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	if opts == nil || opts.Type == "" || opts.Action == "" {
+		return errors.New("vnet firewall rule type and action are required")
+	}
+	return v.client.Post(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall/rules", v.Name), opts, nil)
+}
+
+// FirewallRuleUpdate mutates an existing firewall rule by position.
+//
+// PUT /cluster/sdn/vnets/{vnet}/firewall/rules/{pos}
+func (v *VNet) FirewallRuleUpdate(ctx context.Context, pos int, opts *SDNVNetFirewallRuleOptions) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	if opts == nil {
+		opts = &SDNVNetFirewallRuleOptions{}
+	}
+	return v.client.Put(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall/rules/%d", v.Name, pos), opts, nil)
+}
+
+// FirewallRuleDelete removes a firewall rule by position.
+//
+// DELETE /cluster/sdn/vnets/{vnet}/firewall/rules/{pos}
+func (v *VNet) FirewallRuleDelete(ctx context.Context, pos int) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	return v.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/firewall/rules/%d", v.Name, pos), nil)
+}

--- a/cluster_sdn_vnet_ips.go
+++ b/cluster_sdn_vnet_ips.go
@@ -1,0 +1,62 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// CreateIP creates a MAC/IP mapping in the IPAM for this VNet. opts.Zone and
+// opts.IP are required.
+//
+// POST /cluster/sdn/vnets/{vnet}/ips
+func (v *VNet) CreateIP(ctx context.Context, opts *SDNVNetIPOptions) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	if opts == nil || opts.IP == "" {
+		return errors.New("vnet ip is required")
+	}
+	if opts.Zone == "" {
+		return errors.New("vnet zone is required")
+	}
+	return v.client.Post(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/ips", v.Name), opts, nil)
+}
+
+// UpdateIP updates a MAC/IP mapping in the IPAM (e.g. to associate a VMID).
+//
+// PUT /cluster/sdn/vnets/{vnet}/ips
+func (v *VNet) UpdateIP(ctx context.Context, opts *SDNVNetIPOptions) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	if opts == nil || opts.IP == "" {
+		return errors.New("vnet ip is required")
+	}
+	if opts.Zone == "" {
+		return errors.New("vnet zone is required")
+	}
+	return v.client.Put(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/ips", v.Name), opts, nil)
+}
+
+// DeleteIP removes an IP mapping from the IPAM for this VNet.
+//
+// DELETE /cluster/sdn/vnets/{vnet}/ips
+func (v *VNet) DeleteIP(ctx context.Context, opts *SDNVNetIPOptions) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	if opts == nil || opts.IP == "" {
+		return errors.New("vnet ip is required")
+	}
+	if opts.Zone == "" {
+		return errors.New("vnet zone is required")
+	}
+	// The DELETE endpoint accepts query parameters rather than a body in this
+	// client. Encode the identifying fields onto the URL.
+	path := fmt.Sprintf("/cluster/sdn/vnets/%s/ips?zone=%s&ip=%s", v.Name, opts.Zone, opts.IP)
+	if opts.MAC != "" {
+		path += "&mac=" + opts.MAC
+	}
+	return v.client.Delete(ctx, path, nil)
+}

--- a/cluster_sdn_vnet_subnets.go
+++ b/cluster_sdn_vnet_subnets.go
@@ -1,0 +1,85 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Subnets lists the subnets configured under this VNet.
+//
+// GET /cluster/sdn/vnets/{vnet}/subnets
+func (v *VNet) Subnets(ctx context.Context) (subnets []*VNetSubnet, err error) {
+	if v.Name == "" {
+		return nil, errors.New("vnet name is required")
+	}
+	if err = v.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets", v.Name), &subnets); err != nil {
+		return nil, err
+	}
+	for _, s := range subnets {
+		s.client = v.client
+		s.VNet = v.Name
+	}
+	return
+}
+
+// Subnet returns a handle for a single subnet under this VNet. No API call is
+// made; use the returned handle's Read to populate it.
+//
+// GET /cluster/sdn/vnets/{vnet}/subnets/{subnet}
+func (v *VNet) Subnet(name string) *VNetSubnet {
+	return &VNetSubnet{client: v.client, VNet: v.Name, ID: name}
+}
+
+// NewSubnet creates a new subnet under this VNet. opts.Subnet (CIDR) is
+// required; opts.Type defaults to "subnet" if empty.
+//
+// POST /cluster/sdn/vnets/{vnet}/subnets
+func (v *VNet) NewSubnet(ctx context.Context, opts *SDNSubnetOptions) error {
+	if v.Name == "" {
+		return errors.New("vnet name is required")
+	}
+	if opts == nil || opts.Subnet == "" {
+		return errors.New("subnet cidr is required")
+	}
+	if opts.Type == "" {
+		opts.Type = "subnet"
+	}
+	if opts.VNet == "" {
+		opts.VNet = v.Name
+	}
+	return v.client.Post(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets", v.Name), opts, nil)
+}
+
+// Read populates the receiver with the subnet configuration.
+//
+// GET /cluster/sdn/vnets/{vnet}/subnets/{subnet}
+func (s *VNetSubnet) Read(ctx context.Context) error {
+	if s.VNet == "" || s.ID == "" {
+		return errors.New("vnet and subnet id are required")
+	}
+	return s.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", s.VNet, s.ID), s)
+}
+
+// Update mutates the subnet configuration.
+//
+// PUT /cluster/sdn/vnets/{vnet}/subnets/{subnet}
+func (s *VNetSubnet) Update(ctx context.Context, opts *SDNSubnetOptions) error {
+	if s.VNet == "" || s.ID == "" {
+		return errors.New("vnet and subnet id are required")
+	}
+	if opts == nil {
+		opts = &SDNSubnetOptions{}
+	}
+	return s.client.Put(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", s.VNet, s.ID), opts, nil)
+}
+
+// Delete removes the subnet.
+//
+// DELETE /cluster/sdn/vnets/{vnet}/subnets/{subnet}
+func (s *VNetSubnet) Delete(ctx context.Context) error {
+	if s.VNet == "" || s.ID == "" {
+		return errors.New("vnet and subnet id are required")
+	}
+	return s.client.Delete(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", s.VNet, s.ID), nil)
+}

--- a/cluster_sdn_vnet_test.go
+++ b/cluster_sdn_vnet_test.go
@@ -1,0 +1,94 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVNet_FirewallIndex(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, err := cluster.SDNVNet(context.Background(), "user1")
+	assert.Nil(t, err)
+	assert.NotNil(t, v)
+
+	entries, err := v.FirewallIndex(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+}
+
+func TestVNet_FirewallOptions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	opts, err := v.FirewallOptions(context.Background())
+	assert.Nil(t, err)
+	assert.True(t, bool(opts.Enable))
+	assert.Equal(t, "ACCEPT", opts.PolicyForward)
+
+	assert.Nil(t, v.FirewallOptionsUpdate(context.Background(), &SDNVNetFirewallOptionsUpdate{PolicyForward: "DROP"}))
+}
+
+func TestVNet_FirewallRules(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	rules, err := v.FirewallRules(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, rules, 2)
+
+	rule, err := v.FirewallRule(context.Background(), 0)
+	assert.Nil(t, err)
+	assert.Equal(t, "ACCEPT", rule.Action)
+
+	assert.Nil(t, v.NewFirewallRule(context.Background(), &SDNVNetFirewallRuleOptions{Type: "in", Action: "ACCEPT"}))
+	assert.NotNil(t, v.NewFirewallRule(context.Background(), nil))
+
+	assert.Nil(t, v.FirewallRuleUpdate(context.Background(), 0, &SDNVNetFirewallRuleOptions{Enable: 0}))
+	assert.Nil(t, v.FirewallRuleDelete(context.Background(), 0))
+}
+
+func TestVNet_IPs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	assert.Nil(t, v.CreateIP(context.Background(), &SDNVNetIPOptions{Zone: "zone1", IP: "10.0.0.10"}))
+	assert.Nil(t, v.UpdateIP(context.Background(), &SDNVNetIPOptions{Zone: "zone1", IP: "10.0.0.10", VMID: 100}))
+	assert.Nil(t, v.DeleteIP(context.Background(), &SDNVNetIPOptions{Zone: "zone1", IP: "10.0.0.10"}))
+
+	assert.NotNil(t, v.CreateIP(context.Background(), nil))
+	assert.NotNil(t, v.CreateIP(context.Background(), &SDNVNetIPOptions{IP: "10.0.0.10"}))
+}
+
+func TestVNet_Subnets(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	subs, err := v.Subnets(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, subs, 1)
+	assert.Equal(t, "user1", subs[0].VNet)
+
+	s := v.Subnet("zone1-10.0.0.0-24")
+	assert.Nil(t, s.Read(context.Background()))
+	assert.Equal(t, "10.0.0.0/24", s.CIDR)
+
+	assert.Nil(t, v.NewSubnet(context.Background(), &SDNSubnetOptions{Subnet: "zone1-10.0.1.0-24"}))
+	assert.NotNil(t, v.NewSubnet(context.Background(), nil))
+
+	assert.Nil(t, s.Update(context.Background(), &SDNSubnetOptions{Gateway: "10.0.0.2"}))
+	assert.Nil(t, s.Delete(context.Background()))
+}

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -1769,4 +1769,468 @@ func clusterReplication() {
 			{"subdir":"101"},
 			{"subdir":"200"}
 		]}`)
+
+	// --- /cluster/sdn lock/rollback/dry-run -----------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/lock$").
+		Reply(200).
+		JSON(`{"data":"tok-abc123"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/lock").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/rollback$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/dry-run").
+		Reply(200).
+		JSON(`{"data":{
+			"frr-diff":"+router bgp 65000\n+ network 10.0.0.0/24\n",
+			"interfaces-diff":"+auto vnet1\n+iface vnet1 inet manual\n"
+		}}`)
+
+	// --- /cluster/sdn/controllers ---------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/controllers$").
+		Reply(200).
+		JSON(`{"data":[
+			{"controller":"ctrl1","type":"evpn","asn":65000,"peers":"10.0.0.1,10.0.0.2"},
+			{"controller":"ctrl2","type":"bgp","asn":65001}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/controllers/ctrl1$").
+		Reply(200).
+		JSON(`{"data":{"controller":"ctrl1","type":"evpn","asn":65000,"peers":"10.0.0.1,10.0.0.2","peer-group-name":"VTEP"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/controllers$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/controllers/ctrl1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/controllers/ctrl1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/dns -----------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/dns$").
+		Reply(200).
+		JSON(`{"data":[
+			{"dns":"pdns1","type":"powerdns"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/dns/pdns1$").
+		Reply(200).
+		JSON(`{"data":{"dns":"pdns1","type":"powerdns","url":"https://pdns.example.com/api/v1","ttl":3600}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/dns$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/dns/pdns1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/dns/pdns1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/ipams ---------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/ipams$").
+		Reply(200).
+		JSON(`{"data":[
+			{"ipam":"pve","type":"pve"},
+			{"ipam":"netbox1","type":"netbox"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/ipams/pve$").
+		Reply(200).
+		JSON(`{"data":{"ipam":"pve","type":"pve"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/ipams/pve/status$").
+		Reply(200).
+		JSON(`{"data":[
+			{"hostname":"vm100","ip":"10.0.0.10","mac":"aa:bb:cc:dd:ee:01","subnet":"10.0.0.0-24","vmid":"100","vnet":"vnet1","zone":"zone1"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/ipams$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/ipams/pve$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/ipams/pve$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/fabrics -------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics$").
+		Reply(200).
+		JSON(`{"data":[
+			{"subdir":"fabric"},
+			{"subdir":"node"},
+			{"subdir":"all"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/all$").
+		Reply(200).
+		JSON(`{"data":{
+			"fabrics":[{"id":"fab1","protocol":"openfabric","ip_prefix":"10.0.0.0/24"}],
+			"nodes":[{"fabric_id":"fab1","node_id":"node1","ip":"10.0.0.1"}]
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/fabric$").
+		Reply(200).
+		JSON(`{"data":[
+			{"id":"fab1","protocol":"openfabric","ip_prefix":"10.0.0.0/24"},
+			{"id":"fab2","protocol":"ospf","area":"0.0.0.0"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/fabric/fab1$").
+		Reply(200).
+		JSON(`{"data":{"id":"fab1","protocol":"openfabric","ip_prefix":"10.0.0.0/24","hello_interval":3,"csnp_interval":10}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/fabrics/fabric$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/fabrics/fabric/fab1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/fabrics/fabric/fab1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/node$").
+		Reply(200).
+		JSON(`{"data":[
+			{"fabric_id":"fab1","node_id":"node1","ip":"10.0.0.1"},
+			{"fabric_id":"fab1","node_id":"node2","ip":"10.0.0.2"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/node/fab1$").
+		Reply(200).
+		JSON(`{"data":[
+			{"fabric_id":"fab1","node_id":"node1","ip":"10.0.0.1"},
+			{"fabric_id":"fab1","node_id":"node2","ip":"10.0.0.2"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/node/fab1/node1$").
+		Reply(200).
+		JSON(`{"data":{"fabric_id":"fab1","node_id":"node1","ip":"10.0.0.1","interfaces":["name=eth0,ip=10.0.0.1/24"]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/fabrics/node/fab1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/fabrics/node/fab1/node1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/fabrics/node/fab1/node1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/prefix-lists --------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/prefix-lists$").
+		Reply(200).
+		JSON(`{"data":[
+			{"id":"pl1"},
+			{"id":"pl2"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/prefix-lists/pl1$").
+		Reply(200).
+		JSON(`{"data":{"id":"pl1","entries":[{"seq":10,"action":"permit","prefix":"10.0.0.0/24"}]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/prefix-lists$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/prefix-lists/pl1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/prefix-lists/pl1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/prefix-lists/pl1/entries$").
+		Reply(200).
+		JSON(`{"data":[
+			{"seq":10,"action":"permit","prefix":"10.0.0.0/24"},
+			{"seq":20,"action":"deny","prefix":"10.0.1.0/24"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/prefix-lists/pl1/entries/10$").
+		Reply(200).
+		JSON(`{"data":{"seq":10,"action":"permit","prefix":"10.0.0.0/24"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/prefix-lists/pl1/entries$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/prefix-lists/pl1/entries/10$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/prefix-lists/pl1/entries/10$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/route-maps ----------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps$").
+		Reply(200).
+		JSON(`{"data":[
+			{"id":"rm1"},
+			{"id":"rm2"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps/entries$").
+		Reply(200).
+		JSON(`{"data":[
+			{"route-map-id":"rm1","order":10,"action":"permit"},
+			{"route-map-id":"rm1","order":20,"action":"deny"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps/entries/rm1$").
+		Reply(200).
+		JSON(`{"data":[
+			{"route-map-id":"rm1","order":10,"action":"permit","match":["key=metric,value=100"]}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps/entries/rm1/entry/10$").
+		Reply(200).
+		JSON(`{"data":{"route-map-id":"rm1","order":10,"action":"permit","match":["key=metric,value=100"],"set":["key=local-preference,value=200"]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/route-maps/entries$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/route-maps/entries/rm1/entry/10$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/route-maps/entries/rm1/entry/10$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/vnets/{vnet}/firewall -----------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/user1/firewall$").
+		Reply(200).
+		JSON(`{"data":[{"subdir":"options"},{"subdir":"rules"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/user1/firewall/options$").
+		Reply(200).
+		JSON(`{"data":{"enable":1,"policy_forward":"ACCEPT","log_level_forward":"info"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/vnets/user1/firewall/options$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/user1/firewall/rules$").
+		Reply(200).
+		JSON(`{"data":[
+			{"pos":0,"type":"in","action":"ACCEPT","enable":1,"source":"10.0.0.0/24"},
+			{"pos":1,"type":"out","action":"DROP","enable":1}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/user1/firewall/rules/0$").
+		Reply(200).
+		JSON(`{"data":{"pos":0,"type":"in","action":"ACCEPT","enable":1,"source":"10.0.0.0/24"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/vnets/user1/firewall/rules$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/vnets/user1/firewall/rules/0$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/vnets/user1/firewall/rules/0$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/vnets/{vnet}/ips ----------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/vnets/user1/ips$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/vnets/user1/ips$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/vnets/user1/ips").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/sdn/vnets/{vnet}/subnets ------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/user1/subnets$").
+		Reply(200).
+		JSON(`{"data":[
+			{"id":"zone1-10.0.0.0-24","cidr":"10.0.0.0/24","gateway":"10.0.0.1","type":"subnet","vnet":"user1","zone":"zone1"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/user1/subnets/zone1-10.0.0.0-24$").
+		Reply(200).
+		JSON(`{"data":{"id":"zone1-10.0.0.0-24","cidr":"10.0.0.0/24","gateway":"10.0.0.1","type":"subnet","vnet":"user1","zone":"zone1"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/vnets/user1/subnets$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/vnets/user1/subnets/zone1-10.0.0.0-24$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/vnets/user1/subnets/zone1-10.0.0.0-24$").
+		Reply(200).
+		JSON(`{"data":null}`)
 }

--- a/types.go
+++ b/types.go
@@ -3347,6 +3347,8 @@ type PendingConfigItem struct {
 }
 
 type VNet struct {
+	client *Client `json:"-"`
+
 	Name      string `json:"vnet,omitempty"`
 	Type      string `json:"type,omitempty"`
 	Zone      string `json:"zone,omitempty"`
@@ -3369,6 +3371,8 @@ type NetRange struct {
 	EndAddress   string `json:"end-address,omitempty"`
 }
 type VNetSubnet struct {
+	client *Client `json:"-"`
+
 	CIDR      string     `json:"cidr,omitempty"`
 	Gateway   string     `json:"gateway,omitempty"`
 	Netmask   string     `json:"mask,omitempty"`
@@ -3438,6 +3442,390 @@ type SDNZoneOptions struct {
 	// uint16 zero would attempt to bind port 0; pointer keeps the default
 	// when nil. See #199.
 	VXLANPort *uint16 `json:"vxlan-port,omitempty"`
+}
+
+// --- /cluster/sdn/controllers ----------------------------------------------
+
+// SDNController represents a configured SDN controller (BGP/EVPN/IS-IS/Faucet).
+// PVE returns a union of plugin-type-specific fields; only the keys relevant to
+// Type will be populated.
+type SDNController struct {
+	client *Client `json:"-"`
+
+	Controller             string `json:"controller,omitempty"`
+	Type                   string `json:"type,omitempty"`
+	ASN                    uint32 `json:"asn,omitempty"`
+	BGPMode                string `json:"bgp-mode,omitempty"`
+	BGPMultipathASRelax    bool   `json:"bgp-multipath-as-relax,omitempty"`
+	EBGP                   bool   `json:"ebgp,omitempty"`
+	EBGPMultihop           int    `json:"ebgp-multihop,omitempty"`
+	ISISDomain             string `json:"isis-domain,omitempty"`
+	ISISIfaces             string `json:"isis-ifaces,omitempty"`
+	ISISNet                string `json:"isis-net,omitempty"`
+	Loopback               string `json:"loopback,omitempty"`
+	Node                   string `json:"node,omitempty"`
+	Nodes                  string `json:"nodes,omitempty"`
+	PeerGroupName          string `json:"peer-group-name,omitempty"`
+	Peers                  string `json:"peers,omitempty"`
+	State                  string `json:"state,omitempty"` // new | changed | deleted
+	Digest                 string `json:"digest,omitempty"`
+}
+
+// SDNControllerOptions is the request body for creating/updating a controller.
+// Fields are documented per the PVE schema; only those relevant to Type are
+// accepted server-side.
+type SDNControllerOptions struct {
+	Controller              string `json:"controller,omitempty"`
+	Type                    string `json:"type,omitempty"`
+	ASN                     uint32 `json:"asn,omitempty"`
+	BGPMode                 string `json:"bgp-mode,omitempty"`
+	BGPMultipathASPathRelax bool   `json:"bgp-multipath-as-path-relax,omitempty"`
+	EBGP                    bool   `json:"ebgp,omitempty"`
+	EBGPMultihop            int    `json:"ebgp-multihop,omitempty"`
+	Fabric                  string `json:"fabric,omitempty"`
+	ISISDomain              string `json:"isis-domain,omitempty"`
+	ISISIfaces              string `json:"isis-ifaces,omitempty"`
+	ISISNet                 string `json:"isis-net,omitempty"`
+	Loopback                string `json:"loopback,omitempty"`
+	Node                    string `json:"node,omitempty"`
+	Nodes                   string `json:"nodes,omitempty"`
+	PeerGroupName           string `json:"peer-group-name,omitempty"`
+	Peers                   string `json:"peers,omitempty"`
+	RouteMapIn              string `json:"route-map-in,omitempty"`
+	RouteMapOut             string `json:"route-map-out,omitempty"`
+	LockToken               string `json:"lock-token,omitempty"`
+	Digest                  string `json:"digest,omitempty"`
+	Delete                  string `json:"delete,omitempty"` // PUT only — comma-list of keys to reset
+}
+
+// --- /cluster/sdn/dns ------------------------------------------------------
+
+// SDNDNS represents an SDN DNS plugin configuration (currently PowerDNS only).
+type SDNDNS struct {
+	client *Client `json:"-"`
+
+	DNS           string `json:"dns,omitempty"`
+	Type          string `json:"type,omitempty"`
+	URL           string `json:"url,omitempty"`
+	Key           string `json:"key,omitempty"`
+	TTL           int    `json:"ttl,omitempty"`
+	ReverseMaskV6 int    `json:"reversemaskv6,omitempty"`
+	ReverseV6Mask int    `json:"reversev6mask,omitempty"`
+	Fingerprint   string `json:"fingerprint,omitempty"`
+	Digest        string `json:"digest,omitempty"`
+}
+
+// SDNDNSOptions is the request body for creating/updating an SDN DNS object.
+type SDNDNSOptions struct {
+	DNS           string `json:"dns,omitempty"`
+	Type          string `json:"type,omitempty"` // "powerdns"
+	URL           string `json:"url,omitempty"`
+	Key           string `json:"key,omitempty"`
+	TTL           int    `json:"ttl,omitempty"`
+	ReverseMaskV6 int    `json:"reversemaskv6,omitempty"`
+	ReverseV6Mask int    `json:"reversev6mask,omitempty"`
+	Fingerprint   string `json:"fingerprint,omitempty"`
+	LockToken     string `json:"lock-token,omitempty"`
+	Digest        string `json:"digest,omitempty"`
+	Delete        string `json:"delete,omitempty"`
+}
+
+// --- /cluster/sdn/ipams ----------------------------------------------------
+
+// SDNIPAM represents an IPAM (IP Address Management) backend configuration.
+// PVE supports netbox, phpipam, and pve (built-in) backends.
+type SDNIPAM struct {
+	client *Client `json:"-"`
+
+	IPAM        string `json:"ipam,omitempty"`
+	Type        string `json:"type,omitempty"`
+	URL         string `json:"url,omitempty"`
+	Token       string `json:"token,omitempty"`
+	Section     int    `json:"section,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	Digest      string `json:"digest,omitempty"`
+}
+
+// SDNIPAMOptions is the request body for creating/updating an SDN IPAM.
+type SDNIPAMOptions struct {
+	IPAM        string `json:"ipam,omitempty"`
+	Type        string `json:"type,omitempty"` // "netbox" | "phpipam" | "pve"
+	URL         string `json:"url,omitempty"`
+	Token       string `json:"token,omitempty"`
+	Section     int    `json:"section,omitempty"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+	LockToken   string `json:"lock-token,omitempty"`
+	Digest      string `json:"digest,omitempty"`
+	Delete      string `json:"delete,omitempty"`
+}
+
+// --- /cluster/sdn/fabrics --------------------------------------------------
+
+// SDNFabric represents an SDN fabric (underlay routing protocol configuration).
+// The schema is plugin-type-tagged on Protocol; many fields are protocol-specific.
+type SDNFabric struct {
+	client *Client `json:"-"`
+
+	ID                  string   `json:"id,omitempty"`
+	Protocol            string   `json:"protocol,omitempty"` // openfabric | ospf | wireguard | bgp
+	IPPrefix            string   `json:"ip_prefix,omitempty"`
+	IP6Prefix           string   `json:"ip6_prefix,omitempty"`
+	Area                string   `json:"area,omitempty"`           // ospf
+	HelloInterval       float64  `json:"hello_interval,omitempty"` // openfabric
+	CSNPInterval        float64  `json:"csnp_interval,omitempty"`  // openfabric
+	PersistentKeepalive int      `json:"persistent_keepalive,omitempty"` // wireguard
+	Redistribute        []string `json:"redistribute,omitempty"`         // ospf | bgp
+	RouteFilter         string   `json:"route_filter,omitempty"`         // ospf | openfabric
+	Digest              string   `json:"digest,omitempty"`
+}
+
+// SDNFabricOptions is the request body for creating/updating a fabric.
+type SDNFabricOptions struct {
+	ID                  string   `json:"id,omitempty"`
+	Protocol            string   `json:"protocol,omitempty"`
+	IPPrefix            string   `json:"ip_prefix,omitempty"`
+	IP6Prefix           string   `json:"ip6_prefix,omitempty"`
+	Area                string   `json:"area,omitempty"`
+	HelloInterval       float64  `json:"hello_interval,omitempty"`
+	CSNPInterval        float64  `json:"csnp_interval,omitempty"`
+	PersistentKeepalive int      `json:"persistent_keepalive,omitempty"`
+	Redistribute        []string `json:"redistribute,omitempty"`
+	RouteFilter         string   `json:"route_filter,omitempty"`
+	LockToken           string   `json:"lock-token,omitempty"`
+	Digest              string   `json:"digest,omitempty"`
+	Delete              []string `json:"delete,omitempty"`
+}
+
+// SDNFabricNode represents a node participating in an SDN fabric, including
+// its protocol-specific interfaces and (for WireGuard) peers.
+type SDNFabricNode struct {
+	client *Client `json:"-"`
+
+	FabricID   string   `json:"fabric_id,omitempty"`
+	NodeID     string   `json:"node_id,omitempty"`
+	IP         string   `json:"ip,omitempty"`
+	IP6        string   `json:"ip6,omitempty"`
+	Interfaces []string `json:"interfaces,omitempty"`
+	AllowedIPs []string `json:"allowed_ips,omitempty"` // wireguard
+	Endpoint   string   `json:"endpoint,omitempty"`    // wireguard
+	Peers      []string `json:"peers,omitempty"`       // wireguard
+	Digest     string   `json:"digest,omitempty"`
+}
+
+// SDNFabricNodeOptions is the request body for adding/updating a fabric node.
+type SDNFabricNodeOptions struct {
+	FabricID   string   `json:"fabric_id,omitempty"`
+	NodeID     string   `json:"node_id,omitempty"`
+	IP         string   `json:"ip,omitempty"`
+	IP6        string   `json:"ip6,omitempty"`
+	Interfaces []string `json:"interfaces,omitempty"`
+	AllowedIPs []string `json:"allowed_ips,omitempty"`
+	Endpoint   string   `json:"endpoint,omitempty"`
+	Peers      []string `json:"peers,omitempty"`
+	LockToken  string   `json:"lock-token,omitempty"`
+	Digest     string   `json:"digest,omitempty"`
+	Delete     []string `json:"delete,omitempty"`
+}
+
+// SDNFabricsAll is the combined fabric+node listing returned by
+// GET /cluster/sdn/fabrics/all.
+type SDNFabricsAll struct {
+	Fabrics []*SDNFabric     `json:"fabrics,omitempty"`
+	Nodes   []*SDNFabricNode `json:"nodes,omitempty"`
+}
+
+// --- /cluster/sdn/prefix-lists ---------------------------------------------
+
+// SDNPrefixList represents a named SDN prefix list. List GETs return only the
+// id; the detail GET returns the full entries array.
+type SDNPrefixList struct {
+	client *Client `json:"-"`
+
+	ID      string                `json:"id,omitempty"`
+	Entries []*SDNPrefixListEntry `json:"entries,omitempty"`
+	Digest  string                `json:"digest,omitempty"`
+}
+
+// SDNPrefixListEntry is one rule inside a prefix-list.
+type SDNPrefixListEntry struct {
+	client *Client `json:"-"`
+
+	ID     string `json:"-"` // parent prefix-list id (path-only)
+	Seq    uint32 `json:"seq,omitempty"`
+	Action string `json:"action,omitempty"` // permit | deny
+	Prefix string `json:"prefix,omitempty"`
+	GE     int    `json:"ge,omitempty"`
+	LE     int    `json:"le,omitempty"`
+	Digest string `json:"digest,omitempty"`
+}
+
+// SDNPrefixListOptions is the request body for creating/updating a prefix-list.
+type SDNPrefixListOptions struct {
+	ID        string                `json:"id,omitempty"`
+	Entries   []*SDNPrefixListEntry `json:"entries,omitempty"`
+	LockToken string                `json:"lock-token,omitempty"`
+	Digest    string                `json:"digest,omitempty"`
+	Delete    []string              `json:"delete,omitempty"`
+}
+
+// SDNPrefixListEntryOptions is the request body for creating/updating one entry
+// in a prefix-list.
+type SDNPrefixListEntryOptions struct {
+	Seq       uint32   `json:"seq,omitempty"`
+	Action    string   `json:"action,omitempty"`
+	Prefix    string   `json:"prefix,omitempty"`
+	GE        int      `json:"ge,omitempty"`
+	LE        int      `json:"le,omitempty"`
+	LockToken string   `json:"lock-token,omitempty"`
+	Digest    string   `json:"digest,omitempty"`
+	Delete    []string `json:"delete,omitempty"`
+}
+
+// --- /cluster/sdn/route-maps -----------------------------------------------
+
+// SDNRouteMapID is the listing entry under /cluster/sdn/route-maps.
+type SDNRouteMapID struct {
+	ID string `json:"id,omitempty"`
+}
+
+// SDNRouteMapEntry is one ordered entry in a named route-map. The PVE schema
+// encodes match/set as arrays of pve-property-string formatted "key=...,value=..."
+// so the wire form is `[]string`.
+type SDNRouteMapEntry struct {
+	client *Client `json:"-"`
+
+	RouteMapID string   `json:"route-map-id,omitempty"`
+	Order      uint16   `json:"order,omitempty"`
+	Action     string   `json:"action,omitempty"` // permit | deny
+	Match      []string `json:"match,omitempty"`
+	Set        []string `json:"set,omitempty"`
+	Call       string   `json:"call,omitempty"`
+	ExitAction string   `json:"exit-action,omitempty"`
+	Digest     string   `json:"digest,omitempty"`
+}
+
+// SDNRouteMapEntryOptions is the request body for creating/updating a route-map
+// entry.
+type SDNRouteMapEntryOptions struct {
+	RouteMapID string   `json:"route-map-id,omitempty"`
+	Order      uint16   `json:"order,omitempty"`
+	Action     string   `json:"action,omitempty"`
+	Match      []string `json:"match,omitempty"`
+	Set        []string `json:"set,omitempty"`
+	Call       string   `json:"call,omitempty"`
+	ExitAction string   `json:"exit-action,omitempty"`
+	LockToken  string   `json:"lock-token,omitempty"`
+	Digest     string   `json:"digest,omitempty"`
+	Delete     []string `json:"delete,omitempty"`
+}
+
+// --- /cluster/sdn/lock + rollback + dry-run --------------------------------
+
+// SDNLockToken is the opaque token returned by acquiring the SDN config lock
+// (POST /cluster/sdn/lock). Pass it to mutating endpoints via their LockToken
+// option and to Release/Rollback to surrender the lock.
+type SDNLockToken string
+
+// SDNDryRun is the diff returned by GET /cluster/sdn/dry-run?node=<node>: it
+// shows what changes a SDNApply would push to the node's FRR and ifupdown
+// configuration without actually applying them.
+type SDNDryRun struct {
+	FRRDiff        string `json:"frr-diff,omitempty"`
+	InterfacesDiff string `json:"interfaces-diff,omitempty"`
+}
+
+// --- /cluster/sdn/vnets/{vnet}/firewall ------------------------------------
+
+// SDNVNetFirewallOptions represents the per-VNet firewall toggles returned by
+// GET /cluster/sdn/vnets/{vnet}/firewall/options.
+//
+// Enable: PVE schema marks the type as boolean but the default is `0`. Go's
+// zero value (false) matches the default, so plain bool with omitempty is
+// safe and the wire form stays `0`/`1` thanks to IntOrBool.
+type SDNVNetFirewallOptions struct {
+	Enable          IntOrBool `json:"enable,omitempty"`
+	PolicyForward   string    `json:"policy_forward,omitempty"`   // ACCEPT | DROP
+	LogLevelForward string    `json:"log_level_forward,omitempty"`
+	Digest          string    `json:"digest,omitempty"`
+}
+
+// SDNVNetFirewallOptionsUpdate is the PUT body for vnet firewall options.
+type SDNVNetFirewallOptionsUpdate struct {
+	Enable          *IntOrBool `json:"enable,omitempty"`
+	PolicyForward   string     `json:"policy_forward,omitempty"`
+	LogLevelForward string     `json:"log_level_forward,omitempty"`
+	Digest          string     `json:"digest,omitempty"`
+	Delete          string     `json:"delete,omitempty"`
+}
+
+// SDNVNetFirewallRule is one firewall rule on a VNet. Mirrors the cluster
+// firewall rule shape but scoped to a single VNet.
+type SDNVNetFirewallRule struct {
+	Pos       int    `json:"pos,omitempty"`
+	Type      string `json:"type,omitempty"` // in | out | forward | group
+	Action    string `json:"action,omitempty"`
+	Enable    int    `json:"enable,omitempty"`
+	Comment   string `json:"comment,omitempty"`
+	Source    string `json:"source,omitempty"`
+	Dest      string `json:"dest,omitempty"`
+	Proto     string `json:"proto,omitempty"`
+	SPort     string `json:"sport,omitempty"`
+	DPort     string `json:"dport,omitempty"`
+	IFace     string `json:"iface,omitempty"`
+	Log       string `json:"log,omitempty"`
+	Macro     string `json:"macro,omitempty"`
+	IPVersion int    `json:"ipversion,omitempty"`
+	ICMPType  string `json:"icmp-type,omitempty"`
+}
+
+// SDNVNetFirewallRuleOptions is the create/update body for VNet firewall rules.
+type SDNVNetFirewallRuleOptions struct {
+	Pos      int    `json:"pos,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Action   string `json:"action,omitempty"`
+	Enable   int    `json:"enable,omitempty"`
+	Comment  string `json:"comment,omitempty"`
+	Source   string `json:"source,omitempty"`
+	Dest     string `json:"dest,omitempty"`
+	Proto    string `json:"proto,omitempty"`
+	SPort    string `json:"sport,omitempty"`
+	DPort    string `json:"dport,omitempty"`
+	IFace    string `json:"iface,omitempty"`
+	Log      string `json:"log,omitempty"`
+	Macro    string `json:"macro,omitempty"`
+	ICMPType string `json:"icmp-type,omitempty"`
+	MoveTo   int    `json:"moveto,omitempty"`
+	Digest   string `json:"digest,omitempty"`
+	Delete   string `json:"delete,omitempty"`
+}
+
+// --- /cluster/sdn/vnets/{vnet}/ips -----------------------------------------
+
+// SDNVNetIPOptions is the request body for POST/PUT/DELETE /cluster/sdn/vnets/
+// {vnet}/ips. The endpoint manages MAC/IP/VMID mappings inside the configured
+// IPAM for a VNet.
+type SDNVNetIPOptions struct {
+	Zone string `json:"zone,omitempty"`
+	IP   string `json:"ip,omitempty"`
+	MAC  string `json:"mac,omitempty"`
+	VMID int    `json:"vmid,omitempty"` // PUT only
+}
+
+// --- /cluster/sdn/vnets/{vnet}/subnets/{subnet} ----------------------------
+
+// SDNSubnetOptions is the create/update body for an SDN subnet under a VNet.
+type SDNSubnetOptions struct {
+	Subnet        string   `json:"subnet,omitempty"`
+	Type          string   `json:"type,omitempty"` // "subnet" — only valid value on POST
+	VNet          string   `json:"vnet,omitempty"`
+	Gateway       string   `json:"gateway,omitempty"`
+	DHCPDNSServer string   `json:"dhcp-dns-server,omitempty"`
+	DHCPRange     []string `json:"dhcp-range,omitempty"`
+	DNSZonePrefix string   `json:"dnszoneprefix,omitempty"`
+	SNAT          IntOrBool `json:"snat,omitempty"`
+	LockToken     string   `json:"lock-token,omitempty"`
+	Digest        string   `json:"digest,omitempty"`
+	Delete        string   `json:"delete,omitempty"`
 }
 
 // ClusterMetricServers is the list payload returned by GET /cluster/metrics/server.


### PR DESCRIPTION
## Summary

Wraps the remaining uncovered `/cluster/sdn/*` endpoints — the headline cluster-coverage chunk for v0.7.x. **65 new endpoints** across 5 commits, leaving `/cluster/sdn` at 100%.

### Endpoint count by sub-area

| sub-area | endpoints |
|---|---|
| controllers (CRUD) | 5 |
| dns (CRUD) | 5 |
| ipams (CRUD + status) | 6 |
| fabrics (fabric + node CRUD + indexes + all) | 15 |
| prefix-lists (list + entry CRUD) | 9 |
| route-maps (list + entry CRUD across two indexes) | 7 |
| lock / rollback / dry-run / sdn index | 5 |
| vnets/{vnet}/firewall (options + rules CRUD) | 8 |
| vnets/{vnet}/ips (POST/PUT/DELETE) | 3 |
| vnets/{vnet}/subnets (CRUD) | 5 |
| **total** | **68** |

Coverage delta (per `mage endpoints:coverage`):

- `cluster` area: **57.1% → 82.2%** (148/259 → 213/259)
- Total repo uncovered: 128 → 63 endpoints

## Why

`/cluster/sdn` was the single biggest cluster gap after #270/#274 — SDN landed in PVE 8.x and grew significantly in 9.x (fabrics, prefix-lists, route-maps, vnet firewall, lock/rollback). This PR closes that gap with the same singleton-vs-instance shape AGENTS.md mandates.

## Design notes

- **Singleton-vs-instance pattern.** `Cluster.SDNController(name)` returns `*SDNController` with `Read/Update/Delete` methods. Same for `*SDNDNS`, `*SDNIPAM`, `*SDNFabric`, `*SDNFabricNode`, `*SDNPrefixList`, `*SDNPrefixListEntry`, `*SDNRouteMapEntry`. List endpoints populate the unexported `client` field on each returned handle so list results are immediately chainable.
- **VNet sub-resources hang on `*VNet`.** `vnet.Subnets(ctx)`, `vnet.Subnet(name)`, `vnet.FirewallRules(ctx)`, `vnet.CreateIP(...)` — instead of `cluster.SDNVNetSubnet(vnet, subnet)` etc. Added unexported `client` to `*VNet` and `*VNetSubnet`; existing accessors (`SDNVNets`, `SDNVNet`) thread it.
- **SDN lock semantics.** `SDNLock` returns `SDNLockToken` (a typed alias). The token threads as `LockToken` on every mutating Options struct, and `SDNReleaseLock(token, force)` / `SDNRollback(token, releaseLock)` accept it. PVE's default `release-lock=1` on rollback is preserved — the wrapper only emits the override when the caller passes `releaseLock=false`.
- **IPAM type union.** `SDNIPAM` is a union of fields across netbox/phpipam/pve plugins; the wrapper keeps it as a flat struct (matching PVE's wire format) and lets the caller key on `Type`. `IPAM.Status()` returns `[]map[string]any` because the per-entry shape is plugin-defined.
- **Route-map / prefix-list entries** are addressed by integer (`order` for route-maps, `seq` for prefix-lists). Match/set arrays on route-map entries use PVE's `[]string` of `key=…,value=…` property-strings — preserved on the wire as-is.
- **No `FIXME` left behind.** No new pointer fields needed except where PVE defaults to non-zero (SDN firewall `Enable` uses `*IntOrBool` on the update DTO so explicit-disable is sendable while leaving it absent preserves the server default).

## What's NOT in this PR (deferred to v0.7.x follow-ups)

The remaining cluster-area gaps (46 endpoints) are intentionally scoped out so this PR stays focused on SDN:

- `/cluster/config/*` (cluster join/leave, totem, qdevice)
- `/cluster/ceph/flags` + `/cluster/ceph/metadata`
- `/cluster/qemu/{cpu-flags,custom-cpu-models}`
- `/cluster/bulk-action/*`
- `/cluster/backup-info/*`
- `/cluster/options` PUT
- `/cluster/log`
- `/cluster/ha/status/{arm-ha,disarm-ha}`
- `/cluster/firewall/groups/{group}/{pos}` GET (group rule by position)
- `/cluster/metrics/export`
- `/cluster/notifications/endpoints` GET

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 .` passes (3.7s, all suites green)
- [x] `mage endpoints:coverage` confirms `/cluster/sdn` is 100% covered
- [x] Every new method has at least one happy-path gock test + an error-path test for required-arg validation where applicable
- [x] No new `FIXME` comments; pointer fields documented per AGENTS.md §"don't clobber PVE-side defaults"
- [x] No `Generated with Claude Code` footers, no emojis