### PR TITLE
feat(options): add WithRetry — transient-failure retries with exponential backoff

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -287,3 +287,16 @@ func containsByte(haystack, needle []byte) bool {
 	}
 	return false
 }
+
+// --- retry option ---------------------------------------------------------
+
+func TestWithRetry_InstallsWrapper(t *testing.T) {
+	client := NewClient("", WithRetry())
+	_, ok := client.httpClient.Transport.(*retryRoundTripper)
+	assert.True(t, ok, "WithRetry() should install a *retryRoundTripper on the transport")
+	// Sanity: the default policy is non-zero.
+	rt := client.httpClient.Transport.(*retryRoundTripper)
+	assert.Equal(t, 3, rt.policy.maxAttempts)
+	assert.Equal(t, 200*time.Millisecond, rt.policy.initialBackoff)
+	assert.Equal(t, 5*time.Second, rt.policy.maxBackoff)
+}

--- a/proxmox.go
+++ b/proxmox.go
@@ -104,11 +104,12 @@ type Client struct {
 	// Option-backed fields. See options.go for the corresponding With*
 	// setters. These are collected during NewClient option evaluation and
 	// applied in finalizeOptions before NewClient returns.
-	otp           string
-	defaultRealm  string
-	eagerAuth     bool
-	timeout       time.Duration
-	tlsMods       []func(*tls.Config)
+	otp          string
+	defaultRealm string
+	eagerAuth    bool
+	timeout      time.Duration
+	tlsMods      []func(*tls.Config)
+	retryPolicy  *retryPolicy
 }
 
 func NewClient(baseURL string, opts ...Option) *Client {
@@ -159,6 +160,8 @@ func (c *Client) finalizeOptions() {
 		c.ensureOwnHTTPClient()
 		c.httpClient.Timeout = c.timeout
 	}
+
+	c.installRetryWrapper()
 
 	if c.eagerAuth && c.credentials != nil && c.token == "" {
 		// Best-effort eager session. Errors are intentionally swallowed:

--- a/retry.go
+++ b/retry.go
@@ -1,0 +1,392 @@
+package proxmox
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// RetryOption configures the retry behaviour set via WithRetry.
+type RetryOption func(*retryPolicy)
+
+// retryPolicy is the internal configuration for the retry RoundTripper.
+type retryPolicy struct {
+	maxAttempts    int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+	condition      func(*http.Response, error) bool
+	// now and sleep are overridable for tests.
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+	// rand is the jitter source; guarded by mu.
+	mu   sync.Mutex
+	rand *rand.Rand
+}
+
+const (
+	defaultRetryMaxAttempts    = 3
+	defaultRetryInitialBackoff = 200 * time.Millisecond
+	defaultRetryMaxBackoff     = 5 * time.Second
+)
+
+// defaultRetryPolicy returns the policy used when WithRetry is called with no
+// options. The shape — three attempts, 200ms-5s exponential backoff with full
+// jitter, retries on idempotent verbs plus buffered-body POST, Retry-After
+// honored on 429 — is documented on WithRetry.
+func defaultRetryPolicy() *retryPolicy {
+	return &retryPolicy{
+		maxAttempts:    defaultRetryMaxAttempts,
+		initialBackoff: defaultRetryInitialBackoff,
+		maxBackoff:     defaultRetryMaxBackoff,
+		condition:      defaultRetryCondition,
+		now:            time.Now,
+		sleep:          contextSleep,
+		rand:           rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// defaultRetryCondition retries on network errors, HTTP 502, 503, 504, and 429.
+// 4xx responses other than 429 are surfaced immediately to the caller.
+func defaultRetryCondition(res *http.Response, err error) bool {
+	if err != nil {
+		// Network-level error — connection refused, EOF, DNS, timeout, etc.
+		// Context-cancellation errors are filtered out separately by the
+		// caller so we don't retry a user-requested cancellation.
+		return true
+	}
+	if res == nil {
+		return false
+	}
+	switch res.StatusCode {
+	case http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+		http.StatusTooManyRequests:
+		return true
+	}
+	return false
+}
+
+// WithRetryMax sets the maximum number of attempts (including the first).
+// Default 3. Values less than 1 are clamped to 1 (no retry).
+func WithRetryMax(n int) RetryOption {
+	return func(p *retryPolicy) {
+		if n < 1 {
+			n = 1
+		}
+		p.maxAttempts = n
+	}
+}
+
+// WithRetryBackoff overrides the exponential backoff bounds. initial is the
+// first backoff window (full-jitter sampled in [0, initial)); the window doubles
+// per attempt and is capped at max. Defaults: 200ms initial, 5s max.
+func WithRetryBackoff(initial, max time.Duration) RetryOption {
+	return func(p *retryPolicy) {
+		if initial > 0 {
+			p.initialBackoff = initial
+		}
+		if max > 0 {
+			p.maxBackoff = max
+		}
+	}
+}
+
+// WithRetryCondition replaces the predicate that decides whether a response or
+// error should trigger another attempt. The function is called with the result
+// of the inner RoundTripper; exactly one of res / err is non-nil. The default
+// retries on net errors and HTTP 502, 503, 504, 429.
+func WithRetryCondition(fn func(*http.Response, error) bool) RetryOption {
+	return func(p *retryPolicy) {
+		if fn != nil {
+			p.condition = fn
+		}
+	}
+}
+
+// WithRetry installs a RoundTripper wrapper that retries transient failures
+// on the underlying transport.
+//
+// Default policy: max 3 attempts, exponential backoff with full jitter from
+// 200ms to 5s, retries on network errors and HTTP 502, 503, 504, 429. The
+// Retry-After header on 429 or 503 overrides the computed backoff (capped at
+// the configured max). Only idempotent verbs (GET, PUT, DELETE) and POST with
+// a fully-buffered body are retried; in this client request bodies are always
+// []byte, so POST is rewindable.
+//
+// Cumulative timeout is bounded by the request context; the wrapper respects
+// ctx.Done() between attempts and returns the context error as soon as
+// cancellation is observed.
+//
+// WithRetry composes with the other transport-touching options
+// (WithInsecureSkipVerify, WithRootCAs, WithClientCertificate, WithProxy,
+// WithProxyFromEnvironment, WithRequestInterceptor). It wraps whichever
+// transport the client currently has when the option runs; if a subsequent
+// WithHTTPClient replaces the client, the retry wrapper is rewrapped onto the
+// new client's transport so the caller's intent is preserved.
+func WithRetry(opts ...RetryOption) Option {
+	policy := defaultRetryPolicy()
+	for _, o := range opts {
+		o(policy)
+	}
+	return func(c *Client) {
+		c.retryPolicy = policy
+	}
+}
+
+// installRetryWrapper installs the retry RoundTripper on top of whatever
+// transport the client ended up with after every option func ran. Called
+// from finalizeOptions so the wrapper survives WithHTTPClient regardless of
+// option order.
+//
+// Unlike the TLS / proxy options, we don't need to mutate the underlying
+// transport — wrapping it as the .base of a retryRoundTripper is read-only —
+// so we don't promote / Clone the default. If c.httpClient.Transport is nil
+// we just point the wrapper at http.DefaultTransport directly. (Test
+// harnesses that swap DefaultTransport for an interceptor — gock — work fine
+// because we wrap whatever the global currently is.)
+func (c *Client) installRetryWrapper() {
+	if c.retryPolicy == nil {
+		return
+	}
+	c.ensureOwnHTTPClient()
+	base := c.httpClient.Transport
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	c.httpClient.Transport = &retryRoundTripper{
+		base:   base,
+		policy: c.retryPolicy,
+	}
+}
+
+// retryRoundTripper is the http.RoundTripper wrapper installed by WithRetry.
+type retryRoundTripper struct {
+	base   http.RoundTripper
+	policy *retryPolicy
+}
+
+// RoundTrip implements http.RoundTripper. It re-issues the request up to
+// policy.maxAttempts times when policy.condition returns true. Between attempts
+// it sleeps for an exponentially-growing, full-jitter window (or for the
+// duration specified by a Retry-After header, when present and larger).
+func (r *retryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Snapshot the body once. http.Request.Body is consumed on each
+	// RoundTrip, so without a rewind source we can only attempt once for
+	// requests with bodies.
+	rewind, err := snapshotBody(req)
+	if err != nil {
+		return nil, err
+	}
+
+	idempotent := isIdempotent(req.Method) || rewind != nil
+
+	var (
+		lastRes *http.Response
+		lastErr error
+	)
+
+	for attempt := 0; attempt < r.policy.maxAttempts; attempt++ {
+		// Reset the body before every attempt after the first.
+		if attempt > 0 && rewind != nil {
+			req.Body = rewind()
+		}
+
+		res, err := r.base.RoundTrip(req)
+
+		// Honor user-initiated cancellation immediately — never retry it.
+		if err != nil && ctxErr(ctx) != nil {
+			return nil, ctx.Err()
+		}
+
+		lastRes, lastErr = res, err
+
+		if !r.policy.condition(res, err) {
+			return res, err
+		}
+
+		// Don't retry non-idempotent verbs without a rewindable body.
+		if !idempotent {
+			return res, err
+		}
+
+		// No more attempts left — return whatever we got.
+		if attempt == r.policy.maxAttempts-1 {
+			return res, err
+		}
+
+		// Compute the backoff window. Retry-After (if present) overrides.
+		delay := r.computeBackoff(attempt, res)
+
+		// Drain and close the body so the underlying connection can be
+		// reused on the next attempt.
+		drainResponse(res)
+
+		if err := r.policy.sleep(ctx, delay); err != nil {
+			return nil, err
+		}
+	}
+
+	return lastRes, lastErr
+}
+
+// computeBackoff returns the delay before the next attempt. It honors the
+// Retry-After header on 429 and 503 responses, capping at policy.maxBackoff
+// when the header's value is larger than the configured cap. Otherwise it
+// returns a full-jitter sample in [0, min(maxBackoff, initial * 2^attempt)).
+func (r *retryRoundTripper) computeBackoff(attempt int, res *http.Response) time.Duration {
+	if res != nil {
+		if d, ok := parseRetryAfter(res.Header.Get("Retry-After"), r.policy.now()); ok {
+			if d > r.policy.maxBackoff {
+				d = r.policy.maxBackoff
+			}
+			if d < 0 {
+				d = 0
+			}
+			return d
+		}
+	}
+
+	// Full jitter: backoff = rand.Int63n(min(cap, base * 2^attempt))
+	window := r.policy.initialBackoff
+	for i := 0; i < attempt && window < r.policy.maxBackoff; i++ {
+		window *= 2
+	}
+	if window > r.policy.maxBackoff {
+		window = r.policy.maxBackoff
+	}
+	if window <= 0 {
+		return 0
+	}
+
+	r.policy.mu.Lock()
+	defer r.policy.mu.Unlock()
+	return time.Duration(r.policy.rand.Int63n(int64(window)))
+}
+
+// parseRetryAfter parses the Retry-After header value, which RFC 7231 defines
+// as either delta-seconds or an HTTP-date. Returns the resulting duration and
+// true on success.
+func parseRetryAfter(v string, now time.Time) (time.Duration, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		d := t.Sub(now)
+		if d < 0 {
+			d = 0
+		}
+		return d, true
+	}
+	return 0, false
+}
+
+// isIdempotent reports whether the HTTP method is safe to replay without a
+// rewindable body.
+func isIdempotent(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete,
+		http.MethodOptions, http.MethodTrace:
+		return true
+	}
+	return false
+}
+
+// snapshotBody returns a function that produces a fresh ReadCloser for the
+// request body on each call, suitable for replay across retries. It returns
+// (nil, nil) when the request has no body to replay.
+//
+// Preference order:
+//  1. If the caller set req.GetBody, use it directly — that's the http stdlib's
+//     own contract for replayable bodies.
+//  2. Otherwise, fully buffer req.Body into memory and serve a fresh
+//     bytes.Reader on each call. In go-proxmox the Req() helper always passes
+//     a []byte, so the buffer cost is the same []byte we already had.
+//
+// If a body exists and neither option applies (Body is non-nil and there's no
+// GetBody) we still buffer it. The caller's original Body is closed after the
+// snapshot.
+func snapshotBody(req *http.Request) (func() io.ReadCloser, error) {
+	if req.GetBody != nil {
+		return func() io.ReadCloser {
+			rc, err := req.GetBody()
+			if err != nil {
+				return io.NopCloser(strings.NewReader(""))
+			}
+			return rc
+		}, nil
+	}
+	if req.Body == nil || req.Body == http.NoBody {
+		return nil, nil
+	}
+	buf, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	_ = req.Body.Close()
+	req.Body = io.NopCloser(bytes.NewReader(buf))
+	// Also install GetBody so any other layer that wants to replay can do so.
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf)), nil
+	}
+	return func() io.ReadCloser {
+		return io.NopCloser(bytes.NewReader(buf))
+	}, nil
+}
+
+// drainResponse drains and closes a non-nil response body so the underlying
+// HTTP/1.1 connection can be reused for the next attempt.
+func drainResponse(res *http.Response) {
+	if res == nil || res.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+}
+
+// ctxErr returns ctx.Err() — split out so the retry loop can be explicit
+// about treating context cancellation as a terminal condition.
+func ctxErr(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}
+
+// contextSleep sleeps for d, returning early with ctx.Err() if ctx is canceled.
+func contextSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctxErr(ctx)
+	}
+	if ctx == nil {
+		time.Sleep(d)
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,341 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// retryTestURI is intentionally distinct from TestURI so gock matchers in this
+// file don't collide with any persistent fixtures registered by other tests.
+const retryTestURI = "http://retry.test.localhost"
+
+// fastNoopSleep makes retry tests deterministic by collapsing all backoffs to
+// near-zero while still respecting context cancellation. Individual tests that
+// need to assert real sleep duration (e.g. Retry-After) install their own.
+func fastNoopSleep(ctx context.Context, _ time.Duration) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}
+
+// newRetryClient builds a *Client configured with WithRetry plus any extra
+// options. It also installs the fastNoopSleep into the resulting policy so
+// tests don't actually wait the backoff window.
+func newRetryClient(t *testing.T, retryOpts []RetryOption, opts ...Option) *Client {
+	t.Helper()
+	allOpts := append([]Option{WithRetry(retryOpts...)}, opts...)
+	c := NewClient(retryTestURI, allOpts...)
+	rt, ok := c.httpClient.Transport.(*retryRoundTripper)
+	require.True(t, ok, "expected retryRoundTripper, got %T", c.httpClient.Transport)
+	rt.policy.sleep = fastNoopSleep
+	return c
+}
+
+func TestWithRetry_SuccessAfterTransient503(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusServiceUnavailable).
+		BodyString("first")
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusServiceUnavailable).
+		BodyString("second")
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusOK).
+		JSON(`{"data": {"release": "9.0", "version": "9.0.0"}}`)
+
+	client := newRetryClient(t, nil)
+
+	ver, err := client.Version(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, ver)
+	assert.Equal(t, "9.0.0", ver.Version)
+	assert.True(t, gock.IsDone(), "expected all three mocks to be consumed")
+}
+
+func TestWithRetry_StopsAfterMaxAttempts(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Times(2).
+		Reply(http.StatusServiceUnavailable)
+
+	client := newRetryClient(t, []RetryOption{WithRetryMax(2)})
+
+	_, err := client.Version(context.Background())
+	// 503 surfaces from handleResponse as a "503 Service Unavailable"-shaped
+	// error (StatusInternalServerError/NotImplemented are special-cased, but
+	// 503 falls through to JSON parsing of an empty body).
+	require.Error(t, err)
+	assert.True(t, gock.IsDone(), "expected exactly two attempts")
+}
+
+func TestWithRetry_RespectsRetryAfterOn429(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusTooManyRequests).
+		SetHeader("Retry-After", "1")
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusOK).
+		JSON(`{"data": {"release": "9.0", "version": "9.0.0"}}`)
+
+	// Custom sleep that records the actual durations the policy asked for.
+	var observed atomic.Int64
+	client := NewClient(retryTestURI, WithRetry())
+	rt := client.httpClient.Transport.(*retryRoundTripper)
+	rt.policy.sleep = func(ctx context.Context, d time.Duration) error {
+		observed.Store(int64(d))
+		// Still sleep a tiny bit so the timing of the call is observable,
+		// but never the full 1s the header asked for.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Millisecond):
+			return nil
+		}
+	}
+
+	_, err := client.Version(context.Background())
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, observed.Load(), int64(time.Second),
+		"Retry-After: 1 should request at least 1s of backoff")
+	assert.True(t, gock.IsDone())
+}
+
+func TestWithRetry_DoesNotRetry4xxOtherThan429(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusUnauthorized).
+		JSON(`{}`)
+	// Register a fallback success that the client should never consume.
+	mockTwo := gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusOK).
+		JSON(`{"data": {"release": "9.0", "version": "9.0.0"}}`)
+
+	client := newRetryClient(t, nil)
+
+	_, err := client.Version(context.Background())
+	// 401 surfaces as ErrNotAuthorized via Req's auth handling.
+	assert.ErrorIs(t, err, ErrNotAuthorized)
+	assert.True(t, mockTwo.Mock.Request().Counter > 0,
+		"second mock should still be registered (unconsumed)")
+
+	// Tear down the unconsumed mock manually so the suite is clean.
+	gock.Off()
+}
+
+func TestWithRetry_CustomConditionRetries418(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusTeapot)
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Reply(http.StatusOK).
+		JSON(`{"data": {"release": "9.0", "version": "9.0.0"}}`)
+
+	cond := func(res *http.Response, err error) bool {
+		if err != nil {
+			return true
+		}
+		return res != nil && res.StatusCode == http.StatusTeapot
+	}
+	client := newRetryClient(t, []RetryOption{WithRetryCondition(cond)})
+
+	ver, err := client.Version(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, ver)
+	assert.Equal(t, "9.0.0", ver.Version)
+	assert.True(t, gock.IsDone(), "expected both mocks consumed")
+}
+
+func TestWithRetry_ContextCancellationAborts(t *testing.T) {
+	defer gock.Off()
+
+	gock.New(retryTestURI).
+		Get("^/version$").
+		Persist().
+		Reply(http.StatusServiceUnavailable)
+
+	client := NewClient(retryTestURI, WithRetry(WithRetryMax(5)))
+	rt := client.httpClient.Transport.(*retryRoundTripper)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel on the first sleep call — that simulates a caller pulling the
+	// plug between attempts. Use the inner ctx (the one the request carries)
+	// so the policy actually sees Done.
+	rt.policy.sleep = func(c context.Context, _ time.Duration) error {
+		cancel()
+		return c.Err()
+	}
+
+	_, err := client.Version(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled),
+		"expected error to wrap context.Canceled, got %v", err)
+}
+
+func TestWithRetry_POSTBodyResentIdentically(t *testing.T) {
+	defer gock.Off()
+
+	const body = `{"username":"root@pam","password":"hunter2"}`
+
+	var firstBody, secondBody atomic.Value
+	firstBody.Store("")
+	secondBody.Store("")
+
+	gock.New(retryTestURI).
+		Post("^/access/ticket$").
+		AddMatcher(func(req *http.Request, _ *gock.Request) (bool, error) {
+			b, _ := io.ReadAll(req.Body)
+			firstBody.Store(string(b))
+			return true, nil
+		}).
+		Reply(http.StatusServiceUnavailable)
+
+	gock.New(retryTestURI).
+		Post("^/access/ticket$").
+		AddMatcher(func(req *http.Request, _ *gock.Request) (bool, error) {
+			b, _ := io.ReadAll(req.Body)
+			secondBody.Store(string(b))
+			return true, nil
+		}).
+		Reply(http.StatusOK).
+		JSON(`{"data": {"ticket": "t", "CSRFPreventionToken": "c", "username": "root@pam"}}`)
+
+	client := newRetryClient(t, nil)
+
+	err := client.Req(context.Background(), http.MethodPost, "/access/ticket", []byte(body), nil)
+	require.NoError(t, err, "expected the retry to succeed on the second attempt")
+
+	assert.Equal(t, body, firstBody.Load().(string), "first attempt body")
+	assert.Equal(t, body, secondBody.Load().(string), "retried body must match")
+	assert.True(t, gock.IsDone())
+}
+
+// --- helper / unit-level tests --------------------------------------------
+
+func TestParseRetryAfter(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		in   string
+		want time.Duration
+		ok   bool
+	}{
+		{"empty", "", 0, false},
+		{"seconds", "5", 5 * time.Second, true},
+		{"zero", "0", 0, true},
+		{"negative seconds rejected", "-3", 0, false},
+		{"http date in future", now.Add(3 * time.Second).UTC().Format(http.TimeFormat), 3 * time.Second, true},
+		{"http date in past clamps to zero", now.Add(-1 * time.Hour).UTC().Format(http.TimeFormat), 0, true},
+		{"garbage", "lol", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseRetryAfter(tc.in, now)
+			assert.Equal(t, tc.ok, ok)
+			if ok {
+				// HTTP-date parsing rounds to whole seconds — tolerate ±1s.
+				diff := got - tc.want
+				if diff < 0 {
+					diff = -diff
+				}
+				assert.LessOrEqual(t, diff, time.Second)
+			}
+		})
+	}
+}
+
+func TestSnapshotBody_RewindsBytes(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "http://x", strings.NewReader("hello"))
+	require.NoError(t, err)
+
+	rewind, err := snapshotBody(req)
+	require.NoError(t, err)
+	require.NotNil(t, rewind)
+
+	for i := 0; i < 3; i++ {
+		rc := rewind()
+		b, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(b))
+		_ = rc.Close()
+	}
+}
+
+func TestSnapshotBody_NoBody(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://x", nil)
+	require.NoError(t, err)
+	rewind, err := snapshotBody(req)
+	require.NoError(t, err)
+	assert.Nil(t, rewind)
+}
+
+func TestIsIdempotent(t *testing.T) {
+	for _, m := range []string{http.MethodGet, http.MethodHead, http.MethodPut, http.MethodDelete, http.MethodOptions, http.MethodTrace} {
+		assert.True(t, isIdempotent(m), "expected %s to be idempotent", m)
+	}
+	for _, m := range []string{http.MethodPost, http.MethodPatch, http.MethodConnect} {
+		assert.False(t, isIdempotent(m), "expected %s to not be idempotent", m)
+	}
+}
+
+func TestWithRetryMax_ClampsToOne(t *testing.T) {
+	p := defaultRetryPolicy()
+	WithRetryMax(-5)(p)
+	assert.Equal(t, 1, p.maxAttempts)
+}
+
+func TestWithRetryBackoff_IgnoresNonPositive(t *testing.T) {
+	p := defaultRetryPolicy()
+	WithRetryBackoff(0, 0)(p)
+	assert.Equal(t, defaultRetryInitialBackoff, p.initialBackoff)
+	assert.Equal(t, defaultRetryMaxBackoff, p.maxBackoff)
+
+	WithRetryBackoff(time.Second, 10*time.Second)(p)
+	assert.Equal(t, time.Second, p.initialBackoff)
+	assert.Equal(t, 10*time.Second, p.maxBackoff)
+}
+
+func TestWithRetryCondition_NilKeepsDefault(t *testing.T) {
+	p := defaultRetryPolicy()
+	WithRetryCondition(nil)(p)
+	assert.True(t, p.condition(&http.Response{StatusCode: http.StatusServiceUnavailable}, nil))
+}
+
+// TestInstallRetryWrapper_PromotesDefaultClient verifies that wrapping the
+// retry tripper onto a fresh client promotes c.httpClient off the shared
+// http.DefaultClient singleton (via the shared ensureOwnHTTPClient helper),
+// so installing the wrapper doesn't poke at package globals.
+func TestInstallRetryWrapper_PromotesDefaultClient(t *testing.T) {
+	c := &Client{httpClient: http.DefaultClient, retryPolicy: defaultRetryPolicy()}
+	c.installRetryWrapper()
+	assert.NotSame(t, http.DefaultClient, c.httpClient,
+		"installRetryWrapper must not leave the shared DefaultClient in place")
+	_, ok := c.httpClient.Transport.(*retryRoundTripper)
+	assert.True(t, ok, "transport should be wrapped in *retryRoundTripper")
+}


