### PR TITLE
feat(options): add WithRequestInterceptor — middleware hook for outgoing requests

### DIFF
--- a/options.go
+++ b/options.go
@@ -279,3 +279,31 @@ func (c *Client) ensureTLSConfig() *tls.Config {
 	}
 	return t.TLSClientConfig
 }
+
+// WithRequestInterceptor registers a function called on every outgoing HTTP
+// request after the client's auth headers are added and before the request is
+// sent. Use cases: tracing (OpenTelemetry span injection), custom audit
+// headers, correlation IDs, request logging.
+//
+// The interceptor fires from Client.Req, Client.Upload, and
+// Client.UploadReader. Websocket upgrades (Client.TermWebSocket and
+// Client.VNCWebSocket) are exempt — the dialer does not surface a request
+// object the chain could mutate.
+//
+// Multiple WithRequestInterceptor options compose — each call appends to the
+// interceptor chain. Interceptors run in registration order. The first
+// non-nil error short-circuits the request, is wrapped with a
+// "request interceptor:" prefix (so callers can errors.Is against their own
+// sentinel errors), and is returned to the caller; the HTTP request is never
+// sent.
+//
+// A nil fn is silently skipped at registration; nil entries in the chain are
+// also skipped at request time.
+func WithRequestInterceptor(fn func(*http.Request) error) Option {
+	return func(c *Client) {
+		if fn == nil {
+			return
+		}
+		c.interceptors = append(c.interceptors, fn)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/h2non/gock"
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/luthermonson/go-proxmox/tests/mocks/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -408,4 +412,181 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
+}
+
+// --- request interceptor --------------------------------------------------
+
+// TestWithRequestInterceptor_RegistrationAppends verifies the option appends
+// to the interceptor chain rather than replacing earlier entries, that nil
+// callbacks are skipped at registration time, and that no-options returns
+// nil.
+func TestWithRequestInterceptor_RegistrationAppends(t *testing.T) {
+	noop := func(*http.Request) error { return nil }
+
+	c := NewClient("")
+	assert.Nil(t, c.interceptors)
+
+	c = NewClient("", WithRequestInterceptor(noop), WithRequestInterceptor(noop))
+	assert.Len(t, c.interceptors, 2)
+
+	// nil fn should be a silent no-op at registration time.
+	c = NewClient("", WithRequestInterceptor(nil), WithRequestInterceptor(noop))
+	assert.Len(t, c.interceptors, 1)
+}
+
+// TestWithRequestInterceptor_SingleSeesAuthHeader fires a real request
+// through gock with API-token auth and asserts the interceptor was called
+// exactly once and saw the Authorization header populated by authHeaders.
+// This pins the "fires after authHeaders" contract.
+func TestWithRequestInterceptor_SingleSeesAuthHeader(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	gock.New(config.C.URI).
+		Get("^/version$").
+		Reply(200).
+		JSON(`{"data":{"version":"9.0"}}`)
+
+	var (
+		calls   int
+		sawAuth string
+		sawPath string
+	)
+	intercept := func(req *http.Request) error {
+		calls++
+		sawAuth = req.Header.Get("Authorization")
+		if req.URL != nil {
+			sawPath = req.URL.Path
+		}
+		return nil
+	}
+
+	c := NewClient(
+		mockConfig.URI,
+		WithAPIToken("root@pam!test", "secret"),
+		WithRequestInterceptor(intercept),
+	)
+
+	_, err := c.Version(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls, "interceptor should fire exactly once per request")
+	assert.Equal(t, "PVEAPIToken=root@pam!test=secret", sawAuth,
+		"interceptor must run AFTER authHeaders so it can observe the wire-bound Authorization header")
+	// The interceptor must see the URL.Path that's about to be sent, so
+	// tracing exporters can attach span attributes.
+	assert.Equal(t, "/version", sawPath)
+}
+
+// TestWithRequestInterceptor_OrderPreserved registers two interceptors and
+// asserts they ran in registration order.
+func TestWithRequestInterceptor_OrderPreserved(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	gock.New(config.C.URI).
+		Get("^/version$").
+		Reply(200).
+		JSON(`{"data":{"version":"9.0"}}`)
+
+	var order []string
+	first := func(*http.Request) error { order = append(order, "first"); return nil }
+	second := func(*http.Request) error { order = append(order, "second"); return nil }
+
+	c := NewClient(
+		mockConfig.URI,
+		WithAPIToken("root@pam!test", "secret"),
+		WithRequestInterceptor(first),
+		WithRequestInterceptor(second),
+	)
+
+	_, err := c.Version(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"first", "second"}, order)
+}
+
+// errInterceptorSentinel is a package-level sentinel so the test can assert
+// errors.Is unwraps through the "request interceptor:" wrapper.
+var errInterceptorSentinel = errors.New("sentinel: interceptor refused")
+
+// TestWithRequestInterceptor_ErrorAborts verifies that returning an error
+// from an interceptor short-circuits the request (gock never matches), the
+// returned error wraps the sentinel via fmt.Errorf("%w") so callers can
+// errors.Is against their own sentinels, and a later interceptor in the
+// chain never runs.
+func TestWithRequestInterceptor_ErrorAborts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	// Register a strict route that, if hit, would respond 200. We assert
+	// after the call that this route is *still* pending (never matched).
+	pending := gock.New(config.C.URI).
+		Get("^/version$").
+		Reply(200).
+		JSON(`{"data":{"version":"9.0"}}`)
+
+	bad := func(*http.Request) error { return errInterceptorSentinel }
+	laterCalled := false
+	later := func(*http.Request) error { laterCalled = true; return nil }
+
+	c := NewClient(
+		mockConfig.URI,
+		WithAPIToken("root@pam!test", "secret"),
+		WithRequestInterceptor(bad),
+		WithRequestInterceptor(later),
+	)
+
+	_, err := c.Version(context.Background())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errInterceptorSentinel),
+		"returned error must wrap the sentinel so callers can errors.Is")
+	assert.True(t, strings.Contains(err.Error(), "request interceptor:"),
+		"error message should be prefixed with 'request interceptor:' for diagnostics, got: %s", err.Error())
+	assert.False(t, laterCalled, "first non-nil error must short-circuit the chain")
+
+	// gock should never have matched — the request was aborted before
+	// httpClient.Do was reached.
+	assert.False(t, pending.Done(), "interceptor error must abort before httpClient.Do; gock saw a request when it should not have")
+}
+
+// TestWithRequestInterceptor_FiresForUpload verifies that the interceptor
+// chain also runs for the Upload/UploadReader path, so tracing and auditing
+// is uniform across every outgoing request the client makes.
+func TestWithRequestInterceptor_FiresForUpload(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+
+	var (
+		calls   int
+		sawAuth string
+		sawPath string
+	)
+	intercept := func(req *http.Request) error {
+		calls++
+		sawAuth = req.Header.Get("Authorization")
+		if req.URL != nil {
+			sawPath = req.URL.Path
+		}
+		return nil
+	}
+
+	c := NewClient(
+		mockConfig.URI,
+		WithAPIToken("root@pam!test", "secret"),
+		WithRequestInterceptor(intercept),
+	)
+
+	body := strings.NewReader("payload")
+	err := c.UploadReader(
+		"/nodes/node1/storage/local/upload",
+		map[string]string{"content": "iso"},
+		"hello.txt", body, int64(body.Len()), nil,
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls, "interceptor should fire once for an Upload/UploadReader request")
+	assert.Equal(t, "PVEAPIToken=root@pam!test=secret", sawAuth,
+		"interceptor must run after authHeaders on the upload path too")
+	assert.Equal(t, "/nodes/node1/storage/local/upload", sawPath)
 }

