### PR TITLE
test: cover cluster_sdn*.go (close the post-#320 gap)

### DIFF
--- a/cluster_sdn_controllers_test.go
+++ b/cluster_sdn_controllers_test.go
@@ -60,3 +60,46 @@ func TestSDNController_UpdateDelete(t *testing.T) {
 	err = c.Delete(context.Background())
 	assert.Nil(t, err)
 }
+
+func TestCluster_SDNControllersFiltered(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	controllers, err := cluster.SDNControllers(context.Background(), "evpn")
+	assert.Nil(t, err)
+	assert.Len(t, controllers, 1)
+	assert.Equal(t, "evpn", controllers[0].Type)
+}
+
+func TestSDNController_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	c := cluster.SDNController("ctrl1")
+	// nil opts should be replaced with zero-value internally
+	err := c.Update(context.Background(), nil)
+	assert.Nil(t, err)
+}
+
+func TestSDNController_EmptyName_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	client := mockClient()
+
+	c := &SDNController{client: client}
+	assert.Error(t, c.Read(context.Background()))
+	assert.Error(t, c.Update(context.Background(), &SDNControllerOptions{}))
+	assert.Error(t, c.Delete(context.Background()))
+}
+
+func TestSDNController_Read_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	c := cluster.SDNController("missing")
+	err := c.Read(context.Background())
+	assert.Error(t, err)
+}

--- a/cluster_sdn_dns_test.go
+++ b/cluster_sdn_dns_test.go
@@ -44,3 +44,40 @@ func TestCluster_NewSDNDNS(t *testing.T) {
 	assert.NotNil(t, cluster.NewSDNDNS(context.Background(), nil))
 	assert.NotNil(t, cluster.NewSDNDNS(context.Background(), &SDNDNSOptions{DNS: "x"}))
 }
+
+func TestCluster_SDNDNSListFiltered(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	dns, err := cluster.SDNDNSList(context.Background(), "powerdns")
+	assert.Nil(t, err)
+	assert.Len(t, dns, 1)
+}
+
+func TestSDNDNS_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	d := cluster.SDNDNS("pdns1")
+	assert.Nil(t, d.Update(context.Background(), nil))
+}
+
+func TestSDNDNS_EmptyName_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	d := &SDNDNS{client: mockClient()}
+	assert.Error(t, d.Read(context.Background()))
+	assert.Error(t, d.Update(context.Background(), &SDNDNSOptions{}))
+	assert.Error(t, d.Delete(context.Background()))
+}
+
+func TestSDNDNS_Read_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	d := cluster.SDNDNS("missing")
+	assert.Error(t, d.Read(context.Background()))
+}

--- a/cluster_sdn_fabrics_test.go
+++ b/cluster_sdn_fabrics_test.go
@@ -113,3 +113,62 @@ func TestSDNFabric_AddNode(t *testing.T) {
 
 	assert.NotNil(t, f.AddNode(context.Background(), nil))
 }
+
+func TestCluster_SDNFabricsFiltered(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	fabrics, err := cluster.SDNFabrics(context.Background(), true, false)
+	assert.Nil(t, err)
+	assert.Len(t, fabrics, 1)
+	assert.Equal(t, "fab1", fabrics[0].ID)
+}
+
+func TestSDNFabric_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	f := cluster.SDNFabric("fab1")
+	assert.Nil(t, f.Update(context.Background(), nil))
+}
+
+func TestSDNFabric_EmptyID_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	f := &SDNFabric{client: mockClient()}
+	assert.Error(t, f.Read(context.Background()))
+	assert.Error(t, f.Update(context.Background(), &SDNFabricOptions{}))
+	assert.Error(t, f.Delete(context.Background()))
+	_, err := f.Nodes(context.Background())
+	assert.Error(t, err)
+	assert.Error(t, f.AddNode(context.Background(), &SDNFabricNodeOptions{NodeID: "n"}))
+}
+
+func TestSDNFabric_Read_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	f := cluster.SDNFabric("missing")
+	assert.Error(t, f.Read(context.Background()))
+}
+
+func TestSDNFabricNode_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	n := cluster.SDNFabric("fab1").Node("node1")
+	assert.Nil(t, n.Update(context.Background(), nil))
+}
+
+func TestSDNFabricNode_EmptyIDs_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	n := &SDNFabricNode{client: mockClient()}
+	assert.Error(t, n.Read(context.Background()))
+	assert.Error(t, n.Update(context.Background(), &SDNFabricNodeOptions{}))
+	assert.Error(t, n.Delete(context.Background()))
+}

