### PR TITLE
feat(options): TLS + timeout + auth ergonomics (Tier 1 + Tier 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,43 @@ xterm.js / VNC protocols Proxmox exposes.
 
 `NewClient(baseURL, opts...)` accepts `Option` funcs. Prefer the non-deprecated
 forms: `WithHTTPClient`, `WithCredentials`, `WithAPIToken`, `WithSession`,
-`WithUserAgent`, `WithLogger`. `WithClient` and `WithLogins` are kept for
-backwards compatibility — don't introduce new uses.
+`WithUserAgent`, `WithLogger`, plus the auth/transport options below.
+`WithClient` and `WithLogins` are kept for backwards compatibility — don't
+introduce new uses.
+
+**TLS and transport options** (`WithInsecureSkipVerify`, `WithRootCAs`,
+`WithRootCAFile`, `WithClientCertificate`, `WithTimeout`, plus the Tier 3
+proxy/retry/interceptor options when they land) defer their side effects
+until `finalizeOptions` runs after all option funcs. This makes option order
+irrelevant — `WithHTTPClient(custom) + WithInsecureSkipVerify()` and the
+reverse both end up with the option applied to `custom.Transport`. The
+shared private helpers `ensureOwnHTTPClient`, `ensureTransport`, and
+`ensureTLSConfig` handle the lazy promotion of `http.DefaultClient` /
+`http.DefaultTransport` to writable clones so transport mutations never
+bleed into the package-global singletons. When you add a new
+transport-touching option, route through those helpers rather than mutating
+`c.httpClient` directly.
+
+**Auth ergonomics.** `WithOTP` stashes a single-use TOTP/2FA code on the
+client and threads it into `Credentials.Otp` inside `sessionCredentials`
+(called by `CreateSession`). The OTP is zeroed after first use so a
+re-authentication after session loss doesn't resend a stale code.
+`WithDefaultRealm` is applied at the same merge point — it sets
+`Credentials.Realm` only when both the field is empty and the username has
+no `@realm` suffix.
+
+**Eager auth.** `WithEagerAuth` exists specifically because pveproxy
+enforces a hardcoded 3-second delay on every 401 from `auth_handler` (PVE
+upstream: `# always delay unauthorized calls by 3 seconds` in
+`PVE::APIServer::AnyEvent`). The library's credential-auth path is
+intentionally reactive — the first request goes out unauthenticated and
+triggers the retry-after-/access/ticket loop — which means the first
+user-facing call eats that 3 seconds. `WithEagerAuth` calls `CreateSession`
+synchronously inside `NewClient` to pay that cost at construction time.
+Errors are swallowed (option funcs can't return errors) and logged at debug
+level; the next user request retries via the existing lazy path. Callers
+who need auth errors surfaced at startup should call `CreateSession`
+directly.
 
 ### Resource model
 

--- a/README.md
+++ b/README.md
@@ -63,41 +63,70 @@ func main() {
 ```
 
 ### Usage with Client Options
+
+Lab setup (self-signed PVE, short timeout, API token):
+
 ```go
 package main
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
-	"net/http"
-	
+	"time"
+
 	"github.com/luthermonson/go-proxmox"
 )
 
 func main() {
-    insecureHTTPClient := http.Client{
-        Transport: &http.Transport{
-            TLSClientConfig: &tls.Config{
-                InsecureSkipVerify: true,
-            },
-        },
-    }
-    tokenID := "root@pam!mytoken"
-    secret := "somegeneratedapitokenguidefromtheproxmoxui"
-    
-    client := proxmox.NewClient("https://localhost:8006/api2/json",
-        proxmox.WithHTTPClient(&insecureHTTPClient),
-        proxmox.WithAPIToken(tokenID, secret),
-    )
-    
-    version, err := client.Version(context.Background())
-    if err != nil {
-        panic(err)
-    }
-    fmt.Println(version.Release) // 6.3
+	client := proxmox.NewClient("https://localhost:8006/api2/json",
+		proxmox.WithAPIToken("root@pam!mytoken", "somegeneratedapitokenguidefromtheproxmoxui"),
+		proxmox.WithInsecureSkipVerify(),     // lab only
+		proxmox.WithTimeout(30*time.Second),  // http.DefaultClient has no timeout
+	)
+
+	version, err := client.Version(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(version.Release) // 6.3
 }
 ```
+
+Production setup (pinned CA, mTLS optional):
+
+```go
+caBundle, _ := os.ReadFile("/etc/ssl/certs/pve-cluster.pem")
+pool := x509.NewCertPool()
+pool.AppendCertsFromPEM(caBundle)
+
+client := proxmox.NewClient("https://pve.example.com:8006/api2/json",
+	proxmox.WithAPIToken("automation@pve!ci", "<secret>"),
+	proxmox.WithRootCAs(pool),
+	proxmox.WithTimeout(30*time.Second),
+	// optional mTLS:
+	// proxmox.WithClientCertificate(clientCert),
+)
+```
+
+### Credential authentication and 2FA
+
+API tokens are the right choice for daemons and CI. For interactive tools — anything with a human typing a password and a TOTP code — use credentials with `WithOTP` and `WithEagerAuth`:
+
+```go
+client := proxmox.NewClient(url,
+	proxmox.WithCredentials(&proxmox.Credentials{
+		Username: "admin",
+		Password: password,
+	}),
+	proxmox.WithDefaultRealm("pam"),  // "admin" gets Realm "pam" merged in
+	proxmox.WithOTP("123456"),        // one-shot; consumed on first /access/ticket
+	proxmox.WithEagerAuth(),          // see note below
+)
+```
+
+`WithEagerAuth` is worth calling out. PVE's pveproxy enforces a **hardcoded 3-second delay on every 401 response** as a brute-force mitigation (see `PVE::APIServer::AnyEvent`'s `# always delay unauthorized calls by 3 seconds` block). With credential auth the library's first request goes out unauthenticated by design — the ticket isn't issued until `/access/ticket` succeeds — so the first user-facing call eats the full 3 seconds. `WithEagerAuth` runs `CreateSession` inside `NewClient` so that cost is paid once at startup and every subsequent request is a normal ticket-authenticated call. Token auth doesn't trigger the 401 path at all and doesn't need this.
+
+The OTP is consumed exactly once; subsequent `RefreshTicket` calls renew the session via the ticket itself and don't need a new code. If the session is fully lost later (PVE restart invalidates tickets), construct a fresh client with a fresh OTP — TOTP codes can't be cached.
 
 # Developing
 This project relies on [Mage](https://magefile.org/) for cross os/arch compatibility, please see their installation guide. 

--- a/access.go
+++ b/access.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -44,13 +45,38 @@ func (c *Client) CreateSession(ctx context.Context) error {
 		}
 	}
 
-	if _, err := c.Ticket(ctx, c.credentials); err != nil {
+	if _, err := c.Ticket(ctx, c.sessionCredentials()); err != nil {
 		return err
 	}
 
 	c.sessionExpiresAt = time.Now().Add(time.Hour)
 
 	return nil
+}
+
+// sessionCredentials returns the Credentials value to send to
+// /access/ticket on the next CreateSession call. If WithOTP or
+// WithDefaultRealm has been used the value is a per-call copy with those
+// fields merged in; otherwise the caller's original *Credentials is
+// returned unchanged. The OTP is consumed (zeroed on the client) so a
+// subsequent CreateSession (e.g. after a session loss) doesn't re-send a
+// stale single-use code.
+func (c *Client) sessionCredentials() *Credentials {
+	if c.credentials == nil {
+		return nil
+	}
+	if c.otp == "" && c.defaultRealm == "" {
+		return c.credentials
+	}
+	merged := *c.credentials
+	if c.otp != "" {
+		merged.Otp = c.otp
+		c.otp = "" // single-use; PVE accepts a TOTP code exactly once
+	}
+	if c.defaultRealm != "" && merged.Realm == "" && !strings.Contains(merged.Username, "@") {
+		merged.Realm = c.defaultRealm
+	}
+	return &merged
 }
 
 func (c *Client) Ticket(ctx context.Context, credentials *Credentials) (*Session, error) {

--- a/options.go
+++ b/options.go
@@ -1,8 +1,13 @@
 package proxmox
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
+	"time"
 )
 
 type Option func(*Client)
@@ -58,4 +63,188 @@ func WithLogger(logger LeveledLoggerInterface) Option {
 	return func(c *Client) {
 		c.log = logger
 	}
+}
+
+// --- transport / TLS options ---------------------------------------------
+
+// WithTimeout sets the *http.Client.Timeout used for every request. Composes
+// with WithHTTPClient regardless of option order — if the caller passed their
+// own *http.Client, the timeout is applied to it.
+//
+// The default http.DefaultClient has no timeout. Without this option,
+// a hung PVE node means a hung caller forever; setting at least a generous
+// upper bound is recommended for any non-interactive use.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Client) {
+		c.timeout = d
+	}
+}
+
+// WithInsecureSkipVerify disables TLS certificate verification. For lab use
+// only — production clusters should pin the cluster's CA via WithRootCAs or
+// WithRootCAFile instead.
+//
+// Composes with WithHTTPClient, WithRootCAs, WithRootCAFile, and
+// WithClientCertificate; option order doesn't matter.
+func WithInsecureSkipVerify() Option {
+	return func(c *Client) {
+		c.tlsMods = append(c.tlsMods, func(tc *tls.Config) {
+			tc.InsecureSkipVerify = true
+		})
+	}
+}
+
+// WithRootCAs sets the *x509.CertPool used to verify the cluster's TLS
+// certificate. Use this when the cluster presents a cert chain signed by your
+// org's CA. Composes with the other TLS options.
+func WithRootCAs(pool *x509.CertPool) Option {
+	return func(c *Client) {
+		c.tlsMods = append(c.tlsMods, func(tc *tls.Config) {
+			tc.RootCAs = pool
+		})
+	}
+}
+
+// WithRootCAFile loads a PEM-encoded CA bundle from path and appends every
+// certificate it contains to the TLS root pool. Convenience wrapper around
+// WithRootCAs for the common single-file case.
+//
+// The file is read at NewClient time (when this option is evaluated). If the
+// file can't be read or contains no valid certificates, the error is logged
+// via the client logger and the option is a no-op — option funcs can't
+// return errors. Callers who need the file-IO error surfaced explicitly
+// should read the file themselves and pass the resulting pool to
+// WithRootCAs.
+func WithRootCAFile(path string) Option {
+	return func(c *Client) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			c.log.Errorf("WithRootCAFile: read %q: %v", path, err)
+			return
+		}
+		c.tlsMods = append(c.tlsMods, func(tc *tls.Config) {
+			if tc.RootCAs == nil {
+				tc.RootCAs = x509.NewCertPool()
+			}
+			if !tc.RootCAs.AppendCertsFromPEM(data) {
+				c.log.Errorf("WithRootCAFile: %q contained no valid PEM certificates", path)
+			}
+		})
+	}
+}
+
+// WithClientCertificate adds a client certificate for mutual TLS. Appends to
+// tls.Config.Certificates so multiple calls compose. Composes with the other
+// TLS options.
+func WithClientCertificate(cert tls.Certificate) Option {
+	return func(c *Client) {
+		c.tlsMods = append(c.tlsMods, func(tc *tls.Config) {
+			tc.Certificates = append(tc.Certificates, cert)
+		})
+	}
+}
+
+// --- auth ergonomics ------------------------------------------------------
+
+// WithOTP supplies a one-time password (TOTP, Yubico OTP, etc.) for the
+// initial /access/ticket call when the user has two-factor auth enabled.
+// The code is consumed exactly once on the first CreateSession call;
+// subsequent RefreshTicket calls renew the session via the ticket itself
+// and do not need a new OTP.
+//
+// Requires WithCredentials. No effect when using token auth — tokens bypass
+// 2FA by design.
+//
+// If the session is fully lost later (PVE restart, ticket past the renewal
+// window) and the client tries to re-authenticate, that call will fail
+// because the OTP is single-use. Callers in that scenario must construct a
+// fresh client with a fresh OTP — the library cannot keep a TOTP around.
+func WithOTP(otp string) Option {
+	return func(c *Client) {
+		c.otp = otp
+	}
+}
+
+// WithDefaultRealm auto-appends "@<realm>" to Credentials.Username if the
+// supplied username has no @realm suffix and Credentials.Realm is empty.
+// Saves the most common credential-auth typo ("root" vs "root@pam").
+//
+// No effect when token auth is used or when the username already carries
+// a realm.
+func WithDefaultRealm(realm string) Option {
+	return func(c *Client) {
+		c.defaultRealm = strings.TrimPrefix(realm, "@")
+	}
+}
+
+// WithEagerAuth makes NewClient call CreateSession synchronously so the
+// first user-facing request doesn't trigger PVE pveproxy's hardcoded
+// 3-second 401 delay on unauthenticated requests. Pveproxy enforces this
+// delay on every failed-or-missing-auth response — see
+// PVE::APIServer::AnyEvent's `# always delay unauthorized calls by 3 seconds`
+// block. With credential auth the client's first request is always
+// unauthenticated (the cookie+CSRF aren't set until /access/ticket
+// succeeds), so it eats the full 3s before the library retries with the
+// ticket. WithEagerAuth pays that cost once at construction instead.
+//
+// Has no effect with token auth — tokens attach Authorization on every
+// request and never trigger the 401 path. Has no effect when neither
+// credentials nor token are set.
+//
+// Errors from the eager CreateSession are logged at debug level and
+// otherwise swallowed; the next user request will retry via the existing
+// lazy-auth path. To surface auth errors at startup explicitly, call
+// (*Client).CreateSession yourself instead of using this option.
+func WithEagerAuth() Option {
+	return func(c *Client) {
+		c.eagerAuth = true
+	}
+}
+
+// --- shared transport plumbing -------------------------------------------
+//
+// ensureOwnHTTPClient, ensureTransport, ensureTLSConfig are private helpers
+// shared by every transport-touching option (TLS, timeout — and by the
+// Tier 3 options WithProxy and WithRetry, which land in sibling PRs).
+// Their job is to give those options a writable *http.Transport without
+// mutating http.DefaultClient or http.DefaultTransport when the caller
+// didn't provide their own client.
+
+// ensureOwnHTTPClient guarantees c.httpClient is something we're allowed to
+// mutate. If it's nil or still pointing at http.DefaultClient, allocate a
+// fresh *http.Client (Transport defaulted, Timeout zero) so subsequent
+// option writes don't bleed into the global default.
+func (c *Client) ensureOwnHTTPClient() {
+	if c.httpClient == nil || c.httpClient == http.DefaultClient {
+		c.httpClient = &http.Client{}
+	}
+}
+
+// ensureTransport returns the *http.Transport on c.httpClient, promoting
+// http.DefaultTransport to a clone if necessary. Returns nil if the
+// client's RoundTripper is a custom non-Transport implementation — in that
+// case the caller should debug-log and skip whatever option needed it.
+func (c *Client) ensureTransport() *http.Transport {
+	c.ensureOwnHTTPClient()
+	if c.httpClient.Transport == nil {
+		c.httpClient.Transport = http.DefaultTransport.(*http.Transport).Clone()
+	}
+	if t, ok := c.httpClient.Transport.(*http.Transport); ok {
+		return t
+	}
+	return nil
+}
+
+// ensureTLSConfig returns the *tls.Config on the client's transport,
+// allocating a fresh one if absent. Returns nil if the transport isn't an
+// *http.Transport — see ensureTransport.
+func (c *Client) ensureTLSConfig() *tls.Config {
+	t := c.ensureTransport()
+	if t == nil {
+		return nil
+	}
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	}
+	return t.TLSClientConfig
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,10 +1,16 @@
 package proxmox
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"net/http"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,4 +51,239 @@ func TestWithUserAgent(t *testing.T) {
 func TestWithLogger(t *testing.T) {
 	client := NewClient("", WithLogger(&LeveledLogger{Level: 1}))
 	assert.Equal(t, client.log, &LeveledLogger{Level: 1})
+}
+
+// --- transport / TLS options ---------------------------------------------
+
+func TestWithTimeout(t *testing.T) {
+	client := NewClient("", WithTimeout(15*time.Second))
+	assert.Equal(t, 15*time.Second, client.httpClient.Timeout)
+	// must not have polluted the package-global default
+	assert.Equal(t, time.Duration(0), http.DefaultClient.Timeout)
+}
+
+func TestWithTimeout_AppliesToCallerHTTPClient(t *testing.T) {
+	custom := &http.Client{}
+	client := NewClient("", WithHTTPClient(custom), WithTimeout(7*time.Second))
+	assert.Equal(t, 7*time.Second, custom.Timeout)
+	assert.Same(t, custom, client.httpClient)
+}
+
+func TestWithInsecureSkipVerify(t *testing.T) {
+	client := NewClient("", WithInsecureSkipVerify())
+	tr := client.httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, tr.TLSClientConfig)
+	assert.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+	// must not have polluted the global default
+	defaultTr := http.DefaultTransport.(*http.Transport)
+	assert.False(t, defaultTr.TLSClientConfig != nil && defaultTr.TLSClientConfig.InsecureSkipVerify,
+		"WithInsecureSkipVerify must not mutate http.DefaultTransport")
+}
+
+func TestWithRootCAs(t *testing.T) {
+	pool := x509.NewCertPool()
+	client := NewClient("", WithRootCAs(pool))
+	tr := client.httpClient.Transport.(*http.Transport)
+	assert.Same(t, pool, tr.TLSClientConfig.RootCAs)
+}
+
+func TestWithRootCAFile_AppendsCerts(t *testing.T) {
+	// Self-signed PEM generated once for this test. Any valid PEM works;
+	// we don't need the corresponding private key because we only test that
+	// AppendCertsFromPEM accepts it.
+	const certPEM = `-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----
+`
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "ca.pem")
+	assert.NoError(t, os.WriteFile(path, []byte(certPEM), 0o600))
+
+	client := NewClient("", WithRootCAFile(path))
+	tr := client.httpClient.Transport.(*http.Transport)
+	assert.NotNil(t, tr.TLSClientConfig)
+	assert.NotNil(t, tr.TLSClientConfig.RootCAs)
+}
+
+func TestWithRootCAFile_MissingFileLogsAndNoOps(t *testing.T) {
+	// Missing file should not panic, should not crash, should not set RootCAs.
+	client := NewClient("", WithRootCAFile("/does/not/exist.pem"))
+	if client.httpClient.Transport != nil {
+		if tr, ok := client.httpClient.Transport.(*http.Transport); ok && tr.TLSClientConfig != nil {
+			assert.Nil(t, tr.TLSClientConfig.RootCAs)
+		}
+	}
+}
+
+func TestWithClientCertificate(t *testing.T) {
+	cert := tls.Certificate{Certificate: [][]byte{{0x01, 0x02, 0x03}}}
+	client := NewClient("", WithClientCertificate(cert))
+	tr := client.httpClient.Transport.(*http.Transport)
+	assert.Len(t, tr.TLSClientConfig.Certificates, 1)
+}
+
+func TestTLSOptions_Compose_OrderIndependent(t *testing.T) {
+	pool := x509.NewCertPool()
+	cert := tls.Certificate{Certificate: [][]byte{{0x01}}}
+
+	// Order A: insecure → root → cert
+	a := NewClient("", WithInsecureSkipVerify(), WithRootCAs(pool), WithClientCertificate(cert))
+	atc := a.httpClient.Transport.(*http.Transport).TLSClientConfig
+	assert.True(t, atc.InsecureSkipVerify)
+	assert.Same(t, pool, atc.RootCAs)
+	assert.Len(t, atc.Certificates, 1)
+
+	// Order B: reversed — all three must still land
+	b := NewClient("", WithClientCertificate(cert), WithRootCAs(pool), WithInsecureSkipVerify())
+	btc := b.httpClient.Transport.(*http.Transport).TLSClientConfig
+	assert.True(t, btc.InsecureSkipVerify)
+	assert.Same(t, pool, btc.RootCAs)
+	assert.Len(t, btc.Certificates, 1)
+}
+
+func TestTLSOptions_ComposeWithHTTPClient_BothOrders(t *testing.T) {
+	custom := &http.Client{Transport: &http.Transport{}}
+	// TLS option before WithHTTPClient
+	NewClient("", WithInsecureSkipVerify(), WithHTTPClient(custom))
+	tr := custom.Transport.(*http.Transport)
+	assert.NotNil(t, tr.TLSClientConfig, "TLS option before WithHTTPClient should mutate the caller's transport")
+	assert.True(t, tr.TLSClientConfig.InsecureSkipVerify)
+
+	custom2 := &http.Client{Transport: &http.Transport{}}
+	NewClient("", WithHTTPClient(custom2), WithInsecureSkipVerify())
+	tr2 := custom2.Transport.(*http.Transport)
+	assert.NotNil(t, tr2.TLSClientConfig)
+	assert.True(t, tr2.TLSClientConfig.InsecureSkipVerify)
+}
+
+// --- auth ergonomics ------------------------------------------------------
+
+func TestWithOTP_StashesOnClient(t *testing.T) {
+	client := NewClient("",
+		WithCredentials(&Credentials{Username: "root@pam", Password: "pw"}),
+		WithOTP("123456"),
+	)
+	assert.Equal(t, "123456", client.otp)
+}
+
+func TestWithOTP_ThreadedIntoTicketAndConsumed(t *testing.T) {
+	mockConfig := mockConfig
+	defer gock.Off()
+
+	// Match the ticket POST and assert the body contains otp=123456.
+	gock.New(mockConfig.URI).
+		Post("/access/ticket").
+		MatchType("json").
+		AddMatcher(func(r *http.Request, _ *gock.Request) (bool, error) {
+			body := make([]byte, r.ContentLength)
+			_, _ = r.Body.Read(body)
+			return assert.ObjectsAreEqual(true, true) && containsByte(body, []byte(`"otp":"123456"`)), nil
+		}).
+		Reply(200).
+		JSON(`{"data":{"ticket":"PVE:root@pam:0000:hex","CSRFPreventionToken":"csrf","username":"root@pam"}}`)
+
+	client := NewClient(mockConfig.URI,
+		WithCredentials(&Credentials{Username: "root@pam", Password: "pw"}),
+		WithOTP("123456"),
+	)
+	assert.NoError(t, client.CreateSession(context.Background()))
+
+	// OTP must have been consumed (zeroed out) so a subsequent re-auth
+	// doesn't resend the same single-use code.
+	assert.Equal(t, "", client.otp)
+}
+
+func TestWithDefaultRealm_AppendedWhenMissing(t *testing.T) {
+	client := NewClient("", WithDefaultRealm("pam"))
+	merged := mergeCredsForTest(client, &Credentials{Username: "root", Password: "x"})
+	assert.Equal(t, "pam", merged.Realm)
+	assert.Equal(t, "root", merged.Username, "username should not be rewritten when only Realm is filled in")
+}
+
+func TestWithDefaultRealm_NotAppendedWhenUsernameHasAtSuffix(t *testing.T) {
+	client := NewClient("", WithDefaultRealm("pam"))
+	merged := mergeCredsForTest(client, &Credentials{Username: "root@pve", Password: "x"})
+	assert.Equal(t, "", merged.Realm, "WithDefaultRealm must not override an explicit @realm")
+}
+
+func TestWithDefaultRealm_StripsLeadingAt(t *testing.T) {
+	client := NewClient("", WithDefaultRealm("@pam"))
+	assert.Equal(t, "pam", client.defaultRealm, "leading '@' should be stripped")
+}
+
+func TestWithEagerAuth_SetsFlag(t *testing.T) {
+	client := NewClient("", WithEagerAuth())
+	assert.True(t, client.eagerAuth)
+}
+
+func TestWithEagerAuth_RunsCreateSessionAtConstruction(t *testing.T) {
+	mockConfig := mockConfig
+	defer gock.Off()
+
+	called := false
+	gock.New(mockConfig.URI).
+		Post("/access/ticket").
+		AddMatcher(func(r *http.Request, _ *gock.Request) (bool, error) {
+			called = true
+			return true, nil
+		}).
+		Reply(200).
+		JSON(`{"data":{"ticket":"PVE:root@pam:0000:hex","CSRFPreventionToken":"csrf","username":"root@pam"}}`)
+
+	NewClient(mockConfig.URI,
+		WithCredentials(&Credentials{Username: "root@pam", Password: "pw"}),
+		WithEagerAuth(),
+	)
+	assert.True(t, called, "WithEagerAuth should POST /access/ticket synchronously in NewClient")
+}
+
+func TestWithEagerAuth_NoOpWithToken(t *testing.T) {
+	defer gock.Off()
+	// Even with WithEagerAuth, token auth should not trigger a ticket POST.
+	gock.New("http://nope").
+		Post("/access/ticket").
+		Reply(500)
+
+	NewClient("http://nope",
+		WithAPIToken("root@pam!t", "secret"),
+		WithEagerAuth(),
+	)
+	// If the eager auth had fired, gock would have served the 500 and our
+	// transport would still be intact; the real assertion is just that
+	// NewClient didn't panic and we got here.
+	assert.True(t, gock.IsPending(), "ticket POST should not have been consumed for token auth")
+}
+
+// --- test helpers ---------------------------------------------------------
+
+func mergeCredsForTest(c *Client, base *Credentials) *Credentials {
+	c.credentials = base
+	return c.sessionCredentials()
+}
+
+func containsByte(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := range needle {
+			if haystack[i+j] != needle[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
 }

--- a/proxmox.go
+++ b/proxmox.go
@@ -100,6 +100,15 @@ type Client struct {
 
 	sessionExpiresAt time.Time
 	sessionMux       sync.Mutex
+
+	// Option-backed fields. See options.go for the corresponding With*
+	// setters. These are collected during NewClient option evaluation and
+	// applied in finalizeOptions before NewClient returns.
+	otp           string
+	defaultRealm  string
+	eagerAuth     bool
+	timeout       time.Duration
+	tlsMods       []func(*tls.Config)
 }
 
 func NewClient(baseURL string, opts ...Option) *Client {
@@ -117,7 +126,50 @@ func NewClient(baseURL string, opts ...Option) *Client {
 		c.httpClient = http.DefaultClient
 	}
 
+	c.finalizeOptions()
+
 	return c
+}
+
+// finalizeOptions applies deferred option side-effects after all opt funcs
+// have run. Two reasons for deferral:
+//
+//  1. Order independence — TLS option order shouldn't matter, and
+//     WithHTTPClient should compose regardless of whether it ran before or
+//     after the TLS options.
+//  2. We must avoid mutating http.DefaultClient or http.DefaultTransport
+//     (the package-global singletons) when the caller didn't provide their
+//     own. ensureTransport promotes them via Clone() on demand.
+//
+// Order: TLS first (transport-touching), then timeout (on httpClient), then
+// eager auth (which makes a network request and needs everything else
+// settled).
+func (c *Client) finalizeOptions() {
+	if len(c.tlsMods) > 0 {
+		if tc := c.ensureTLSConfig(); tc != nil {
+			for _, mod := range c.tlsMods {
+				mod(tc)
+			}
+		} else {
+			c.log.Debugf("TLS options requested but client's RoundTripper is not an *http.Transport; options have no effect")
+		}
+	}
+
+	if c.timeout > 0 {
+		c.ensureOwnHTTPClient()
+		c.httpClient.Timeout = c.timeout
+	}
+
+	if c.eagerAuth && c.credentials != nil && c.token == "" {
+		// Best-effort eager session. Errors are intentionally swallowed:
+		// the next user request will retry via the existing lazy-auth path,
+		// and option funcs can't return errors. Callers who want auth
+		// errors surfaced at startup time should call CreateSession
+		// explicitly instead of using WithEagerAuth.
+		if err := c.CreateSession(context.Background()); err != nil {
+			c.log.Debugf("WithEagerAuth: CreateSession failed: %v", err)
+		}
+	}
 }
 
 func (c *Client) Version(ctx context.Context) (*Version, error) {


### PR DESCRIPTION
Closes the long-standing README boilerplate problem and adds the auth ergonomics layer for v0.7.x.

## Tier 1 — TLS + timeout

| Option | Purpose |
|---|---|
| `WithInsecureSkipVerify()` | Lab-only TLS skip. Replaces the 7-line `http.Client{Transport: &http.Transport{TLSClientConfig: ...}}` dance from the README. |
| `WithRootCAs(*x509.CertPool)` | Pin the cluster's CA bundle. |
| `WithRootCAFile(path)` | Sugar for the single-file case. Logs and no-ops on file read / no-valid-PEM errors. |
| `WithClientCertificate(tls.Certificate)` | mTLS, appends to `tls.Config.Certificates`. |
| `WithTimeout(time.Duration)` | Sets `http.Client.Timeout`. Applies to a caller-supplied `*http.Client` too. |

## Tier 2 — auth ergonomics

| Option | Purpose |
|---|---|
| `WithOTP(string)` | Single-shot TOTP / 2FA code threaded into `Credentials.Otp` at `CreateSession` time. Zeroed after first use so a re-auth after session loss can't replay a stale code. |
| `WithDefaultRealm(string)` | Auto-merges `Credentials.Realm` when both the field is empty and the username has no `@realm` suffix. Saves the most common credential typo. |
| `WithEagerAuth()` | Runs `CreateSession` synchronously inside `NewClient` so the first user-facing request doesn't trigger PVE pveproxy's hardcoded 3-second 401 delay (see [PVE upstream](https://github.com/proxmox/pve-http-server/blob/master/src/PVE/APIServer/AnyEvent.pm): `# always delay unauthorized calls by 3 seconds`). Real production bug for any credential-auth adopter. Token auth bypasses this entirely. |

## Design

- TLS options stash mutation closures on the `Client` and apply them in `finalizeOptions` after every option func has run. That makes option order irrelevant — `WithHTTPClient(custom) + WithInsecureSkipVerify()` and the reverse both end up with the option applied to `custom.Transport`.
- Shared private helpers — `ensureOwnHTTPClient`, `ensureTransport`, `ensureTLSConfig` — lazily promote `http.DefaultClient` and `http.DefaultTransport` to writable clones so transport mutations never bleed into the package-global singletons.
- `WithOTP` and `WithDefaultRealm` are merged in via a new unexported `sessionCredentials()` helper that `CreateSession` calls. Per-call copy of the user's `*Credentials` — we don't mutate the caller's struct.
- `WithEagerAuth` errors are debug-logged (option funcs can't return errors); the next user request retries via the existing lazy 401 path. Callers needing auth errors at startup should call `CreateSession` directly.

## Coordination with the Tier 3 PRs

Three sibling PRs are in flight, each adding a Tier 3 transport-touching option:

- #324 `WithProxy` / `WithProxyFromEnvironment`
- #325 `WithRequestInterceptor`
- #326 `WithRetry` (+ helpers)

Each subagent introduced its own version of the transport-promotion helper. Whichever PR merges first wins the helper; the others will rebase and call into the shared one. This PR's `ensureOwnHTTPClient` / `ensureTransport` / `ensureTLSConfig` are the intended home — they're documented in `AGENTS.md` for future option authors.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 .` (4.2s, all green)
- [x] 17 new tests in `options_test.go` covering each option, both orderings against `WithHTTPClient`, order-independence among the TLS options, that `http.DefaultClient` / `http.DefaultTransport` globals are never mutated, OTP threading + single-use consumption via gock, eager auth firing `/access/ticket` synchronously, and the no-op for token auth.
- [x] README updated: lab + production examples replace the old single example; new "Credential authentication and 2FA" section walks through `WithOTP` / `WithEagerAuth` and explains the 3-second delay rationale.
- [x] AGENTS.md updated: documents `finalizeOptions` + `ensure*` helpers for transport-touching options, the `sessionCredentials` merge point, the eager-auth rationale.