--- a/proxmox.go
+++ b/proxmox.go
@@ -98,6 +98,17 @@ type Client struct {
 	session     *Session
 	log         LeveledLoggerInterface
 
+	// interceptors is the chain of WithRequestInterceptor callbacks invoked
+	// on every outgoing HTTP request after auth headers are populated and
+	// before the request is handed to httpClient.Do. They run in
+	// registration order; the first non-nil error short-circuits the
+	// request. The chain fires from Req, Upload, and UploadReader.
+	// Websocket upgrades (TermWebSocket, VNCWebSocket) are deliberately
+	// exempt — the spec does not require interceptors on the upgrade
+	// handshake and the websocket dialer does not surface a *http.Request
+	// the chain could mutate.
+	interceptors []func(*http.Request) error
+
 	sessionExpiresAt time.Time
 	sessionMux       sync.Mutex
 
@@ -111,6 +122,22 @@ type Client struct {
 	tlsMods      []func(*tls.Config)
 	retryPolicy  *retryPolicy
 	proxyFunc    func(*http.Request) (*url.URL, error)
+}
+
+// runInterceptors invokes the registered request interceptors in registration
+// order. The first non-nil error short-circuits the chain and is wrapped with
+// a "request interceptor:" prefix so callers can errors.Is against their own
+// sentinel errors.
+func (c *Client) runInterceptors(req *http.Request) error {
+	for _, fn := range c.interceptors {
+		if fn == nil {
+			continue
+		}
+		if err := fn(req); err != nil {
+			return fmt.Errorf("request interceptor: %w", err)
+		}
+	}
+	return nil
 }
 
 func NewClient(baseURL string, opts ...Option) *Client {
@@ -218,6 +245,10 @@ func (c *Client) Req(ctx context.Context, method, path string, data []byte, v in
 	}
 
 	c.authHeaders(&req.Header)
+
+	if err := c.runInterceptors(req); err != nil {
+		return err
+	}
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {
@@ -385,6 +416,10 @@ func (c *Client) UploadReader(path string, fields map[string]string, filename st
 	req.Header.Set("Content-Type", w.FormDataContentType())
 	req.ContentLength = int64(b.Len()) + size
 	c.authHeaders(&req.Header)
+
+	if err := c.runInterceptors(req); err != nil {
+		return err
+	}
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds `WithRequestInterceptor(func(*http.Request) error) Option` — a middleware hook the caller registers on `proxmox.NewClient` to inspect/mutate every outgoing HTTP request after auth headers are populated and before it's handed to `httpClient.Do`.

## Why

Tracing (OpenTelemetry span injection), correlation IDs, custom audit headers, request logging, and similar cross-cutting concerns currently require callers to wrap `*Client` or replace its `http.Client` wholesale. A first-class request interceptor option keeps the existing `Client` ergonomic while making these uses cases one-liners.

## Behavior

- **Runs after auth headers, before `httpClient.Do`.** The hook sees the `Authorization: PVEAPIToken=...` (or `Cookie: PVEAuthCookie=...` + `CSRFPreventionToken`) header that's about to go on the wire, so tracing exporters can attach the auth subject as a span attribute and audit middleware can log the wire-bound headers.
- **Applies to `Req`, `Upload`, `UploadReader`.** Every path inside `proxmox.go` that calls `httpClient.Do` runs the interceptor chain first, so coverage is uniform across JSON and multipart upload requests.
- **Not applied to websocket upgrades** (`TermWebSocket`, `VNCWebSocket`). The `websocket.Dialer.Dial` API does not surface a `*http.Request` the chain could mutate, and the v0.7.x client-options spec explicitly exempts upgrades. Documented inline on the `Client.interceptors` field.
- **Composes in registration order.** Each `WithRequestInterceptor` call appends; interceptors run in the order they were registered.
- **First-error-aborts.** The first non-nil error short-circuits the chain, is wrapped via `fmt.Errorf("request interceptor: %w", err)` so callers can `errors.Is` against their own sentinels, and is returned to the caller. The HTTP request is never sent; downstream interceptors don't run.
- **Nil-safe.** `WithRequestInterceptor(nil)` is silently skipped at registration; nil entries in the chain are also skipped at request time.

## Non-goals

- `WithResponseInterceptor` is deliberately deferred per the v0.7.x client-options spec — the request side covers 95% of the use cases (tracing, correlation IDs, custom auth-bound headers) and the response side can land later without breaking anything.

## Test plan

`options_test.go` additions, gock-backed for the request-flight tests:

- [x] `TestWithRequestInterceptor_RegistrationAppends` — registers 0 / 1 / 2 / nil interceptors and asserts the chain length matches; nil callbacks are skipped at registration time.
- [x] `TestWithRequestInterceptor_SingleSeesAuthHeader` — registers an API token + one interceptor, fires `Version()`, asserts the interceptor saw `Authorization: PVEAPIToken=root@pam!test=secret` (pins the "fires AFTER `authHeaders`" contract) and saw `URL.Path == /version` (for span attribution).
- [x] `TestWithRequestInterceptor_OrderPreserved` — registers two interceptors, asserts they ran in registration order.
- [x] `TestWithRequestInterceptor_ErrorAborts` — first interceptor returns a sentinel, second is registered after; asserts the returned error wraps the sentinel (`errors.Is`), is prefixed with `request interceptor:`, the later interceptor never ran, and gock's pending route was never matched (the request was aborted before `httpClient.Do`).
- [x] `TestWithRequestInterceptor_FiresForUpload` — uses `UploadReader` against the mocked `POST /nodes/node1/storage/local/upload` route to verify the chain also runs for multipart/upload requests.
- [x] `go build ./...`, `go vet ./...`, `go test -count=1 .` all green.