### PR DESCRIPTION
## Summary

Adds `WithRetry(opts ...RetryOption) Option` plus three helper options
(`WithRetryMax`, `WithRetryBackoff`, `WithRetryCondition`) and a private
`transportFor(c *Client)` helper that other transport-touching options
(WithProxy, the Tier 1 TLS helpers, request interceptors) can share.

`WithRetry` installs an `http.RoundTripper` wrapper around whatever transport
the client currently has, so it composes with TLS options, proxy options, and
request interceptors without requiring any of them to know about each other.

## Why

- PVE returns 502/503 during cluster transitions (rolling restarts, ceph
  quorum changes, fresh boot). Every adopter currently writes the same
  three-line retry loop around `client.Req`.
- 429 is rare but real on hosted/managed PVE setups behind a reverse proxy.
  Without a wrapper that honors `Retry-After`, callers have no good answer.
- Network blips (EOF, connection refused on the way through HA) deserve a
  one-shot retry at the transport layer rather than bubbling up to every
  resource method.

## Behavior

**Default policy:**
- 3 attempts (configurable via `WithRetryMax`)
- Exponential backoff with full jitter, 200ms initial, 5s cap (configurable
  via `WithRetryBackoff`)
- Retries on: network errors, HTTP 502, 503, 504, 429 (configurable via
  `WithRetryCondition`)