--- a/cluster_sdn_ipams_test.go
+++ b/cluster_sdn_ipams_test.go
@@ -55,3 +55,42 @@ func TestCluster_NewSDNIPAM(t *testing.T) {
 	assert.NotNil(t, cluster.NewSDNIPAM(context.Background(), nil))
 	assert.NotNil(t, cluster.NewSDNIPAM(context.Background(), &SDNIPAMOptions{IPAM: "x"}))
 }
+
+func TestCluster_SDNIPAMsFiltered(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	ipams, err := cluster.SDNIPAMs(context.Background(), "pve")
+	assert.Nil(t, err)
+	assert.Len(t, ipams, 1)
+}
+
+func TestSDNIPAM_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	i := cluster.SDNIPAM("pve")
+	assert.Nil(t, i.Update(context.Background(), nil))
+}
+
+func TestSDNIPAM_EmptyName_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	i := &SDNIPAM{client: mockClient()}
+	assert.Error(t, i.Read(context.Background()))
+	assert.Error(t, i.Update(context.Background(), &SDNIPAMOptions{}))
+	assert.Error(t, i.Delete(context.Background()))
+	_, err := i.Status(context.Background())
+	assert.Error(t, err)
+}
+
+func TestSDNIPAM_Read_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	i := cluster.SDNIPAM("missing")
+	assert.Error(t, i.Read(context.Background()))
+}

--- a/cluster_sdn_misc_test.go
+++ b/cluster_sdn_misc_test.go
@@ -62,3 +62,13 @@ func TestCluster_SDNDryRun(t *testing.T) {
 	_, err = cluster.SDNDryRun(context.Background(), "")
 	assert.NotNil(t, err)
 }
+
+func TestCluster_SDNLock_AllowPending(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	token, err := cluster.SDNLock(context.Background(), true)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, token)
+}

--- a/cluster_sdn_prefix_lists_test.go
+++ b/cluster_sdn_prefix_lists_test.go
@@ -80,3 +80,64 @@ func TestSDNPrefixList_AddEntry(t *testing.T) {
 	assert.NotNil(t, l.AddEntry(context.Background(), nil))
 	assert.NotNil(t, l.AddEntry(context.Background(), &SDNPrefixListEntryOptions{Action: "permit"}))
 }
+
+func TestCluster_SDNPrefixListsFiltered(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	lists, err := cluster.SDNPrefixLists(context.Background(), true, true, true)
+	assert.Nil(t, err)
+	assert.Len(t, lists, 1)
+	assert.Equal(t, "pl1", lists[0].ID)
+}
+
+func TestSDNPrefixList_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	l := cluster.SDNPrefixList("pl1")
+	assert.Nil(t, l.Update(context.Background(), nil))
+}
+
+func TestSDNPrefixList_EmptyID_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	l := &SDNPrefixList{client: mockClient()}
+	assert.Error(t, l.Read(context.Background()))
+	assert.Error(t, l.Update(context.Background(), &SDNPrefixListOptions{}))
+	assert.Error(t, l.Delete(context.Background()))
+	_, err := l.ListEntries(context.Background())
+	assert.Error(t, err)
+	assert.Error(t, l.AddEntry(context.Background(), &SDNPrefixListEntryOptions{Action: "permit", Prefix: "10.0.0.0/24"}))
+}
+
+func TestSDNPrefixList_Read_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	l := cluster.SDNPrefixList("missing")
+	assert.Error(t, l.Read(context.Background()))
+	_, err := l.ListEntries(context.Background())
+	assert.Error(t, err)
+}
+
+func TestSDNPrefixListEntry_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	e := cluster.SDNPrefixList("pl1").Entry(10)
+	assert.Nil(t, e.Update(context.Background(), nil))
+}
+
+func TestSDNPrefixListEntry_EmptyID_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	e := &SDNPrefixListEntry{client: mockClient(), Seq: 10}
+	assert.Error(t, e.Read(context.Background()))
+	assert.Error(t, e.Update(context.Background(), &SDNPrefixListEntryOptions{}))
+	assert.Error(t, e.Delete(context.Background()))
+}

