### PR TITLE
feat(cluster): close remaining /cluster/* coverage gap - config, custom CPU models, bulk-action, ceph flags, backup-info, options, ha arm/disarm, log, notifications

### DIFF
--- a/cluster_backup_info.go
+++ b/cluster_backup_info.go
@@ -1,0 +1,39 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Wrappers for /cluster/backup-info + /cluster/backup/{id}/included_volumes —
+// cluster-wide backup coverage audit helpers.
+
+// BackupInfoSubdirs enumerates the children of /cluster/backup-info
+// ("not-backed-up" today). ACL-filtered.
+//
+// GET /cluster/backup-info
+func (cl *Cluster) BackupInfoSubdirs(ctx context.Context) ([]string, error) {
+	return cl.backupInfoDiridx(ctx, "/cluster/backup-info")
+}
+
+// GuestsNotInBackup returns guests that aren't covered by any backup job.
+//
+// GET /cluster/backup-info/not-backed-up
+func (cl *Cluster) GuestsNotInBackup(ctx context.Context) (guests []*BackupGuestEntry, err error) {
+	err = cl.client.Get(ctx, "/cluster/backup-info/not-backed-up", &guests)
+	return
+}
+
+// IncludedVolumes returns a tree of guests and their volumes' inclusion
+// status for the given backup job ID.
+//
+// GET /cluster/backup/{id}/included_volumes
+func (b *ClusterBackup) IncludedVolumes(ctx context.Context) (root *BackupIncludedVolumesRoot, err error) {
+	if b.ID == "" {
+		return nil, errors.New("backup id can not be empty")
+	}
+	root = &BackupIncludedVolumesRoot{}
+	err = b.client.Get(ctx, fmt.Sprintf("/cluster/backup/%s/included_volumes", b.ID), root)
+	return
+}

--- a/cluster_backup_info_test.go
+++ b/cluster_backup_info_test.go
@@ -1,0 +1,53 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_BackupInfoSubdirs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	subs, err := cluster.BackupInfoSubdirs(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subs, "not-backed-up")
+}
+
+func TestCluster_GuestsNotInBackup(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	guests, err := cluster.GuestsNotInBackup(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, guests, 1)
+	assert.Equal(t, 100, guests[0].VMID)
+	assert.Equal(t, "qemu", guests[0].Type)
+}
+
+func TestClusterBackup_IncludedVolumes(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	backup, err := cluster.Backup(context.Background(), "backup-1")
+	assert.Nil(t, err)
+	assert.NotNil(t, backup)
+
+	root, err := backup.IncludedVolumes(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, root)
+	assert.Len(t, root.Children, 1)
+	assert.Equal(t, 100, root.Children[0].ID)
+	assert.Len(t, root.Children[0].Children, 1)
+
+	// blank id guard
+	bare := &ClusterBackup{}
+	_, err = bare.IncludedVolumes(context.Background())
+	assert.Error(t, err)
+}

--- a/cluster_bulk_action.go
+++ b/cluster_bulk_action.go
@@ -1,0 +1,87 @@
+package proxmox
+
+import (
+	"context"
+)
+
+// Wrappers for /cluster/bulk-action — fleet-wide guest start/shutdown/suspend
+// /migrate operations. Each action returns a UPID for the worker task that
+// dispatches per-guest subtasks; poll the returned *Task for completion.
+
+// BulkActionSubdirs enumerates the children of /cluster/bulk-action ("guest"
+// today). ACL-filtered.
+//
+// GET /cluster/bulk-action
+func (cl *Cluster) BulkActionSubdirs(ctx context.Context) ([]string, error) {
+	return cl.bulkActionDiridx(ctx, "/cluster/bulk-action")
+}
+
+// BulkActionGuestSubdirs enumerates the children of /cluster/bulk-action/guest
+// ("start", "shutdown", "suspend", "migrate"). ACL-filtered.
+//
+// GET /cluster/bulk-action/guest
+func (cl *Cluster) BulkActionGuestSubdirs(ctx context.Context) ([]string, error) {
+	return cl.bulkActionDiridx(ctx, "/cluster/bulk-action/guest")
+}
+
+// BulkStartGuests starts (or resumes) all guests matching opts.VMIDs, or every
+// guest cluster-wide when opts.VMIDs is empty. Returns the UPID for the
+// worker task.
+//
+// POST /cluster/bulk-action/guest/start
+func (cl *Cluster) BulkStartGuests(ctx context.Context, opts *BulkStartOptions) (*Task, error) {
+	if opts == nil {
+		opts = &BulkStartOptions{}
+	}
+	var upid UPID
+	if err := cl.client.Post(ctx, "/cluster/bulk-action/guest/start", opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}
+
+// BulkShutdownGuests shuts down all guests matching opts.VMIDs, or every guest
+// cluster-wide when opts.VMIDs is empty. Returns the UPID for the worker task.
+//
+// POST /cluster/bulk-action/guest/shutdown
+func (cl *Cluster) BulkShutdownGuests(ctx context.Context, opts *BulkShutdownOptions) (*Task, error) {
+	if opts == nil {
+		opts = &BulkShutdownOptions{}
+	}
+	var upid UPID
+	if err := cl.client.Post(ctx, "/cluster/bulk-action/guest/shutdown", opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}
+
+// BulkSuspendGuests suspends all guests matching opts.VMIDs, or every guest
+// cluster-wide when opts.VMIDs is empty. Returns the UPID for the worker task.
+//
+// POST /cluster/bulk-action/guest/suspend
+func (cl *Cluster) BulkSuspendGuests(ctx context.Context, opts *BulkSuspendOptions) (*Task, error) {
+	if opts == nil {
+		opts = &BulkSuspendOptions{}
+	}
+	var upid UPID
+	if err := cl.client.Post(ctx, "/cluster/bulk-action/guest/suspend", opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}
+
+// BulkMigrateGuests migrates guests to the target node. opts.Target is
+// required by the schema; opts.VMIDs filters which guests are moved. Returns
+// the UPID for the worker task.
+//
+// POST /cluster/bulk-action/guest/migrate
+func (cl *Cluster) BulkMigrateGuests(ctx context.Context, opts *BulkMigrateOptions) (*Task, error) {
+	if opts == nil {
+		opts = &BulkMigrateOptions{}
+	}
+	var upid UPID
+	if err := cl.client.Post(ctx, "/cluster/bulk-action/guest/migrate", opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}

--- a/cluster_bulk_action_test.go
+++ b/cluster_bulk_action_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const fakeBulkUPID = "UPID:node1:0000ABCD:00ABCDEF:00000000:bulk_action:cluster:root@pam:"
-
 func TestCluster_BulkActionSubdirs(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/cluster_bulk_action_test.go
+++ b/cluster_bulk_action_test.go
@@ -1,0 +1,75 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+const fakeBulkUPID = "UPID:node1:0000ABCD:00ABCDEF:00000000:bulk_action:cluster:root@pam:"
+
+func TestCluster_BulkActionSubdirs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	subs, err := cluster.BulkActionSubdirs(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subs, "guest")
+}
+
+func TestCluster_BulkActionGuestSubdirs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	subs, err := cluster.BulkActionGuestSubdirs(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subs, "start")
+	assert.Contains(t, subs, "shutdown")
+	assert.Contains(t, subs, "migrate")
+	assert.Contains(t, subs, "suspend")
+}
+
+func TestCluster_BulkStartGuests(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	task, err := cluster.BulkStartGuests(context.Background(), &BulkStartOptions{VMIDs: []int{100, 101}})
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "node1", task.Node)
+}
+
+func TestCluster_BulkShutdownGuests(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	task, err := cluster.BulkShutdownGuests(context.Background(), nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+}
+
+func TestCluster_BulkSuspendGuests(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	task, err := cluster.BulkSuspendGuests(context.Background(), &BulkSuspendOptions{})
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+}
+
+func TestCluster_BulkMigrateGuests(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	task, err := cluster.BulkMigrateGuests(context.Background(), &BulkMigrateOptions{Target: "node2"})
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+}

--- a/cluster_ceph_flags.go
+++ b/cluster_ceph_flags.go
@@ -1,0 +1,73 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Wrappers for /cluster/ceph/flags + /cluster/ceph/metadata — cluster-wide
+// Ceph flag inspection / mutation and a per-service version snapshot.
+
+// CephFlags returns the catalog of Ceph OSD-map flags with their current
+// enabled state.
+//
+// GET /cluster/ceph/flags
+func (cl *Cluster) CephFlags(ctx context.Context) (flags []*CephFlag, err error) {
+	err = cl.client.Get(ctx, "/cluster/ceph/flags", &flags)
+	return
+}
+
+// CephFlag returns the current state of a single flag. Useful as a quick poll
+// helper without parsing the full catalog.
+//
+// GET /cluster/ceph/flags/{flag}
+func (cl *Cluster) CephFlag(ctx context.Context, flag string) (value string, err error) {
+	if flag == "" {
+		err = errors.New("ceph flag: name is required")
+		return
+	}
+	err = cl.client.Get(ctx, fmt.Sprintf("/cluster/ceph/flags/%s", flag), &value)
+	return
+}
+
+// CephMetadata returns the Ceph services version snapshot — versions and
+// device-id mapping per OSD, MON, MGR, MDS. PVE's response is a wide
+// version-dependent shape; we surface it as a typed root with the common
+// service buckets and let callers reach into the per-service maps directly.
+//
+// GET /cluster/ceph/metadata
+func (cl *Cluster) CephMetadata(ctx context.Context) (meta *CephMetadata, err error) {
+	meta = &CephMetadata{}
+	err = cl.client.Get(ctx, "/cluster/ceph/metadata", meta)
+	return
+}
+
+// SetCephFlags toggles multiple ceph flags atomically and returns a *Task for
+// the worker that applies them. Each pointer field in opts: true sets, false
+// unsets, nil leaves the flag alone.
+//
+// PUT /cluster/ceph/flags
+func (cl *Cluster) SetCephFlags(ctx context.Context, opts *CephFlagsUpdateOptions) (*Task, error) {
+	if opts == nil {
+		opts = &CephFlagsUpdateOptions{}
+	}
+	var upid UPID
+	if err := cl.client.Put(ctx, "/cluster/ceph/flags", opts, &upid); err != nil {
+		return nil, err
+	}
+	return NewTask(upid, cl.client), nil
+}
+
+// SetCephFlag sets or clears a single ceph flag synchronously. The PVE schema
+// describes this as a sync wrapper around the bulk endpoint; no UPID is
+// returned.
+//
+// PUT /cluster/ceph/flags/{flag}
+func (cl *Cluster) SetCephFlag(ctx context.Context, flag string, value bool) error {
+	if flag == "" {
+		return errors.New("ceph flag: name is required")
+	}
+	body := map[string]bool{"value": value}
+	return cl.client.Put(ctx, fmt.Sprintf("/cluster/ceph/flags/%s", flag), body, nil)
+}

--- a/cluster_ceph_flags_test.go
+++ b/cluster_ceph_flags_test.go
@@ -1,0 +1,67 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_CephFlags(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	flags, err := cluster.CephFlags(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, flags, 2)
+	assert.Equal(t, "noout", flags[0].Name)
+	assert.True(t, flags[0].Value)
+}
+
+func TestCluster_CephFlag(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, err := cluster.CephFlag(context.Background(), "noout")
+	assert.Nil(t, err)
+	assert.NotEmpty(t, v)
+
+	_, err = cluster.CephFlag(context.Background(), "")
+	assert.Error(t, err)
+}
+
+func TestCluster_CephMetadata(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	meta, err := cluster.CephMetadata(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, meta)
+	assert.NotNil(t, meta.Version)
+	assert.Equal(t, "18.2.0", meta.Version.Version)
+	assert.Len(t, meta.OSD, 1)
+}
+
+func TestCluster_SetCephFlags(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	noout := true
+	task, err := cluster.SetCephFlags(context.Background(), &CephFlagsUpdateOptions{NoOut: &noout})
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+}
+
+func TestCluster_SetCephFlag(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	assert.Nil(t, cluster.SetCephFlag(context.Background(), "noout", true))
+	assert.Error(t, cluster.SetCephFlag(context.Background(), "", true))
+}

--- a/cluster_config.go
+++ b/cluster_config.go
@@ -1,0 +1,132 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Wrappers for /cluster/config/* — corosync cluster bootstrap, join,
+// node membership, and read-only quorum / totem inspection. The POST and
+// DELETE endpoints under this tree are protected and intended to be driven
+// by `pvecm` on the affected node; we expose them for completeness so
+// callers building tooling on top of the API can drive them.
+
+// JoinAPIVersion returns the version of the cluster join API on this node.
+//
+// GET /cluster/config/apiversion
+func (cl *Cluster) JoinAPIVersion(ctx context.Context) (version int, err error) {
+	err = cl.client.Get(ctx, "/cluster/config/apiversion", &version)
+	return
+}
+
+// JoinInfo returns the parameters a prospective member needs to join this
+// cluster: nodelist, totem config, preferred-node, config digest, and per-node
+// SSH/cert fingerprints. node is optional — empty defaults to the connected
+// node.
+//
+// GET /cluster/config/join
+func (cl *Cluster) JoinInfo(ctx context.Context, node string) (info *ClusterJoinInfo, err error) {
+	path := "/cluster/config/join"
+	if node != "" {
+		path = path + "?node=" + node
+	}
+	info = &ClusterJoinInfo{}
+	err = cl.client.Get(ctx, path, info)
+	return
+}
+
+// JoinCluster joins this node to an existing cluster. PVE returns a status
+// string on success (not a UPID). opts.Hostname, opts.Password, and
+// opts.Fingerprint are required.
+//
+// POST /cluster/config/join
+func (cl *Cluster) JoinCluster(ctx context.Context, opts *ClusterJoinOptions) (status string, err error) {
+	if opts == nil || opts.Hostname == "" {
+		err = errors.New("cluster join: hostname is required")
+		return
+	}
+	if opts.Password == "" {
+		err = errors.New("cluster join: password is required")
+		return
+	}
+	if opts.Fingerprint == "" {
+		err = errors.New("cluster join: fingerprint is required")
+		return
+	}
+	err = cl.client.Post(ctx, "/cluster/config/join", opts, &status)
+	return
+}
+
+// ConfigNodes lists the corosync node list (just names — use
+// ClusterStatus/NodeStatuses for richer per-node state).
+//
+// GET /cluster/config/nodes
+func (cl *Cluster) ConfigNodes(ctx context.Context) (nodes []*ClusterConfigNodeEntry, err error) {
+	err = cl.client.Get(ctx, "/cluster/config/nodes", &nodes)
+	return
+}
+
+// QDevice returns the QDevice (corosync external arbitrator) status. Returns
+// an open-shape map because PVE's response shape depends on whether qdevice
+// is configured and which net algorithm is in use.
+//
+// GET /cluster/config/qdevice
+func (cl *Cluster) QDevice(ctx context.Context) (status map[string]any, err error) {
+	status = map[string]any{}
+	err = cl.client.Get(ctx, "/cluster/config/qdevice", &status)
+	return
+}
+
+// Totem returns the corosync totem protocol settings (token timeouts, link
+// modes, secauth, etc.). Returns an open-shape map because the totem config
+// has many version-dependent knobs.
+//
+// GET /cluster/config/totem
+func (cl *Cluster) Totem(ctx context.Context) (totem map[string]any, err error) {
+	totem = map[string]any{}
+	err = cl.client.Get(ctx, "/cluster/config/totem", &totem)
+	return
+}
+
+// CreateCluster generates a new cluster configuration on this node. PVE
+// returns a status string on success.
+//
+// POST /cluster/config
+func (cl *Cluster) CreateCluster(ctx context.Context, opts *ClusterCreateOptions) (status string, err error) {
+	if opts == nil || opts.ClusterName == "" {
+		err = errors.New("cluster create: clustername is required")
+		return
+	}
+	err = cl.client.Post(ctx, "/cluster/config", opts, &status)
+	return
+}
+
+// AddConfigNode adds a node to the cluster configuration. PVE documents this
+// call as "for internal use" — it returns corosync.conf bytes + the authkey
+// the new node needs, which `pvecm add` normally consumes locally. Exposed
+// here for tooling.
+//
+// POST /cluster/config/nodes/{node}
+func (cl *Cluster) AddConfigNode(ctx context.Context, node string, opts *ClusterAddNodeOptions) (result *ClusterAddNodeResult, err error) {
+	if node == "" {
+		err = errors.New("cluster add node: node is required")
+		return
+	}
+	if opts == nil {
+		opts = &ClusterAddNodeOptions{}
+	}
+	result = &ClusterAddNodeResult{}
+	err = cl.client.Post(ctx, fmt.Sprintf("/cluster/config/nodes/%s", node), opts, result)
+	return
+}
+
+// DeleteConfigNode removes a node from the cluster configuration.
+//
+// DELETE /cluster/config/nodes/{node}
+func (cl *Cluster) DeleteConfigNode(ctx context.Context, node string) error {
+	if node == "" {
+		return errors.New("cluster delete node: node is required")
+	}
+	return cl.client.Delete(ctx, fmt.Sprintf("/cluster/config/nodes/%s", node), nil)
+}

--- a/cluster_config_test.go
+++ b/cluster_config_test.go
@@ -1,0 +1,125 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_JoinAPIVersion(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, err := cluster.JoinAPIVersion(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, 1, v)
+}
+
+func TestCluster_JoinInfo(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	info, err := cluster.JoinInfo(context.Background(), "")
+	assert.Nil(t, err)
+	assert.NotNil(t, info)
+	assert.Equal(t, "node1", info.PreferredNode)
+	assert.Equal(t, "abc123", info.ConfigDigest)
+	assert.Len(t, info.NodeList, 1)
+	assert.Equal(t, "node1", info.NodeList[0].Name)
+	assert.NotNil(t, info.Totem)
+}
+
+func TestCluster_JoinCluster(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	status, err := cluster.JoinCluster(context.Background(), &ClusterJoinOptions{
+		Hostname:    "10.0.0.1",
+		Password:    "secret",
+		Fingerprint: "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99",
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, "OK", status)
+
+	_, err = cluster.JoinCluster(context.Background(), nil)
+	assert.Error(t, err)
+	_, err = cluster.JoinCluster(context.Background(), &ClusterJoinOptions{Hostname: "x"})
+	assert.Error(t, err)
+	_, err = cluster.JoinCluster(context.Background(), &ClusterJoinOptions{Hostname: "x", Password: "p"})
+	assert.Error(t, err)
+}
+
+func TestCluster_ConfigNodes(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	nodes, err := cluster.ConfigNodes(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, nodes, 2)
+	assert.Equal(t, "node1", nodes[0].Node)
+}
+
+func TestCluster_QDevice(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	status, err := cluster.QDevice(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, "running", status["state"])
+}
+
+func TestCluster_Totem(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	totem, err := cluster.Totem(context.Background())
+	assert.Nil(t, err)
+	assert.Equal(t, "knet", totem["transport"])
+}
+
+func TestCluster_CreateCluster(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	status, err := cluster.CreateCluster(context.Background(), &ClusterCreateOptions{ClusterName: "mycluster"})
+	assert.Nil(t, err)
+	assert.Equal(t, "OK", status)
+
+	_, err = cluster.CreateCluster(context.Background(), nil)
+	assert.Error(t, err)
+	_, err = cluster.CreateCluster(context.Background(), &ClusterCreateOptions{})
+	assert.Error(t, err)
+}
+
+func TestCluster_AddConfigNode(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	res, err := cluster.AddConfigNode(context.Background(), "node2", &ClusterAddNodeOptions{NewNodeIP: "10.0.0.2"})
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+	assert.NotEmpty(t, res.CorosyncConf)
+	assert.NotEmpty(t, res.CorosyncAuthkey)
+
+	_, err = cluster.AddConfigNode(context.Background(), "", nil)
+	assert.Error(t, err)
+}
+
+func TestCluster_DeleteConfigNode(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	assert.Nil(t, cluster.DeleteConfigNode(context.Background(), "node2"))
+	assert.Error(t, cluster.DeleteConfigNode(context.Background(), ""))
+}

--- a/cluster_diridx.go
+++ b/cluster_diridx.go
@@ -99,3 +99,19 @@ func (cl *Cluster) haDiridx(ctx context.Context, path string) ([]string, error) 
 func (cl *Cluster) qemuDiridx(ctx context.Context, path string) ([]string, error) {
 	return decodeSubdirList(ctx, cl.client, path)
 }
+
+func (cl *Cluster) bulkActionDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) backupInfoDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) metricsDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}
+
+func (cl *Cluster) notificationsDiridx(ctx context.Context, path string) ([]string, error) {
+	return decodeSubdirList(ctx, cl.client, path)
+}

--- a/cluster_ha.go
+++ b/cluster_ha.go
@@ -2,6 +2,7 @@ package proxmox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -135,4 +136,24 @@ func (cl *Cluster) HAManagerStatus(ctx context.Context) (status *HAManagerStatus
 	status = &HAManagerStatus{}
 	err = cl.client.Get(ctx, "/cluster/ha/status/manager_status", status)
 	return
+}
+
+// HAArm re-arms the HA stack after it was previously disarmed. Manual
+// quorum-override action — requires Sys.Console on /.
+//
+// POST /cluster/ha/status/arm-ha
+func (cl *Cluster) HAArm(ctx context.Context) error {
+	return cl.client.Post(ctx, "/cluster/ha/status/arm-ha", nil, nil)
+}
+
+// HADisarm requests disarming the HA stack and releases watchdogs cluster-wide.
+// resourceMode is required by PVE: "freeze" preserves HA-tracking state but
+// holds commands, "ignore" removes resources from HA tracking entirely.
+//
+// POST /cluster/ha/status/disarm-ha
+func (cl *Cluster) HADisarm(ctx context.Context, resourceMode string) error {
+	if resourceMode == "" {
+		return errors.New("ha disarm: resource-mode is required (\"freeze\" or \"ignore\")")
+	}
+	return cl.client.Post(ctx, "/cluster/ha/status/disarm-ha", map[string]string{"resource-mode": resourceMode}, nil)
 }

--- a/cluster_ha_test.go
+++ b/cluster_ha_test.go
@@ -250,3 +250,20 @@ func TestCluster_HAManagerStatus(t *testing.T) {
 	assert.NotNil(t, mgr.NodeStatus)
 	assert.Equal(t, "online", mgr.NodeStatus["node1"])
 }
+
+func TestCluster_HAArm(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	assert.Nil(t, cluster.HAArm(context.Background()))
+}
+
+func TestCluster_HADisarm(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	assert.Nil(t, cluster.HADisarm(context.Background(), "freeze"))
+	assert.Error(t, cluster.HADisarm(context.Background(), ""))
+}

--- a/cluster_metrics.go
+++ b/cluster_metrics.go
@@ -4,7 +4,61 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"strconv"
 )
+
+// MetricsSubdirs enumerates the children of /cluster/metrics ("server",
+// "export"). ACL-filtered.
+//
+// GET /cluster/metrics
+func (cl *Cluster) MetricsSubdirs(ctx context.Context) ([]string, error) {
+	return cl.metricsDiridx(ctx, "/cluster/metrics")
+}
+
+// MetricsExportOptions filters the /cluster/metrics/export response.
+type MetricsExportOptions struct {
+	// History returns the full historic series instead of just the latest
+	// observation. PVE default false; matches Go zero, so plain bool is safe.
+	History bool
+	// LocalOnly restricts the output to the current node instead of the whole
+	// cluster. PVE default false; matches Go zero.
+	LocalOnly bool
+	// StartTime: only include metrics with timestamp > start-time (unix
+	// seconds). 0 disables the filter.
+	StartTime int64
+	// NodeList: comma-separated node names to scope the export to. Empty =
+	// all nodes (or local-only when LocalOnly is true).
+	NodeList string
+}
+
+// MetricsExport retrieves cluster metrics. opts is optional.
+//
+// GET /cluster/metrics/export
+func (cl *Cluster) MetricsExport(ctx context.Context, opts *MetricsExportOptions) (export *MetricsExportResponse, err error) {
+	path := "/cluster/metrics/export"
+	if opts != nil {
+		q := url.Values{}
+		if opts.History {
+			q.Set("history", "1")
+		}
+		if opts.LocalOnly {
+			q.Set("local-only", "1")
+		}
+		if opts.StartTime > 0 {
+			q.Set("start-time", strconv.FormatInt(opts.StartTime, 10))
+		}
+		if opts.NodeList != "" {
+			q.Set("node-list", opts.NodeList)
+		}
+		if enc := q.Encode(); enc != "" {
+			path = path + "?" + enc
+		}
+	}
+	export = &MetricsExportResponse{}
+	err = cl.client.Get(ctx, path, export)
+	return
+}
 
 // MetricServers lists configured external metric servers (graphite / influxdb /
 // opentelemetry). See https://pve.proxmox.com/pve-docs/api-viewer/#/cluster/metrics/server

--- a/cluster_metrics_test.go
+++ b/cluster_metrics_test.go
@@ -109,6 +109,45 @@ func TestCluster_UpdateMetricServer(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestCluster_MetricsSubdirs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	subs, err := cluster.MetricsSubdirs(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subs, "server")
+	assert.Contains(t, subs, "export")
+}
+
+func TestCluster_MetricsExport(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	export, err := cluster.MetricsExport(context.Background(), nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, export)
+	assert.Len(t, export.Data, 2)
+	assert.Equal(t, "node/node1", export.Data[0].ID)
+	assert.Equal(t, "gauge", export.Data[0].Type)
+}
+
+func TestCluster_MetricsExport_WithOptions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	export, err := cluster.MetricsExport(context.Background(), &MetricsExportOptions{
+		History:   true,
+		LocalOnly: true,
+		StartTime: 1700000000,
+		NodeList:  "node1,node2",
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, export)
+}
+
 func TestCluster_DeleteMetricServer(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()

--- a/cluster_misc.go
+++ b/cluster_misc.go
@@ -1,0 +1,52 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// Miscellaneous /cluster/* wrappers: cluster-wide log, the
+// notifications/endpoints diridx, and the GET single-rule helper on a
+// firewall security group.
+
+// Log returns the cluster-wide task log. max caps the number of entries; 0
+// uses the PVE default.
+//
+// GET /cluster/log
+func (cl *Cluster) Log(ctx context.Context, max int) (entries []*ClusterLogEntry, err error) {
+	path := "/cluster/log"
+	if max > 0 {
+		q := url.Values{}
+		q.Set("max", strconv.Itoa(max))
+		path = path + "?" + q.Encode()
+	}
+	err = cl.client.Get(ctx, path, &entries)
+	return
+}
+
+// NotificationEndpointsSubdirs enumerates the children of
+// /cluster/notifications/endpoints ("sendmail", "gotify", "smtp", "webhook").
+// ACL-filtered. Each typed sub-resource is already covered by the per-type
+// methods on *Cluster (NotificationSendmail, NotificationGotify, …).
+//
+// GET /cluster/notifications/endpoints
+func (cl *Cluster) NotificationEndpointsSubdirs(ctx context.Context) ([]string, error) {
+	return cl.notificationsDiridx(ctx, "/cluster/notifications/endpoints")
+}
+
+// FWGroupRule returns a single firewall rule in this security group by
+// position. Companion to (*FirewallSecurityGroup).RuleCreate /
+// RuleUpdate / RuleDelete.
+//
+// GET /cluster/firewall/groups/{group}/{pos}
+func (g *FirewallSecurityGroup) GetRule(ctx context.Context, pos int) (rule *FirewallRule, err error) {
+	if g.Group == "" {
+		return nil, errors.New("firewall security group: name is required")
+	}
+	rule = &FirewallRule{}
+	err = g.client.Get(ctx, fmt.Sprintf("/cluster/firewall/groups/%s/%d", g.Group, pos), rule)
+	return
+}

--- a/cluster_misc_test.go
+++ b/cluster_misc_test.go
@@ -1,0 +1,64 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_Log(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.Log(context.Background(), 0)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 2)
+	assert.Equal(t, "node1", entries[0].Node)
+}
+
+func TestCluster_Log_WithMax(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.Log(context.Background(), 50)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, entries)
+}
+
+func TestCluster_NotificationEndpointsSubdirs(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	subs, err := cluster.NotificationEndpointsSubdirs(context.Background())
+	assert.Nil(t, err)
+	assert.Contains(t, subs, "sendmail")
+	assert.Contains(t, subs, "gotify")
+	assert.Contains(t, subs, "smtp")
+	assert.Contains(t, subs, "webhook")
+}
+
+func TestFirewallSecurityGroup_GetRule(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	group, err := cluster.FWGroup(context.Background(), "test-group")
+	assert.Nil(t, err)
+	assert.NotNil(t, group)
+
+	rule, err := group.GetRule(context.Background(), 0)
+	assert.Nil(t, err)
+	assert.NotNil(t, rule)
+	assert.Equal(t, "in", rule.Type)
+	assert.Equal(t, "ACCEPT", rule.Action)
+
+	// blank-group guard
+	empty := &FirewallSecurityGroup{}
+	_, err = empty.GetRule(context.Background(), 0)
+	assert.Error(t, err)
+}

--- a/cluster_options.go
+++ b/cluster_options.go
@@ -1,0 +1,138 @@
+package proxmox
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+)
+
+// Wrappers for /cluster/options — the datacenter.cfg surface. The PVE schema
+// here is wide and growing (50+ keys across HA, CRS, migration, replication,
+// notifications, MAC prefix, tag styles, U2F/WebAuthn, console default, …).
+// We expose:
+//
+//   - a typed struct for the most common scalars (console, keyboard,
+//     language, mac_prefix, max_workers, http_proxy, fencing, migration,
+//     description, email_from, …) — round-trippable cleanly;
+//
+//   - an Extra map[string]any for the long tail (HA, CRS, replication,
+//     notify, location, tag-style, u2f, webauthn, next-id, etc.) so callers
+//     can read/write keys we haven't gone through the trouble of typing.
+//     PVE's `additionalProperties: 0` means *unknown* keys are rejected on
+//     PUT, but Extra is populated from the GET response so callers can read
+//     whatever the server returned and pass it back as a map.
+//
+// The Update path accepts a typed *ClusterOptionsUpdate to keep the typed
+// scalars discoverable without forcing callers to learn the Extra-map
+// convention for fields they DO want to type.
+
+// ClusterOptions reads the cluster-wide datacenter.cfg.
+//
+// GET /cluster/options
+func (cl *Cluster) ClusterOptions(ctx context.Context) (opts *ClusterOptionsResponse, err error) {
+	opts = &ClusterOptionsResponse{}
+	err = cl.client.Get(ctx, "/cluster/options", opts)
+	return
+}
+
+// UpdateClusterOptions mutates the datacenter.cfg. opts.Delete is a
+// comma-separated list of keys to reset to their PVE defaults.
+//
+// PUT /cluster/options
+func (cl *Cluster) UpdateClusterOptions(ctx context.Context, opts *ClusterOptionsUpdate) error {
+	if opts == nil {
+		opts = &ClusterOptionsUpdate{}
+	}
+	return cl.client.Put(ctx, "/cluster/options", opts, nil)
+}
+
+// UnmarshalJSON splits the wire payload into typed scalars and the Extra
+// catch-all map so callers can read every key PVE returned without us
+// enumerating the entire wide datacenter.cfg surface.
+func (r *ClusterOptionsResponse) UnmarshalJSON(data []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Decode the typed scalars by round-tripping the raw map through the
+	// alias to avoid recursion into this method.
+	type alias ClusterOptionsResponse
+	scalar, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	tmp := alias{}
+	if err := json.Unmarshal(scalar, &tmp); err != nil {
+		return err
+	}
+	*r = ClusterOptionsResponse(tmp)
+
+	// Extra captures every key not consumed by a typed field.
+	typed := map[string]struct{}{}
+	t := reflect.TypeOf(*r)
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := tag
+		if c := indexComma(tag); c >= 0 {
+			name = tag[:c]
+		}
+		typed[name] = struct{}{}
+	}
+	extra := map[string]any{}
+	for k, v := range raw {
+		if _, ok := typed[k]; ok {
+			continue
+		}
+		var any any
+		if err := json.Unmarshal(v, &any); err != nil {
+			return err
+		}
+		extra[k] = any
+	}
+	if len(extra) > 0 {
+		r.Extra = extra
+	}
+	return nil
+}
+
+// MarshalJSON merges Extra into the wire payload alongside the typed scalars.
+// Typed keys take precedence over Extra (a caller mistake — typed scalar
+// should be the source of truth).
+func (u ClusterOptionsUpdate) MarshalJSON() ([]byte, error) {
+	type alias ClusterOptionsUpdate
+	scalar, err := json.Marshal(alias(u))
+	if err != nil {
+		return nil, err
+	}
+	if len(u.Extra) == 0 {
+		return scalar, nil
+	}
+	m := map[string]json.RawMessage{}
+	if err := json.Unmarshal(scalar, &m); err != nil {
+		return nil, err
+	}
+	for k, v := range u.Extra {
+		if _, exists := m[k]; exists {
+			continue
+		}
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		m[k] = raw
+	}
+	return json.Marshal(m)
+}
+
+func indexComma(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ',' {
+			return i
+		}
+	}
+	return -1
+}

--- a/cluster_options_test.go
+++ b/cluster_options_test.go
@@ -1,0 +1,60 @@
+package proxmox
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_ClusterOptions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	opts, err := cluster.ClusterOptions(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, opts)
+	assert.Equal(t, "html5", opts.Console)
+	assert.Equal(t, "en", opts.Language)
+	assert.Equal(t, 4, opts.MaxWorkers)
+
+	// Extra picks up the long-tail keys.
+	assert.NotNil(t, opts.Extra)
+	assert.Contains(t, opts.Extra, "ha")
+	assert.Contains(t, opts.Extra, "next-id")
+}
+
+func TestCluster_UpdateClusterOptions(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.UpdateClusterOptions(context.Background(), &ClusterOptionsUpdate{
+		Console:  "xtermjs",
+		Language: "en",
+	})
+	assert.Nil(t, err)
+
+	err = cluster.UpdateClusterOptions(context.Background(), nil)
+	assert.Nil(t, err)
+}
+
+func TestClusterOptionsUpdate_MarshalIncludesExtra(t *testing.T) {
+	u := ClusterOptionsUpdate{
+		Console: "xtermjs",
+		Extra: map[string]any{
+			"ha":      "shutdown_policy=conditional",
+			"next-id": "lower=100,upper=1000000",
+		},
+	}
+	b, err := json.Marshal(u)
+	assert.Nil(t, err)
+	m := map[string]any{}
+	assert.Nil(t, json.Unmarshal(b, &m))
+	assert.Equal(t, "xtermjs", m["console"])
+	assert.Equal(t, "shutdown_policy=conditional", m["ha"])
+	assert.Equal(t, "lower=100,upper=1000000", m["next-id"])
+}

--- a/cluster_qemu_cpu.go
+++ b/cluster_qemu_cpu.go
@@ -1,0 +1,102 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Wrappers for /cluster/qemu/cpu-flags and /cluster/qemu/custom-cpu-models —
+// the QEMU CPU flag catalog and CRUD for custom CPU model definitions used by
+// `cpu: custom-<name>` in VM configs.
+
+// QEMUCPUFlags returns the catalog of CPU flags available across the cluster
+// (currently x86_64 only — aarch64 returns an empty list). arch and accel are
+// optional; pass "" to use PVE defaults (host arch + kvm acceleration).
+//
+// GET /cluster/qemu/cpu-flags
+func (cl *Cluster) QEMUCPUFlags(ctx context.Context, arch, accel string) (flags []*QEMUCPUFlag, err error) {
+	path := "/cluster/qemu/cpu-flags"
+	q := url.Values{}
+	if arch != "" {
+		q.Set("arch", arch)
+	}
+	if accel != "" {
+		q.Set("accel", accel)
+	}
+	if enc := q.Encode(); enc != "" {
+		path = path + "?" + enc
+	}
+	err = cl.client.Get(ctx, path, &flags)
+	return
+}
+
+// CustomCPUModels lists configured custom CPU model definitions. Only entries
+// the caller has Mapping.{Audit,Use,Modify} on are returned.
+//
+// GET /cluster/qemu/custom-cpu-models
+func (cl *Cluster) CustomCPUModels(ctx context.Context) (models []*CustomCPUModel, err error) {
+	if err = cl.client.Get(ctx, "/cluster/qemu/custom-cpu-models", &models); err != nil {
+		return nil, err
+	}
+	for _, m := range models {
+		m.client = cl.client
+	}
+	return
+}
+
+// CustomCPUModel returns a handle for a single custom CPU model. No API call.
+// The "custom-" prefix on cputype is optional per PVE.
+//
+// GET /cluster/qemu/custom-cpu-models/{cputype}
+func (cl *Cluster) CustomCPUModel(cputype string) *CustomCPUModel {
+	return &CustomCPUModel{client: cl.client, CPUType: cputype}
+}
+
+// NewCustomCPUModel creates a new custom CPU model. opts.CPUType is required;
+// opts.ReportedModel is required by PVE per the schema (optional=0).
+//
+// POST /cluster/qemu/custom-cpu-models
+func (cl *Cluster) NewCustomCPUModel(ctx context.Context, opts *CustomCPUModelOptions) error {
+	if opts == nil || opts.CPUType == "" {
+		return errors.New("custom cpu model: cputype is required")
+	}
+	if opts.ReportedModel == "" {
+		return errors.New("custom cpu model: reported-model is required")
+	}
+	return cl.client.Post(ctx, "/cluster/qemu/custom-cpu-models", opts, nil)
+}
+
+// Read populates the receiver with the current definition.
+//
+// GET /cluster/qemu/custom-cpu-models/{cputype}
+func (m *CustomCPUModel) Read(ctx context.Context) error {
+	if m.CPUType == "" {
+		return errors.New("custom cpu model: cputype is required")
+	}
+	return m.client.Get(ctx, fmt.Sprintf("/cluster/qemu/custom-cpu-models/%s", m.CPUType), m)
+}
+
+// Update mutates an existing custom CPU model.
+//
+// PUT /cluster/qemu/custom-cpu-models/{cputype}
+func (m *CustomCPUModel) Update(ctx context.Context, opts *CustomCPUModelOptions) error {
+	if m.CPUType == "" {
+		return errors.New("custom cpu model: cputype is required")
+	}
+	if opts == nil {
+		opts = &CustomCPUModelOptions{}
+	}
+	return m.client.Put(ctx, fmt.Sprintf("/cluster/qemu/custom-cpu-models/%s", m.CPUType), opts, nil)
+}
+
+// Delete removes a custom CPU model definition.
+//
+// DELETE /cluster/qemu/custom-cpu-models/{cputype}
+func (m *CustomCPUModel) Delete(ctx context.Context) error {
+	if m.CPUType == "" {
+		return errors.New("custom cpu model: cputype is required")
+	}
+	return m.client.Delete(ctx, fmt.Sprintf("/cluster/qemu/custom-cpu-models/%s", m.CPUType), nil)
+}

--- a/cluster_qemu_cpu_test.go
+++ b/cluster_qemu_cpu_test.go
@@ -1,0 +1,75 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_QEMUCPUFlags(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	flags, err := cluster.QEMUCPUFlags(context.Background(), "", "")
+	assert.Nil(t, err)
+	assert.Len(t, flags, 2)
+	assert.Equal(t, "aes", flags[0].Name)
+}
+
+func TestCluster_QEMUCPUFlags_WithArchAccel(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	flags, err := cluster.QEMUCPUFlags(context.Background(), "x86_64", "kvm")
+	assert.Nil(t, err)
+	assert.Len(t, flags, 2)
+}
+
+func TestCluster_CustomCPUModels(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	models, err := cluster.CustomCPUModels(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, models, 1)
+	assert.Equal(t, "custom-epyc", models[0].CPUType)
+}
+
+func TestCustomCPUModel_CRUD(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	m := cluster.CustomCPUModel("custom-epyc")
+	assert.Nil(t, m.Read(context.Background()))
+	assert.Equal(t, "EPYC", m.ReportedModel)
+
+	assert.Nil(t, m.Update(context.Background(), &CustomCPUModelOptions{Flags: "+aes"}))
+	assert.Nil(t, m.Delete(context.Background()))
+
+	// blank cputype guard
+	empty := cluster.CustomCPUModel("")
+	assert.Error(t, empty.Read(context.Background()))
+	assert.Error(t, empty.Update(context.Background(), nil))
+	assert.Error(t, empty.Delete(context.Background()))
+}
+
+func TestCluster_NewCustomCPUModel(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewCustomCPUModel(context.Background(), &CustomCPUModelOptions{
+		CPUType:       "custom-epyc",
+		ReportedModel: "EPYC",
+	})
+	assert.Nil(t, err)
+
+	assert.Error(t, cluster.NewCustomCPUModel(context.Background(), nil))
+	assert.Error(t, cluster.NewCustomCPUModel(context.Background(), &CustomCPUModelOptions{CPUType: "x"}))
+}

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -2233,4 +2233,294 @@ func clusterReplication() {
 		Delete("^/cluster/sdn/vnets/user1/subnets/zone1-10.0.0.0-24$").
 		Reply(200).
 		JSON(`{"data":null}`)
+
+	// --- /cluster/config/* ----------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/config/apiversion$").
+		Reply(200).
+		JSON(`{"data":1}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/config/join$").
+		Reply(200).
+		JSON(`{"data":{
+			"config_digest":"abc123",
+			"preferred_node":"node1",
+			"nodelist":[
+				{"name":"node1","nodeid":1,"pve_addr":"10.0.0.1","pve_fp":"AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99","quorum_votes":1,"ring0_addr":"10.0.0.1"}
+			],
+			"totem":{"transport":"knet","token":10000}
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/config/join$").
+		Reply(200).
+		JSON(`{"data":"OK"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/config/nodes$").
+		Reply(200).
+		JSON(`{"data":[{"node":"node1"},{"node":"node2"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/config/qdevice$").
+		Reply(200).
+		JSON(`{"data":{"state":"running","mode":"sync"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/config/totem$").
+		Reply(200).
+		JSON(`{"data":{"transport":"knet","token":10000,"version":2}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/config$").
+		Reply(200).
+		JSON(`{"data":"OK"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/config/nodes/node2$").
+		Reply(200).
+		JSON(`{"data":{"corosync_authkey":"key-bytes","corosync_conf":"conf-bytes","warnings":[]}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/config/nodes/node2$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/qemu/cpu-flags + custom-cpu-models --------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/qemu/cpu-flags$").
+		Reply(200).
+		JSON(`{"data":[
+			{"name":"aes","description":"AES-NI","supported-on":["node1","node2"]},
+			{"name":"avx2","description":"AVX2","supported-on":["node1"]}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/qemu/custom-cpu-models$").
+		Reply(200).
+		JSON(`{"data":[
+			{"cputype":"custom-epyc","reported-model":"EPYC","flags":"+aes","hidden":0}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/qemu/custom-cpu-models/custom-epyc$").
+		Reply(200).
+		JSON(`{"data":{"cputype":"custom-epyc","reported-model":"EPYC","flags":"+aes","hidden":0,"phys-bits":"host"}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/qemu/custom-cpu-models$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/qemu/custom-cpu-models/custom-epyc$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/qemu/custom-cpu-models/custom-epyc$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/bulk-action -------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/bulk-action$").
+		Reply(200).
+		JSON(`{"data":[{"subdir":"guest"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/bulk-action/guest$").
+		Reply(200).
+		JSON(`{"data":[{"subdir":"start"},{"subdir":"shutdown"},{"subdir":"suspend"},{"subdir":"migrate"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/bulk-action/guest/start$").
+		Reply(200).
+		JSON(`{"data":"UPID:node1:0000ABCD:00ABCDEF:00000000:bulk_action:cluster:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/bulk-action/guest/shutdown$").
+		Reply(200).
+		JSON(`{"data":"UPID:node1:0000ABCD:00ABCDEF:00000000:bulk_action:cluster:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/bulk-action/guest/suspend$").
+		Reply(200).
+		JSON(`{"data":"UPID:node1:0000ABCD:00ABCDEF:00000000:bulk_action:cluster:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/bulk-action/guest/migrate$").
+		Reply(200).
+		JSON(`{"data":"UPID:node1:0000ABCD:00ABCDEF:00000000:bulk_action:cluster:root@pam:"}`)
+
+	// --- /cluster/ceph/flags + /cluster/ceph/metadata -------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/ceph/flags$").
+		Reply(200).
+		JSON(`{"data":[
+			{"name":"noout","description":"OSDs will not be marked out","value":true},
+			{"name":"noscrub","description":"Scrubbing disabled","value":false}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/ceph/flags/noout$").
+		Reply(200).
+		JSON(`{"data":"set"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/ceph/metadata$").
+		Reply(200).
+		JSON(`{"data":{
+			"version":{"version":"18.2.0","buildcommit":"abc"},
+			"osd":[{"id":0,"ceph_version":"18.2.0","hostname":"node1"}],
+			"mon":[],
+			"mgr":[],
+			"mds":[]
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/ceph/flags$").
+		Reply(200).
+		JSON(`{"data":"UPID:node1:0000ABCD:00ABCDEF:00000000:cephflags:cluster:root@pam:"}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/ceph/flags/noout$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/backup-info -------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/backup-info$").
+		Reply(200).
+		JSON(`{"data":[{"subdir":"not-backed-up"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/backup-info/not-backed-up$").
+		Reply(200).
+		JSON(`{"data":[
+			{"vmid":100,"type":"qemu","name":"server1"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/backup/backup-1/included_volumes$").
+		Reply(200).
+		JSON(`{"data":{
+			"children":[
+				{"id":100,"type":"qemu","name":"server1","children":[
+					{"id":"scsi0","name":"local-lvm:vm-100-disk-0","included":true,"reason":"in-backup"}
+				]}
+			]
+		}}`)
+
+	// --- /cluster/ha/status/{arm,disarm}-ha -----------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/ha/status/arm-ha$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/ha/status/disarm-ha$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/metrics (top-level) + /cluster/metrics/export ---------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/metrics$").
+		Reply(200).
+		JSON(`{"data":[{"subdir":"server"},{"subdir":"export"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/metrics/export").
+		Reply(200).
+		JSON(`{"data":{"data":[
+			{"id":"node/node1","metric":"cpu","timestamp":1700000000,"type":"gauge","value":0.42},
+			{"id":"qemu/100","metric":"mem","timestamp":1700000000,"type":"gauge","value":123456789}
+		]}}`)
+
+	// --- /cluster/options -----------------------------------------------------
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/options$").
+		Reply(200).
+		JSON(`{"data":{
+			"console":"html5",
+			"language":"en",
+			"max_workers":4,
+			"mac_prefix":"BC:24:11",
+			"migration":"secure",
+			"ha":"shutdown_policy=conditional",
+			"next-id":"lower=100,upper=1000000",
+			"crs":"ha=basic"
+		}}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/options$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// --- /cluster/log + /cluster/notifications/endpoints + firewall group rule
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/log").
+		Reply(200).
+		JSON(`{"data":[
+			{"node":"node1","time":1700000000,"user":"root@pam","pri":6,"tag":"task","msg":"start"},
+			{"node":"node2","time":1700000050,"user":"root@pam","pri":6,"tag":"task","msg":"done"}
+		]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/notifications/endpoints$").
+		Reply(200).
+		JSON(`{"data":[{"subdir":"sendmail"},{"subdir":"gotify"},{"subdir":"smtp"},{"subdir":"webhook"}]}`)
+
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/firewall/groups/test-group/0$").
+		Reply(200).
+		JSON(`{"data":{"pos":0,"type":"in","action":"ACCEPT","enable":1,"source":"10.0.0.0/24"}}`)
 }

--- a/types.go
+++ b/types.go
@@ -4916,3 +4916,345 @@ type StorageIdentity struct {
 	ID   string `json:"id"`
 	Type string `json:"type"`
 }
+
+// --- /cluster/config -------------------------------------------------------
+
+// ClusterJoinInfo is the response shape of GET /cluster/config/join — the
+// payload a new node needs (or that pvecm consumes) to join the cluster.
+type ClusterJoinInfo struct {
+	ConfigDigest  string                 `json:"config_digest,omitempty"`
+	PreferredNode string                 `json:"preferred_node,omitempty"`
+	NodeList      []*ClusterJoinNodeInfo `json:"nodelist,omitempty"`
+	// Totem is the corosync totem subtree as returned by PVE — open shape
+	// because the config can carry arbitrary corosync-format keys.
+	Totem map[string]any `json:"totem,omitempty"`
+}
+
+// ClusterJoinNodeInfo is one entry in the join-info nodelist.
+type ClusterJoinNodeInfo struct {
+	Name        string `json:"name,omitempty"`
+	NodeID      int    `json:"nodeid,omitempty"`
+	PVEAddr     string `json:"pve_addr,omitempty"`
+	PVEFP       string `json:"pve_fp,omitempty"` // SHA-256 certificate fingerprint
+	QuorumVotes int    `json:"quorum_votes,omitempty"`
+	Ring0Addr   string `json:"ring0_addr,omitempty"`
+}
+
+// ClusterJoinOptions is the body of POST /cluster/config/join.
+type ClusterJoinOptions struct {
+	Hostname    string `json:"hostname,omitempty"`    // required: existing cluster member
+	Password    string `json:"password,omitempty"`    // required: root password of peer
+	Fingerprint string `json:"fingerprint,omitempty"` // required: peer SHA-256 cert FP
+	// Force, when true, suppresses the "node already exists" error.
+	// PVE schema is boolean; pointer keeps an unset field out of the body.
+	Force  *bool  `json:"force,omitempty"`
+	NodeID int    `json:"nodeid,omitempty"`
+	Votes  int    `json:"votes,omitempty"`
+	Link0  string `json:"link0,omitempty"` // [address=]<IP>[,priority=<int>]
+	Link1  string `json:"link1,omitempty"`
+	Link2  string `json:"link2,omitempty"`
+	Link3  string `json:"link3,omitempty"`
+	Link4  string `json:"link4,omitempty"`
+	Link5  string `json:"link5,omitempty"`
+	Link6  string `json:"link6,omitempty"`
+	Link7  string `json:"link7,omitempty"`
+}
+
+// ClusterConfigNodeEntry is one row from GET /cluster/config/nodes — the bare
+// corosync node list (just names). Use the typed cluster status for richer
+// per-node state.
+type ClusterConfigNodeEntry struct {
+	Node string `json:"node,omitempty"`
+}
+
+// ClusterCreateOptions is the body of POST /cluster/config — "create cluster".
+type ClusterCreateOptions struct {
+	ClusterName      string `json:"clustername,omitempty"` // required, max 15 chars
+	NodeID           int    `json:"nodeid,omitempty"`
+	Votes            int    `json:"votes,omitempty"`
+	TokenCoefficient int    `json:"token-coefficient,omitempty"` // PVE default 125
+	Link0            string `json:"link0,omitempty"`
+	Link1            string `json:"link1,omitempty"`
+	Link2            string `json:"link2,omitempty"`
+	Link3            string `json:"link3,omitempty"`
+	Link4            string `json:"link4,omitempty"`
+	Link5            string `json:"link5,omitempty"`
+	Link6            string `json:"link6,omitempty"`
+	Link7            string `json:"link7,omitempty"`
+}
+
+// ClusterAddNodeOptions is the body of POST /cluster/config/nodes/{node}.
+type ClusterAddNodeOptions struct {
+	APIVersion int    `json:"apiversion,omitempty"`
+	NewNodeIP  string `json:"new_node_ip,omitempty"`
+	NodeID     int    `json:"nodeid,omitempty"`
+	Votes      int    `json:"votes,omitempty"`
+	// Force, when true, suppresses the "node already exists" error.
+	// PVE schema is boolean; pointer keeps an unset field out of the body.
+	Force *bool  `json:"force,omitempty"`
+	Link0 string `json:"link0,omitempty"`
+	Link1 string `json:"link1,omitempty"`
+	Link2 string `json:"link2,omitempty"`
+	Link3 string `json:"link3,omitempty"`
+	Link4 string `json:"link4,omitempty"`
+	Link5 string `json:"link5,omitempty"`
+	Link6 string `json:"link6,omitempty"`
+	Link7 string `json:"link7,omitempty"`
+}
+
+// ClusterAddNodeResult is the response of POST /cluster/config/nodes/{node} —
+// the corosync authkey + conf bytes that pvecm normally writes locally on the
+// joining node.
+type ClusterAddNodeResult struct {
+	CorosyncAuthkey string   `json:"corosync_authkey,omitempty"`
+	CorosyncConf    string   `json:"corosync_conf,omitempty"`
+	Warnings        []string `json:"warnings,omitempty"`
+}
+
+// --- /cluster/qemu ---------------------------------------------------------
+
+// QEMUCPUFlag is reused for both the per-host /nodes/{node}/capabilities/qemu/cpu
+// surface and the cluster-wide /cluster/qemu/cpu-flags catalog (defined above).
+
+// CustomCPUModel is a single custom CPU model definition (the inverse of the
+// `cpu: custom-<name>` field in a VM config). client is populated by the
+// list/getter on the parent; identifying fields drive instance methods.
+type CustomCPUModel struct {
+	client *Client `json:"-"`
+
+	CPUType        string `json:"cputype,omitempty"`
+	Flags          string `json:"flags,omitempty"`
+	GuestPhysBits  int    `json:"guest-phys-bits,omitempty"`
+	Hidden         int    `json:"hidden,omitempty"`
+	HVVendorID     string `json:"hv-vendor-id,omitempty"`
+	Level          int    `json:"level,omitempty"`
+	PhysBits       string `json:"phys-bits,omitempty"`
+	ReportedModel  string `json:"reported-model,omitempty"`
+	Digest         string `json:"digest,omitempty"`
+}
+
+// --- /cluster/log ----------------------------------------------------------
+
+// ClusterLogEntry is one row from /cluster/log — a single task-log line.
+// PVE's response shape is open (it varies per task kind); we expose the
+// common fields and Extra for the rest.
+type ClusterLogEntry struct {
+	Node    string `json:"node,omitempty"`
+	Time    int64  `json:"time,omitempty"`
+	UID     int    `json:"uid,omitempty"`
+	User    string `json:"user,omitempty"`
+	Pri     int    `json:"pri,omitempty"`
+	Tag     string `json:"tag,omitempty"`
+	Pid     int    `json:"pid,omitempty"`
+	Msg     string `json:"msg,omitempty"`
+	UPID    string `json:"upid,omitempty"`
+}
+
+// --- /cluster/options ------------------------------------------------------
+
+// ClusterOptionsResponse is the response of GET /cluster/options — the
+// datacenter.cfg surface. Common scalars are typed; the long tail (HA, CRS,
+// replication, notify, location, tag-style, u2f, webauthn, next-id, etc.)
+// lives in Extra so callers can read every key PVE returned without us
+// having to enumerate the entire wide config space.
+type ClusterOptionsResponse struct {
+	BWLimit         string `json:"bwlimit,omitempty"`
+	ConsentText     string `json:"consent-text,omitempty"`
+	Console         string `json:"console,omitempty"` // applet | vv | html5 | xtermjs
+	Description     string `json:"description,omitempty"`
+	EmailFrom       string `json:"email_from,omitempty"`
+	Fencing         string `json:"fencing,omitempty"` // watchdog (default) | hardware | both
+	HTTPProxy       string `json:"http_proxy,omitempty"`
+	Keyboard        string `json:"keyboard,omitempty"`
+	Language        string `json:"language,omitempty"`
+	MACPrefix       string `json:"mac_prefix,omitempty"`
+	MaxWorkers      int    `json:"max_workers,omitempty"`
+	Migration       string `json:"migration,omitempty"`
+	// MigrationUnsecure: deprecated in favor of migration=insecure. PVE
+	// schema is boolean (no documented default beyond "off"); pointer keeps
+	// the field out of the body when callers leave it unset.
+	MigrationUnsecure *bool `json:"migration_unsecure,omitempty"`
+	RegisteredTags    string `json:"registered-tags,omitempty"`
+
+	// Extra captures every other top-level key PVE returned (HA, CRS,
+	// replication, notify, location, tag-style, u2f, webauthn, next-id, etc.).
+	// It is populated by a custom UnmarshalJSON; on the way back through
+	// ClusterOptionsUpdate.Extra it is sent verbatim.
+	Extra map[string]any `json:"-"`
+}
+
+// ClusterOptionsUpdate is the body of PUT /cluster/options.
+type ClusterOptionsUpdate struct {
+	BWLimit         string `json:"bwlimit,omitempty"`
+	ConsentText     string `json:"consent-text,omitempty"`
+	Console         string `json:"console,omitempty"`
+	Description     string `json:"description,omitempty"`
+	EmailFrom       string `json:"email_from,omitempty"`
+	Fencing         string `json:"fencing,omitempty"`
+	HTTPProxy       string `json:"http_proxy,omitempty"`
+	Keyboard        string `json:"keyboard,omitempty"`
+	Language        string `json:"language,omitempty"`
+	MACPrefix       string `json:"mac_prefix,omitempty"`
+	MaxWorkers      int    `json:"max_workers,omitempty"`
+	Migration       string `json:"migration,omitempty"`
+	MigrationUnsecure *bool  `json:"migration_unsecure,omitempty"` // deprecated; see ClusterOptionsResponse
+	RegisteredTags    string `json:"registered-tags,omitempty"`
+	// Delete is a comma-separated list of keys to reset to PVE defaults.
+	Delete string `json:"delete,omitempty"`
+	// Extra is merged into the request body alongside the typed fields,
+	// covering the long tail of datacenter.cfg keys (HA, CRS, replication,
+	// notify, location, tag-style, u2f, webauthn, next-id, …). Marshaling is
+	// handled by a custom MarshalJSON.
+	Extra map[string]any `json:"-"`
+}
+
+// --- /cluster/metrics/export -----------------------------------------------
+
+// MetricsExportResponse is the response of GET /cluster/metrics/export.
+type MetricsExportResponse struct {
+	Data []*MetricsExportEntry `json:"data,omitempty"`
+}
+
+// MetricsExportEntry is one observation in the export series.
+type MetricsExportEntry struct {
+	ID        string  `json:"id"`        // e.g. "node/node1", "qemu/100"
+	Metric    string  `json:"metric"`    // metric name
+	Timestamp int64   `json:"timestamp"` // unix seconds
+	Type      string  `json:"type"`      // "gauge" | "counter" | "derive"
+	Value     float64 `json:"value"`
+}
+
+// --- /cluster/backup-info --------------------------------------------------
+
+// BackupGuestEntry is one row in GET /cluster/backup-info/not-backed-up.
+type BackupGuestEntry struct {
+	VMID int    `json:"vmid"`
+	Type string `json:"type,omitempty"` // "qemu" | "lxc"
+	Name string `json:"name,omitempty"`
+}
+
+// BackupIncludedVolumesRoot is the response of
+// GET /cluster/backup/{id}/included_volumes — a 2-level tree (guests ->
+// volumes) shaped for ExtJS tree views.
+type BackupIncludedVolumesRoot struct {
+	Children []*BackupIncludedVolumesGuest `json:"children,omitempty"`
+}
+
+// BackupIncludedVolumesGuest is one guest entry under IncludedVolumes.
+type BackupIncludedVolumesGuest struct {
+	ID       int                            `json:"id"`
+	Name     string                         `json:"name,omitempty"`
+	Type     string                         `json:"type,omitempty"` // "qemu" | "lxc" | "unknown"
+	Children []*BackupIncludedVolumesVolume `json:"children,omitempty"`
+}
+
+// BackupIncludedVolumesVolume is one volume entry under a guest.
+type BackupIncludedVolumesVolume struct {
+	ID       string `json:"id"`
+	Name     string `json:"name,omitempty"`
+	Included bool   `json:"included"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// --- /cluster/ceph/flags + /cluster/ceph/metadata --------------------------
+
+// CephFlag is one row of /cluster/ceph/flags.
+type CephFlag struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Value       bool   `json:"value"`
+}
+
+// CephFlagsUpdateOptions is the body of PUT /cluster/ceph/flags. Each pointer
+// field maps to a Ceph OSDMap flag: true sets, false unsets, nil leaves the
+// current state untouched (PVE schema has no defaults — they're per-cluster
+// runtime state — so pointer is mandatory to distinguish "not specified").
+type CephFlagsUpdateOptions struct {
+	NoBackfill   *bool `json:"nobackfill,omitempty"`
+	NoDeepScrub  *bool `json:"nodeep-scrub,omitempty"`
+	NoDown       *bool `json:"nodown,omitempty"`
+	NoIn         *bool `json:"noin,omitempty"`
+	NoOut        *bool `json:"noout,omitempty"`
+	NoRebalance  *bool `json:"norebalance,omitempty"`
+	NoRecover    *bool `json:"norecover,omitempty"`
+	NoScrub      *bool `json:"noscrub,omitempty"`
+	NoTierAgent  *bool `json:"notieragent,omitempty"`
+	NoUp         *bool `json:"noup,omitempty"`
+	Pause        *bool `json:"pause,omitempty"`
+}
+
+// CephMetadata is the response of /cluster/ceph/metadata. PVE returns per-OSD
+// (and per-MON/MGR/MDS) version+device info; we expose the common service
+// buckets and a Version block when present.
+type CephMetadata struct {
+	Version *CephMetadataVersion        `json:"version,omitempty"`
+	OSD     []map[string]any            `json:"osd,omitempty"`
+	MON     []map[string]any            `json:"mon,omitempty"`
+	MGR     []map[string]any            `json:"mgr,omitempty"`
+	MDS     []map[string]any            `json:"mds,omitempty"`
+	Node    map[string]map[string]any   `json:"node,omitempty"`
+}
+
+// CephMetadataVersion captures the cluster-wide ceph version string PVE
+// derives across all running daemons.
+type CephMetadataVersion struct {
+	Version string `json:"version,omitempty"`
+	Buildcommit string `json:"buildcommit,omitempty"`
+}
+
+// BulkStartOptions is the body of POST /cluster/bulk-action/guest/start.
+type BulkStartOptions struct {
+	VMIDs      []int `json:"vms,omitempty"`
+	MaxWorkers int   `json:"max-workers,omitempty"` // PVE default 4
+	Timeout    int   `json:"timeout,omitempty"`     // seconds, VM-only
+}
+
+// BulkShutdownOptions is the body of POST /cluster/bulk-action/guest/shutdown.
+type BulkShutdownOptions struct {
+	VMIDs      []int `json:"vms,omitempty"`
+	MaxWorkers int   `json:"max-workers,omitempty"` // PVE default 4
+	Timeout    int   `json:"timeout,omitempty"`     // PVE default 180
+	// ForceStop: stop the guest hard after timeout. PVE default 1 (true);
+	// pointer so leaving the field unset does NOT flip the server default to
+	// false. See AGENTS.md "don't clobber PVE-side defaults".
+	ForceStop *bool `json:"force-stop,omitempty"`
+}
+
+// BulkSuspendOptions is the body of POST /cluster/bulk-action/guest/suspend.
+type BulkSuspendOptions struct {
+	VMIDs      []int `json:"vms,omitempty"`
+	MaxWorkers int   `json:"max-workers,omitempty"` // PVE default 4
+	// ToDisk suspends to disk (resumed on next start). PVE default 0 (false);
+	// matches Go zero — plain bool with omitempty drops the field on unset.
+	ToDisk       bool   `json:"to-disk,omitempty"`
+	StateStorage string `json:"statestorage,omitempty"` // requires ToDisk
+}
+
+// BulkMigrateOptions is the body of POST /cluster/bulk-action/guest/migrate.
+type BulkMigrateOptions struct {
+	Target         string `json:"target,omitempty"` // required by PVE
+	VMIDs          []int  `json:"vms,omitempty"`
+	MaxWorkers     int    `json:"max-workers,omitempty"` // PVE default 1
+	Online         *bool  `json:"online,omitempty"`      // live migration for VMs / restart for CTs
+	WithLocalDisks *bool  `json:"with-local-disks,omitempty"`
+}
+
+// CustomCPUModelOptions is the body of POST /cluster/qemu/custom-cpu-models
+// (create) and PUT /cluster/qemu/custom-cpu-models/{cputype} (update).
+type CustomCPUModelOptions struct {
+	CPUType        string `json:"cputype,omitempty"` // required
+	Flags          string `json:"flags,omitempty"`
+	GuestPhysBits  int    `json:"guest-phys-bits,omitempty"`
+	// Hidden: do not identify as a KVM virtual machine. PVE default 0,
+	// matches Go zero — plain bool with omitempty would still flip it when
+	// the caller omits the field, so we keep an int matching the wire shape
+	// and rely on omitempty.
+	Hidden        int    `json:"hidden,omitempty"`
+	HVVendorID    string `json:"hv-vendor-id,omitempty"`
+	Level         int    `json:"level,omitempty"`
+	PhysBits      string `json:"phys-bits,omitempty"`
+	// ReportedModel is required on POST (PVE schema marks it optional=0).
+	ReportedModel string `json:"reported-model,omitempty"`
+	Digest        string `json:"digest,omitempty"` // PUT only — optimistic concurrency
+	Delete        string `json:"delete,omitempty"` // PUT only — comma list of keys to reset
+}


### PR DESCRIPTION
## Summary

Closes the remaining 38 /cluster/* coverage gaps after PR #320's SDN sweep, taking the cluster area from 221/259 (85%) to **259/259 (100%)** missing=0.

Breakdown by sub-area:

- **cluster/config (9)** — apiversion, join (GET+POST), nodes (GET), nodes/{node} (POST add / DELETE remove), qdevice, totem, POST /cluster/config (create cluster).
- **cluster/qemu CPU (6)** — cpu-flags + full CRUD on custom-cpu-models via a *CustomCPUModel singleton-instance handle.
- **cluster/bulk-action (6)** — diridx indices + the four guest POSTs (start/shutdown/suspend/migrate), each returning a *Task.
- **cluster/ceph (5)** — flags catalog + per-flag GET + PUT (sync single, async multi via UPID) + /cluster/ceph/metadata.
- **cluster/backup-info (3)** — BackupInfoSubdirs, GuestsNotInBackup, and (*ClusterBackup).IncludedVolumes.
- **cluster/ha arm/disarm (2)** — manual quorum-override POSTs.
- **cluster/metrics top-level (2)** — MetricsSubdirs + typed /cluster/metrics/export.
- **cluster/options (2)** — GET + PUT with hybrid typed-scalar / Extra-map shape (see notes).
- **misc (3)** — /cluster/log, /cluster/notifications/endpoints diridx, /cluster/firewall/groups/{group}/{pos} GET on *FirewallSecurityGroup.

## Why

Final push to bring v0.7.x to 100% cluster-area coverage. Combined with PRs #313-#320, the whole repo is now at 99.9% — only POST /nodes/{node}/storage/{storage}/upload remains, which is out of scope (covered by PR #321 / scanner-upload-fix).

## Notes / design decisions

- **/cluster/options** — the datacenter.cfg surface is wide (50+ keys spanning HA, CRS, migration, replication, notify, tag-style, U2F, WebAuthn, next-id, location, ...). Rather than enumerate them all, the type exposes typed scalars for the most-used fields and a map[string]any Extra catch-all for the long tail. Read populates Extra from the wire; Update merges Extra into the PUT body via custom MarshalJSON. Callers using only the typed fields get IDE help; callers needing the long tail get raw map access.
- **Bulk-action shutdown.ForceStop** uses *bool because PVE defaults the flag to 1/true — leaving the field unset on a plain bool,omitempty would silently flip it server-side. Same treatment for the other PVE-true defaults per AGENTS.md.
- **CephFlagsUpdateOptions** pointerizes every flag — there are no documented defaults (runtime state, not config), so we must distinguish "unset → leave alone" from "explicit false → clear".
- **/cluster/config/qdevice and /cluster/config/totem** return open-shape responses (corosync config is version-dependent) — exposed as map[string]any.
- ***CustomCPUModel** follows the singleton-vs-instance pattern; Cluster.CustomCPUModel(cputype) returns a handle exposing Read/Update/Delete. NewCustomCPUModel stays on the parent per the AGENTS.md "creation stays on the parent" rule.
- **Diridx helpers** — added bulkActionDiridx, backupInfoDiridx, metricsDiridx, notificationsDiridx in cluster_diridx.go so the endpoint scanner attributes the directory-index GETs to diridx wrappers consistent with PR #319.

No endpoints deliberately skipped.

## Test plan

- [x] go build ./... clean
- [x] go test -count=1 . green (full unit suite)
- [x] mage endpoints:coverage — cluster 259/259 missing=0
- [x] New gock fixtures in tests/mocks/pve9x/cluster.go for every new endpoint; happy-path test in the matching _test.go plus empty-input error-path tests where applicable.