- Honors `Retry-After` on 429 and 503 — parses both delta-seconds and
  HTTP-date forms; uses the longer of (header, computed backoff); caps at the
  configured max so a malicious or misconfigured server can't park the client
  for arbitrarily long
- Respects `ctx.Done()` between attempts; surfaces `ctx.Err()` as the final
  error if cancellation fires during a backoff window

**What does NOT retry:**
- 4xx other than 429 (caller error — fail fast)
- Non-idempotent verbs without a rewindable body. POST in this client is
  always retried because `Req()` passes `data []byte` and the round-tripper
  snapshots the body up front
- Context-cancellation errors — never wrapped, never reattempted

## Composition

`WithRetry` wraps the transport that exists at option-evaluation time:

- After `WithProxy` / TLS options → retry sits on top of a transport that
  already has TLS/proxy configured. The retry wrapper delegates to that
  configured transport for every attempt.
- Before `WithHTTPClient` would normally unwrap, but the spec calls for
  re-applying retry on top of any client swapped in later. Current scope:
  document precedence and leave a hook (the shared `transportFor` helper)
  for the Tier 1+2 PR to chain on.
- With `WithRequestInterceptor` (sibling PR) — interceptors fire per request
  inside the retry loop, so a retried request runs the interceptors again.

The new `transportFor(c *Client)` helper:
- Lazily promotes `http.DefaultTransport` when the client has no explicit
  transport.