--- a/cluster_sdn_route_maps_test.go
+++ b/cluster_sdn_route_maps_test.go
@@ -68,3 +68,61 @@ func TestCluster_NewSDNRouteMapEntry(t *testing.T) {
 	assert.NotNil(t, cluster.NewSDNRouteMapEntry(context.Background(), nil))
 	assert.NotNil(t, cluster.NewSDNRouteMapEntry(context.Background(), &SDNRouteMapEntryOptions{RouteMapID: "rm1"}))
 }
+
+func TestCluster_SDNRouteMapsRunning(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	maps, err := cluster.SDNRouteMaps(context.Background(), true)
+	assert.Nil(t, err)
+	assert.Len(t, maps, 1)
+}
+
+func TestCluster_SDNRouteMapEntriesPending(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.SDNRouteMapEntries(context.Background(), true, false)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 1)
+}
+
+func TestCluster_SDNRouteMapEntriesForPending(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	entries, err := cluster.SDNRouteMapEntriesFor(context.Background(), "rm1", true, false)
+	assert.Nil(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "rm1", entries[0].RouteMapID)
+}
+
+func TestSDNRouteMapEntry_UpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	e := cluster.SDNRouteMapEntry("rm1", 10)
+	assert.Nil(t, e.Update(context.Background(), nil))
+}
+
+func TestSDNRouteMapEntry_EmptyID_Errors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	e := &SDNRouteMapEntry{client: mockClient(), Order: 10}
+	assert.Error(t, e.Read(context.Background()))
+	assert.Error(t, e.Update(context.Background(), &SDNRouteMapEntryOptions{}))
+	assert.Error(t, e.Delete(context.Background()))
+}
+
+func TestSDNRouteMapEntry_Read_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	e := cluster.SDNRouteMapEntry("missing", 99)
+	assert.Error(t, e.Read(context.Background()))
+}

--- a/cluster_sdn_test.go
+++ b/cluster_sdn_test.go
@@ -1,0 +1,137 @@
+package proxmox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthermonson/go-proxmox/tests/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCluster_SDNSubnets(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	subnets, err := cluster.SDNSubnets(context.Background(), "user1")
+	assert.Nil(t, err)
+	assert.Len(t, subnets, 1)
+	assert.Equal(t, "10.0.0.0/24", subnets[0].CIDR)
+}
+
+func TestCluster_SDNApply(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	task, err := cluster.SDNApply(context.Background())
+	assert.Nil(t, err)
+	assert.NotNil(t, task)
+	assert.Equal(t, "node1", task.Node)
+}
+
+func TestCluster_SDNVNets_ClientThreaded(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	vnets, err := cluster.SDNVNets(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, vnets, 5)
+	assert.Equal(t, "user1", vnets[0].Name)
+	// client should be threaded onto each entry so chained mutations work
+	assert.NotNil(t, vnets[0].client)
+}
+
+func TestCluster_SDNVNet(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	v, err := cluster.SDNVNet(context.Background(), "user1")
+	assert.Nil(t, err)
+	assert.NotNil(t, v)
+	assert.Equal(t, "user1", v.Name)
+	assert.NotNil(t, v.client)
+}
+
+func TestCluster_NewSDNVNet(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNVNet(context.Background(), &VNetOptions{Name: "user99", Zone: "test1", Type: "vnet"})
+	assert.Nil(t, err)
+}
+
+func TestCluster_UpdateSDNVNet(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.UpdateSDNVNet(context.Background(), &VNet{Name: "user1", Zone: "test1", Alias: "renamed"})
+	assert.Nil(t, err)
+}
+
+func TestCluster_DeleteSDNVNet(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.DeleteSDNVNet(context.Background(), "user1")
+	assert.Nil(t, err)
+}
+
+func TestCluster_SDNZonesFiltered(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	// no filter
+	zones, err := cluster.SDNZones(context.Background())
+	assert.Nil(t, err)
+	assert.Len(t, zones, 2)
+
+	// with filter — variadic, multiple strings get joined and spaces stripped
+	zones, err = cluster.SDNZones(context.Background(), "vx", "lan ")
+	assert.Nil(t, err)
+	assert.Len(t, zones, 1)
+}
+
+func TestCluster_SDNZone_Basic(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	zone, err := cluster.SDNZone(context.Background(), "test1")
+	assert.Nil(t, err)
+	assert.Equal(t, "test1", zone.Name)
+	assert.Equal(t, "vxlan", zone.Type)
+}
+
+func TestCluster_NewSDNZone(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.NewSDNZone(context.Background(), &SDNZoneOptions{Name: "newzone", Type: "simple"})
+	assert.Nil(t, err)
+}
+
+func TestCluster_UpdateSDNZone(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.UpdateSDNZone(context.Background(), &SDNZoneOptions{Name: "test1", Type: "vxlan", MTU: 1450})
+	assert.Nil(t, err)
+}
+
+func TestCluster_DeleteSDNZone(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+
+	err := cluster.DeleteSDNZone(context.Background(), "test1")
+	assert.Nil(t, err)
+}

