### PR TITLE
fix(test): make TestWithProxyFromEnvironment order-independent

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -386,23 +386,21 @@ func TestWithProxy(t *testing.T) {
 }
 
 func TestWithProxyFromEnvironment(t *testing.T) {
-	t.Setenv("HTTP_PROXY", "http://env-proxy.example.com:8080")
-	t.Setenv("HTTPS_PROXY", "")
-	t.Setenv("NO_PROXY", "")
-
 	c := NewClient("", WithProxyFromEnvironment())
 	tr := transportFromClient(t, c)
 	require.NotNil(t, tr.Proxy, "Proxy should be set")
 
-	// http.ProxyFromEnvironment caches its env lookup on first call across the
-	// process, so we can't reliably assert pointer identity with the package
-	// symbol — instead exercise it.
-	req, err := http.NewRequest(http.MethodGet, "http://target.example.com/", nil)
-	require.NoError(t, err)
-	got, err := tr.Proxy(req)
-	require.NoError(t, err)
-	require.NotNil(t, got, "ProxyFromEnvironment should resolve a proxy for HTTP_PROXY")
-	assert.Equal(t, "env-proxy.example.com:8080", got.Host)
+	// Assert by function-pointer identity rather than by exercising the
+	// returned func with a t.Setenv-driven HTTP_PROXY. http.ProxyFromEnvironment
+	// populates its env lookup behind a process-wide sync.Once, so any prior
+	// test that touches the default transport (every gock-using test does) primes
+	// the cache to whatever the environment looked like at that moment, and a
+	// later t.Setenv has no effect on the cached result. The pointer-identity
+	// check still proves the option installed the expected proxy resolver.
+	assert.Equal(t,
+		reflect.ValueOf(http.ProxyFromEnvironment).Pointer(),
+		reflect.ValueOf(tr.Proxy).Pointer(),
+		"WithProxyFromEnvironment should install http.ProxyFromEnvironment as the transport proxy func")
 }
 
 // roundTripperFunc is a test helper that adapts a function into a


### PR DESCRIPTION
## Why

\`http.ProxyFromEnvironment\` populates its env-var lookup behind a process-wide \`sync.Once\` on first call. Any prior test that exercises the default transport (in this package: every test using gock for HTTP mocking) primes that cache to the environment as it stood at that moment. A later \`t.Setenv\` changes \`os.Getenv\` but not the cached result, so calling \`tr.Proxy(req)\` after the cache is primed returns nil regardless of what \`HTTP_PROXY\` is now set to.

The behavior-based assertion has been a latent flake since PR #324 landed; the new container-coverage tests in PR #328 happen to push the test ordering past the threshold where the cache is reliably primed before this test runs, surfacing the failure deterministically.

## What

Switch to a pointer-identity assertion. Still proves the option installed the right proxy resolver, without depending on observable behavior the cache prevents us from observing in-process.

## Test plan
- [x] \`go test -count=1 .\` green
- [x] Run order doesn't matter (verified by spot-checking with \`-run\` filters that previously failed)