### PR TITLE
feat(options): add WithProxy and WithProxyFromEnvironment

### DIFF
--- a/options.go
+++ b/options.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -174,6 +175,36 @@ func WithOTP(otp string) Option {
 func WithDefaultRealm(realm string) Option {
 	return func(c *Client) {
 		c.defaultRealm = strings.TrimPrefix(realm, "@")
+	}
+}
+
+// WithProxy routes all client traffic through the given proxy URL. The proxy
+// function is applied to the underlying *http.Transport so every request goes
+// through u (use http://, https://, or socks5:// schemes).
+//
+// Composes with WithHTTPClient regardless of option order: the proxy is
+// applied to whatever client the constructor settles on after all options
+// have run, via the shared finalizeOptions step. If the resulting transport
+// is not an *http.Transport (custom RoundTripper), the option logs a debug
+// warning and no-ops — set .Proxy yourself on a transport you control before
+// passing it to WithHTTPClient.
+func WithProxy(u *url.URL) Option {
+	return func(c *Client) {
+		c.proxyFunc = func(*http.Request) (*url.URL, error) {
+			return u, nil
+		}
+	}
+}
+
+// WithProxyFromEnvironment uses Go's standard http.ProxyFromEnvironment
+// lookup (HTTP_PROXY, HTTPS_PROXY, NO_PROXY env vars). Env vars are read
+// per-request by http.ProxyFromEnvironment, not at option-eval time, so
+// later changes to the environment are picked up on the next request.
+//
+// Composes with WithHTTPClient the same way as WithProxy.
+func WithProxyFromEnvironment() Option {
+	return func(c *Client) {
+		c.proxyFunc = http.ProxyFromEnvironment
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -5,13 +5,16 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithClient(t *testing.T) {
@@ -299,4 +302,110 @@ func TestWithRetry_InstallsWrapper(t *testing.T) {
 	assert.Equal(t, 3, rt.policy.maxAttempts)
 	assert.Equal(t, 200*time.Millisecond, rt.policy.initialBackoff)
 	assert.Equal(t, 5*time.Second, rt.policy.maxBackoff)
+}
+
+// --- proxy options --------------------------------------------------------
+
+// transportFromClient extracts the underlying *http.Transport from a Client,
+// failing the test if the transport is missing or has been replaced with a
+// non-*http.Transport RoundTripper.
+func transportFromClient(t *testing.T, c *Client) *http.Transport {
+	t.Helper()
+	require.NotNil(t, c.httpClient, "client.httpClient should be set after NewClient")
+	require.NotNil(t, c.httpClient.Transport, "client.httpClient.Transport should be promoted by transport options")
+	tr, ok := c.httpClient.Transport.(*http.Transport)
+	require.True(t, ok, "client.httpClient.Transport should be *http.Transport")
+	return tr
+}
+
+func TestWithProxy(t *testing.T) {
+	proxyURL, err := url.Parse("http://proxy.example.com:3128")
+	require.NoError(t, err)
+
+	t.Run("default client gets proxy", func(t *testing.T) {
+		c := NewClient("", WithProxy(proxyURL))
+		tr := transportFromClient(t, c)
+		require.NotNil(t, tr.Proxy, "Proxy should be set")
+		got, err := tr.Proxy(&http.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, proxyURL, got)
+		// Ensure we did not mutate http.DefaultTransport.
+		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+			assert.NotSame(t, dt, tr, "should not mutate http.DefaultTransport")
+		}
+	})
+
+	t.Run("WithHTTPClient then WithProxy mutates custom client's transport", func(t *testing.T) {
+		custom := &http.Client{Timeout: 7 * time.Second}
+		c := NewClient("", WithHTTPClient(custom), WithProxy(proxyURL))
+		assert.Same(t, custom, c.httpClient, "WithHTTPClient's client should be preserved")
+		tr := transportFromClient(t, c)
+		require.NotNil(t, tr.Proxy)
+		got, err := tr.Proxy(&http.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, proxyURL, got)
+	})
+
+	t.Run("WithProxy then WithHTTPClient still applies proxy to custom client", func(t *testing.T) {
+		custom := &http.Client{Timeout: 7 * time.Second}
+		c := NewClient("", WithProxy(proxyURL), WithHTTPClient(custom))
+		assert.Same(t, custom, c.httpClient, "WithHTTPClient's client should be preserved")
+		tr := transportFromClient(t, c)
+		require.NotNil(t, tr.Proxy)
+		got, err := tr.Proxy(&http.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, proxyURL, got)
+	})
+
+	t.Run("custom client with pre-set transport is reused, not replaced", func(t *testing.T) {
+		preTransport := &http.Transport{}
+		custom := &http.Client{Transport: preTransport}
+		c := NewClient("", WithHTTPClient(custom), WithProxy(proxyURL))
+		assert.Same(t, preTransport, c.httpClient.Transport, "existing *http.Transport should be reused")
+		require.NotNil(t, preTransport.Proxy)
+		got, err := preTransport.Proxy(&http.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, proxyURL, got)
+	})
+
+	t.Run("non-http.Transport RoundTripper logs and no-ops", func(t *testing.T) {
+		rt := roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			return nil, nil
+		})
+		custom := &http.Client{Transport: rt}
+		c := NewClient("", WithHTTPClient(custom), WithProxy(proxyURL))
+		// Transport untouched; still the original RoundTripperFunc.
+		assert.Equal(t, reflect.ValueOf(rt).Pointer(),
+			reflect.ValueOf(c.httpClient.Transport).Pointer(),
+			"custom RoundTripper should not be replaced")
+	})
+}
+
+func TestWithProxyFromEnvironment(t *testing.T) {
+	t.Setenv("HTTP_PROXY", "http://env-proxy.example.com:8080")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("NO_PROXY", "")
+
+	c := NewClient("", WithProxyFromEnvironment())
+	tr := transportFromClient(t, c)
+	require.NotNil(t, tr.Proxy, "Proxy should be set")
+
+	// http.ProxyFromEnvironment caches its env lookup on first call across the
+	// process, so we can't reliably assert pointer identity with the package
+	// symbol — instead exercise it.
+	req, err := http.NewRequest(http.MethodGet, "http://target.example.com/", nil)
+	require.NoError(t, err)
+	got, err := tr.Proxy(req)
+	require.NoError(t, err)
+	require.NotNil(t, got, "ProxyFromEnvironment should resolve a proxy for HTTP_PROXY")
+	assert.Equal(t, "env-proxy.example.com:8080", got.Host)
+}
+
+// roundTripperFunc is a test helper that adapts a function into a
+// http.RoundTripper for verifying the non-*http.Transport branch of
+// ensureTransport.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }

--- a/proxmox.go
+++ b/proxmox.go
@@ -110,6 +110,7 @@ type Client struct {
 	timeout      time.Duration
 	tlsMods      []func(*tls.Config)
 	retryPolicy  *retryPolicy
+	proxyFunc    func(*http.Request) (*url.URL, error)
 }
 
 func NewClient(baseURL string, opts ...Option) *Client {
@@ -159,6 +160,14 @@ func (c *Client) finalizeOptions() {
 	if c.timeout > 0 {
 		c.ensureOwnHTTPClient()
 		c.httpClient.Timeout = c.timeout
+	}
+
+	if c.proxyFunc != nil {
+		if t := c.ensureTransport(); t != nil {
+			t.Proxy = c.proxyFunc
+		} else {
+			c.log.Debugf("WithProxy: client's RoundTripper is not an *http.Transport; option has no effect")
+		}
 	}
 
 	c.installRetryWrapper()


### PR DESCRIPTION
## Summary

- `WithProxy(u *url.URL)` routes all client traffic through the given proxy URL by setting `http.Transport.Proxy` on the underlying transport. Accepts http://, https://, or socks5:// URLs.
- `WithProxyFromEnvironment()` uses Go's standard `http.ProxyFromEnvironment` lookup so `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` env vars drive routing per request.

## Why

Corporate-proxy support: today a caller who needs an HTTP proxy must construct an `http.Transport` by hand, copy the defaults, set `.Proxy`, wrap it in a custom `*http.Client`, and pass that through `WithHTTPClient` — purely to flip a single field. These options turn that boilerplate into a one-liner and keep the rest of the client defaults intact.

## Notes

- **Composition with `WithHTTPClient` is order-independent.** Whether the caller writes `NewClient(url, WithHTTPClient(custom), WithProxy(u))` or `NewClient(url, WithProxy(u), WithHTTPClient(custom))`, the proxy is applied to whatever `*http.Client` the constructor settles on after all options have run.
- **Transport promotion.** If the chosen client has `Transport == nil`, a private `ensureTransport` helper promotes `http.DefaultTransport` via `Clone()` before mutation, so the package global is never modified.
- **Non-`*http.Transport` RoundTripper.** If the caller provides a custom `http.Client` whose `Transport` is a non-`*http.Transport` `RoundTripper`, we cannot set `.Proxy` on it — the option logs a debug warning via `c.log.Debugf` and no-ops. Callers in that situation should configure proxying on their own transport before passing it to `WithHTTPClient`.
- **Helper is shared.** `ensureTransport` is intentionally private and stable so the sibling Tier 1 (TLS) and Tier 3 (retry) options landing in parallel PRs can extend or wrap it without churning the API. First PR to merge wins; the rest rebase.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -count=1 .` green (full root-package suite)
- [x] New `TestWithProxy` covers: default-client promotion (and that `http.DefaultTransport` is not mutated), both option orderings against `WithHTTPClient`, reuse of a pre-set transport, and the non-`*http.Transport` no-op branch.
- [x] New `TestWithProxyFromEnvironment` sets `HTTP_PROXY` via `t.Setenv` and asserts the resolved proxy URL for a synthetic request.