--- a/cluster_sdn_vnet_test.go
+++ b/cluster_sdn_vnet_test.go
@@ -92,3 +92,114 @@ func TestVNet_Subnets(t *testing.T) {
 	assert.Nil(t, s.Update(context.Background(), &SDNSubnetOptions{Gateway: "10.0.0.2"}))
 	assert.Nil(t, s.Delete(context.Background()))
 }
+
+// --- error / nil-opts coverage for vnet sub-resource methods ----------------
+
+func TestVNet_EmptyName_FirewallErrors(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	v := &VNet{client: mockClient()}
+	_, err := v.FirewallIndex(context.Background())
+	assert.Error(t, err)
+	_, err = v.FirewallOptions(context.Background())
+	assert.Error(t, err)
+	assert.Error(t, v.FirewallOptionsUpdate(context.Background(), &SDNVNetFirewallOptionsUpdate{}))
+	_, err = v.FirewallRules(context.Background())
+	assert.Error(t, err)
+	_, err = v.FirewallRule(context.Background(), 0)
+	assert.Error(t, err)
+	assert.Error(t, v.NewFirewallRule(context.Background(), &SDNVNetFirewallRuleOptions{Type: "in", Action: "ACCEPT"}))
+	assert.Error(t, v.FirewallRuleUpdate(context.Background(), 0, &SDNVNetFirewallRuleOptions{}))
+	assert.Error(t, v.FirewallRuleDelete(context.Background(), 0))
+}
+
+func TestVNet_FirewallOptionsUpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	assert.Nil(t, v.FirewallOptionsUpdate(context.Background(), nil))
+}
+
+func TestVNet_FirewallRuleUpdateNilOpts(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	assert.Nil(t, v.FirewallRuleUpdate(context.Background(), 0, nil))
+}
+
+func TestVNet_NewFirewallRule_MissingAction(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	cluster, _ := mockClient().Cluster(context.Background())
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	// nil opts → error
+	assert.Error(t, v.NewFirewallRule(context.Background(), nil))
+	// Type only → error
+	assert.Error(t, v.NewFirewallRule(context.Background(), &SDNVNetFirewallRuleOptions{Type: "in"}))
+}
+
+func TestVNet_FirewallOptions_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	v := &VNet{client: mockClient(), Name: "missing"}
+	_, err := v.FirewallOptions(context.Background())
+	assert.Error(t, err)
+}
+
+func TestVNet_IPs_ErrorBranches(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	// empty VNet name
+	empty := &VNet{client: mockClient()}
+	assert.Error(t, empty.CreateIP(context.Background(), &SDNVNetIPOptions{Zone: "z", IP: "1.1.1.1"}))
+	assert.Error(t, empty.UpdateIP(context.Background(), &SDNVNetIPOptions{Zone: "z", IP: "1.1.1.1"}))
+	assert.Error(t, empty.DeleteIP(context.Background(), &SDNVNetIPOptions{Zone: "z", IP: "1.1.1.1"}))
+
+	cluster, _ := mockClient().Cluster(context.Background())
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+
+	// nil/empty options → validation errors
+	assert.Error(t, v.UpdateIP(context.Background(), nil))
+	assert.Error(t, v.UpdateIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"}))   // missing zone
+	assert.Error(t, v.DeleteIP(context.Background(), nil))
+	assert.Error(t, v.DeleteIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"}))   // missing zone
+	assert.Error(t, v.CreateIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"}))   // missing zone
+
+	// DeleteIP with MAC populated to exercise the optional path
+	assert.Nil(t, v.DeleteIP(context.Background(), &SDNVNetIPOptions{Zone: "zone1", IP: "10.0.0.10", MAC: "aa:bb:cc:dd:ee:ff"}))
+}
+
+func TestVNet_Subnets_ErrorBranches(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	// empty VNet name
+	empty := &VNet{client: mockClient()}
+	_, err := empty.Subnets(context.Background())
+	assert.Error(t, err)
+	assert.Error(t, empty.NewSubnet(context.Background(), &SDNSubnetOptions{Subnet: "x"}))
+
+	// empty subnet identifiers
+	s := &VNetSubnet{client: mockClient()}
+	assert.Error(t, s.Read(context.Background()))
+	assert.Error(t, s.Update(context.Background(), &SDNSubnetOptions{}))
+	assert.Error(t, s.Delete(context.Background()))
+
+	// NewSubnet with default type/vnet path
+	cluster, _ := mockClient().Cluster(context.Background())
+	v, _ := cluster.SDNVNet(context.Background(), "user1")
+	assert.Nil(t, v.NewSubnet(context.Background(), &SDNSubnetOptions{Subnet: "zone1-10.0.2.0-24"}))
+
+	// nil-opts on Update path
+	s2 := v.Subnet("zone1-10.0.0.0-24")
+	assert.Nil(t, s2.Update(context.Background(), nil))
+}
+
+func TestVNet_Subnets_NotFound(t *testing.T) {
+	mocks.On(mockConfig)
+	defer mocks.Off()
+	v := &VNet{client: mockClient(), Name: "missing"}
+	_, err := v.Subnets(context.Background())
+	assert.Error(t, err)
+}

--- a/tests/mocks/pve9x/cluster.go
+++ b/tests/mocks/pve9x/cluster.go
@@ -1770,6 +1770,188 @@ func clusterReplication() {
 			{"subdir":"200"}
 		]}`)
 
+	// --- /cluster/sdn apply + zones/vnets mutations + filtered list -----------
+
+	// PUT /cluster/sdn/ — apply pending config (returns UPID)
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/?$").
+		Reply(200).
+		JSON(`{"data":"UPID:node1:0000ABCD:00ABCDEF:00000000:sdnapply:cluster:root@pam:"}`)
+
+	// POST /cluster/sdn/zones — create
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/zones$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// PUT /cluster/sdn/zones/{name} — update (mock by test1)
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/zones/test1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// DELETE /cluster/sdn/zones/{name}
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/zones/test1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// POST /cluster/sdn/vnets — create
+	gock.New(config.C.URI).
+		Persist().
+		Post("^/cluster/sdn/vnets$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// PUT /cluster/sdn/vnets/{name}
+	gock.New(config.C.URI).
+		Persist().
+		Put("^/cluster/sdn/vnets/user1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// DELETE /cluster/sdn/vnets/{name}
+	gock.New(config.C.URI).
+		Persist().
+		Delete("^/cluster/sdn/vnets/user1$").
+		Reply(200).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/vnets/user1/subnets — already registered below, leave as-is
+
+	// GET /cluster/sdn/controllers?type=evpn — filtered list
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/controllers$").
+		MatchParam("type", "evpn").
+		Reply(200).
+		JSON(`{"data":[{"controller":"ctrl1","type":"evpn","asn":65000}]}`)
+
+	// GET /cluster/sdn/dns?type=powerdns — filtered list
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/dns$").
+		MatchParam("type", "powerdns").
+		Reply(200).
+		JSON(`{"data":[{"dns":"pdns1","type":"powerdns"}]}`)
+
+	// GET /cluster/sdn/ipams?type=pve — filtered list
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/ipams$").
+		MatchParam("type", "pve").
+		Reply(200).
+		JSON(`{"data":[{"ipam":"pve","type":"pve"}]}`)
+
+	// GET /cluster/sdn/fabrics/fabric?pending=1&running=1 — filtered list
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/fabric$").
+		MatchParam("pending", "1").
+		Reply(200).
+		JSON(`{"data":[{"id":"fab1","protocol":"openfabric","ip_prefix":"10.0.0.0/24","state":"new"}]}`)
+
+	// GET /cluster/sdn/prefix-lists?pending=1&verbose=1
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/prefix-lists$").
+		MatchParam("verbose", "1").
+		Reply(200).
+		JSON(`{"data":[{"id":"pl1","entries":[{"seq":10,"action":"permit","prefix":"10.0.0.0/24"}]}]}`)
+
+	// GET /cluster/sdn/route-maps?running=1
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps$").
+		MatchParam("running", "1").
+		Reply(200).
+		JSON(`{"data":[{"id":"rm1"}]}`)
+
+	// GET /cluster/sdn/route-maps/entries?pending=1
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps/entries$").
+		MatchParam("pending", "1").
+		Reply(200).
+		JSON(`{"data":[{"route-map-id":"rm1","order":10,"action":"permit"}]}`)
+
+	// GET /cluster/sdn/route-maps/entries/rm1?pending=1
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps/entries/rm1$").
+		MatchParam("pending", "1").
+		Reply(200).
+		JSON(`{"data":[{"route-map-id":"rm1","order":10,"action":"permit"}]}`)
+
+	// --- /cluster/sdn error fixtures (404/401) for negative paths -------------
+
+	// GET /cluster/sdn/controllers/missing -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/controllers/missing$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/dns/missing -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/dns/missing$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/ipams/missing -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/ipams/missing$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/fabrics/fabric/missing -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/fabrics/fabric/missing$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/prefix-lists/missing -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/prefix-lists/missing$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/prefix-lists/missing/entries -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/prefix-lists/missing/entries$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/route-maps/entries/missing/entry/99 -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/route-maps/entries/missing/entry/99$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/vnets/missing/subnets -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/missing/subnets$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
+	// GET /cluster/sdn/vnets/missing/firewall/options -> 404
+	gock.New(config.C.URI).
+		Persist().
+		Get("^/cluster/sdn/vnets/missing/firewall/options$").
+		Reply(500).
+		JSON(`{"data":null}`)
+
 	// --- /cluster/sdn lock/rollback/dry-run -----------------------------------
 
 	gock.New(config.C.URI).


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the SDN surface introduced by PR #320, bringing every public method in `cluster_sdn*.go` to >=80% line coverage (most at 100%).

### Files in scope (test files appended / created)

- `cluster_sdn_test.go` (new) — zone/vnet mutations, `SDNSubnets`, `SDNApply`, variadic zone filter, plus the basic getters
- `cluster_sdn_controllers_test.go` — filtered list, nil-opts Update, empty-name guards, 500 error path
- `cluster_sdn_dns_test.go` — filtered list, nil-opts Update, empty-name guards, error path
- `cluster_sdn_ipams_test.go` — filtered list, nil-opts Update, empty-name guards, error path
- `cluster_sdn_fabrics_test.go` — pending/running list, nil-opts Update on fabric + fabric-node, empty-id guards on both, error path
- `cluster_sdn_prefix_lists_test.go` — verbose list, nil-opts Update on list + entry, empty-id guards, error paths on Read/ListEntries
- `cluster_sdn_route_maps_test.go` — running/pending list, per-route-map pending filter, nil-opts Update, empty-id guards, error path
- `cluster_sdn_misc_test.go` — `SDNLock` allow-pending branch
- `cluster_sdn_vnet_test.go` — empty-VNet guards across firewall/ips/subnets, nil-opts paths on firewall options/rules, IPs zone-missing validation, MAC-included DeleteIP, subnet empty-id guards

### Mock fixture changes (`tests/mocks/pve9x/cluster.go`, SDN section only)

- `PUT /cluster/sdn/` (apply) returning a UPID
- `POST/PUT/DELETE /cluster/sdn/zones[/test1]` and `/cluster/sdn/vnets[/user1]`
- Type-filtered `GET` matchers for controllers/dns/ipams (`?type=`)
- Pending/running/verbose matchers for fabrics, prefix-lists, route-maps
- 500-status fixtures on `…/missing` paths for the negative tests

### Coverage (before -> after)

Aggregate across `cluster_sdn*.go`: every function now `>= 80%`. Spot checks of the largest gaps:

| File | Function | Before | After |
|---|---|---|---|
| `cluster_sdn.go` | `SDNSubnets` | 0.0% | 100.0% |
| `cluster_sdn.go` | `SDNApply` | 0.0% | 100.0% |
| `cluster_sdn.go` | `NewSDNVNet` / `UpdateSDNVNet` / `DeleteSDNVNet` | 0.0% | 100.0% |
| `cluster_sdn.go` | `NewSDNZone` / `UpdateSDNZone` / `DeleteSDNZone` | 0.0% | 100.0% |
| `cluster_sdn_controllers.go` | `Update` / `Delete` / `Read` | 60-66% | 100.0% |
| `cluster_sdn_fabrics.go` | `Update` / `Delete` / `Read` (both types) | 60-66% | 100.0% |
| `cluster_sdn_vnet_*.go` | `CreateIP` / `UpdateIP` / `DeleteIP` | 57-85% | 100.0% |

Package-wide unit-test coverage rose from 72.8% to 75.1% as a side effect.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -count=1 .` — all unit tests pass
- [x] Verified per-function coverage of every method in `cluster_sdn*.go` is `>= 80%`