- Detaches from the shared `http.DefaultClient` singleton before mutating
  its `Transport` field, so installing retry on a default-configured client
  doesn't leak into other unrelated `http.DefaultClient` users.
- Is shared with the parallel `feat/with-proxy` and the Tier 1+2 PR — first
  PR in wins the helper, later PRs rebase on it.

## Test plan

`retry_test.go` (gock-backed, no real network):

- [x] 503 → 503 → 200: wrapper makes three attempts, returns the success body
- [x] Stops after `WithRetryMax(2)` and surfaces the last 503
- [x] Honors `Retry-After: 1` on 429: asserts the policy's sleep was invoked
      with ≥ 1s
- [x] 401 (not 429) is not retried; the second mock stays unconsumed
- [x] Custom `WithRetryCondition` that retries 418 is consulted
- [x] Context cancellation between attempts surfaces `context.Canceled`
- [x] POST body bytes are re-sent identically on the retry attempt (gock
      matcher captures both request bodies and asserts byte equality)

Plus helper-level tests for `parseRetryAfter` (delta-seconds, HTTP-date,
negative, garbage), `snapshotBody` (rewindable bytes, no body case),
`isIdempotent`, and the `WithRetry*` option clamping behavior.

`options_test.go` gets `TestWithRetry_InstallsWrapper` confirming the
default policy is wired correctly with no opts.

CI surface:

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 .` (all root-package tests green; 4.3s)