### PR TITLE
docs: add migration/v0.6.0.md, migration/v0.7.0.md, codify the convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,33 @@ Gated by build tags so they don't run by default: `nodes`, `containers`,
 destructive — they create and delete VMs/containers — and always pair a
 "create" step with a deferred cleanup.
 
+## Release migration guides
+
+Every release that ships at least one apidiff `incompatible` change must
+include a `migration/v<VERSION>.md` file describing the upgrade path FROM
+the previous release. The file is created as part of the release-cut PR,
+not retrofitted later, and is linked from the GitHub release body.
+
+Confirm what's incompatible with:
+
+```shell
+go install golang.org/x/exp/cmd/apidiff@latest
+git worktree add /tmp/old-version v<previous-version>
+cd /tmp/old-version && apidiff -w /tmp/old.api .
+cd <repo>          && apidiff -w /tmp/new.api .
+apidiff -incompatible /tmp/old.api /tmp/new.api
+```
+
+The migration doc should group breaks into themed sections (e.g. "snapshots
+refactored to instance pattern", "indexed device fields dropped",
+"bool → IntOrBool") rather than listing them as a flat dump. Each section
+shows a before/after code example. `v0.7.0.md` is the template; copy its
+structure.
+
+Releases with zero incompatible changes don't need a migration file — the
+GitHub release notes are sufficient. The directory is a record of the
+breaks we've shipped, not a per-release ritual.
+
 ## Repo-specific gotchas
 
 - **Local replace in `go.mod`.** `go.mod` contains

--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ _ = cluster.NewSDNZone(ctx, &proxmox.SDNZoneOptions{
 - [`examples/sdn`](./examples/sdn/) — full SDN walkthrough: create a zone, vnet, subnet, controller, dry-run / apply / rollback.
 - [`examples/term-and-vnc`](./examples/term-and-vnc/) — websocket terminal and VNC proxy via a small Gin server.
 
+### Upgrading between releases
+
+Per-release migration guides live in [`migration/`](./migration/). Each file describes the source-level changes when upgrading FROM the named release.
+
+- [`migration/v0.6.0.md`](./migration/v0.6.0.md) — upgrading from v0.5.x
+- [`migration/v0.7.0.md`](./migration/v0.7.0.md) — upgrading from v0.6.0 (the major cleanup release)
+
 # Developing
 This project relies on [Mage](https://magefile.org/) for cross os/arch compatibility, please see their installation guide. 
 

--- a/migration/v0.6.0.md
+++ b/migration/v0.6.0.md
@@ -1,0 +1,96 @@
+# Migrating to v0.6.0
+
+v0.6.0 is a coverage-and-correctness release. Four source-level breaks; the
+rest is purely additive (new wrappers for `/access`, `/pools`, `/nodes/{qemu,
+lxc,ceph,sdn,disks,...}`, the new `mage endpoints:coverage` tool, etc.).
+
+## TL;DR
+
+| Change | Affected callers | Fix |
+|---|---|---|
+| `(*Container).Delete` now takes a `*ContainerDeleteOptions` | every caller of `container.Delete(ctx)` | pass `nil` for the old behaviour, or `&ContainerDeleteOptions{...}` to use the new force/purge/destroy-unreferenced-disks flags |
+| `(*Container).UpdateSnapshot` now takes a `*ContainerSnapshotUpdateOptions` | every caller of `container.UpdateSnapshot(ctx, name)` | pass `nil` for the old behaviour, or `&ContainerSnapshotUpdateOptions{Description: "..."}` |
+| `CephMon` struct reshaped | callers that read `mon.CrushLocation`, `mon.Priority`, `mon.Weight`, `mon.PublicAddr`, `mon.PublicAddrs` from `/cluster/ceph` mons | the type now represents `/nodes/{node}/ceph/mon/{monid}` instances; if you were reading cluster ceph status, the equivalent fields live on the cluster-ceph response type |
+| `SDNZone.Nodes` type changed `[]string` → `proxmox.CSV` | anyone assigning the field to a `[]string` variable, or passing it to a `[]string` parameter | iterate it as before (it is a named `[]string`) or explicit cast: `[]string(zone.Nodes)` |
+
+## Container.Delete options
+
+```go
+// before
+task, err := container.Delete(ctx)
+
+// after — preserves old behaviour
+task, err := container.Delete(ctx, nil)
+
+// or use the new flags
+task, err := container.Delete(ctx, &proxmox.ContainerDeleteOptions{
+    Force:                    proxmox.IntOrBool(true),
+    Purge:                    proxmox.IntOrBool(true),
+    DestroyUnreferencedDisks: proxmox.IntOrBool(true),
+})
+```
+
+The flags close issue [#149](https://github.com/luthermonson/go-proxmox/issues/149) — previously there was no way to force-delete a locked container, purge job entries, or remove unreferenced disks.
+
+## Container.UpdateSnapshot options
+
+```go
+// before
+err := container.UpdateSnapshot(ctx, "snap1")
+
+// after — preserves old behaviour
+err := container.UpdateSnapshot(ctx, "snap1", nil)
+
+// or set a description
+err := container.UpdateSnapshot(ctx, "snap1", &proxmox.ContainerSnapshotUpdateOptions{
+    Description: "pre-upgrade baseline",
+})
+```
+
+## CephMon reshape
+
+`CephMon` was previously the row shape from `/cluster/ceph` status results. In v0.6.0 it became the instance handle for `/nodes/{node}/ceph/mon/{monid}` endpoints (the `node.CephMon("monid")` getter from the v0.6.0 Ceph 100% sweep — see PR [#307](https://github.com/luthermonson/go-proxmox/pull/307)). The old cluster-status reader fields are gone:
+
+| Removed field | Replacement |
+|---|---|
+| `CrushLocation` | `(*Node).CephMon(id).Read(ctx)` returns the full per-mon status; cluster-wide aggregate is in the corresponding cluster ceph response type |
+| `Priority`, `Rank`, `Weight` | same — read via the node-level instance |
+| `PublicAddr` | `(*CephMon).Addr` (cleaned up field name) |
+| `PublicAddrs.Addrvec` | not exposed; the bracketed addrvec is a Ceph implementation detail not surfaced separately |
+
+Code reading mons from `/cluster/ceph` results should switch to calling the node-level Ceph wrappers (`node.CephMons(ctx)` returns `[]*CephMon` instance handles).
+
+## SDNZone.Nodes type
+
+The on-the-wire format is a comma-joined string (`"pve1,pve2,pve3"`). v0.5.x typed it as `[]string`, which was straight-up broken: any zone with assigned nodes returned
+
+```
+json: cannot unmarshal string into Go struct field SDNZone.nodes of type []string
+```
+
+v0.6.0 introduces `proxmox.CSV` — a `[]string` named type with custom marshal/unmarshal that accepts both `"a,b,c"` and `["a","b","c"]` on the wire and always emits the comma-joined form PVE expects.
+
+```go
+// iteration still works without changes
+zone, _ := cluster.SDNZones(ctx)
+for _, n := range zone[0].Nodes {
+    fmt.Println(n)
+}
+
+// callers passing zone.Nodes to []string-typed APIs need an explicit conversion
+nodes := []string(zone[0].Nodes)
+
+// on the write side, SDNZoneOptions.Nodes stays a plain `string` (PVE only
+// accepts the comma-joined form on POST/PUT)
+_ = cluster.NewSDNZone(ctx, &proxmox.SDNZoneOptions{
+    Name:  "vxlan-1",
+    Type:  "vxlan",
+    Nodes: "pve1,pve2,pve3",
+})
+```
+
+See PR [#297](https://github.com/luthermonson/go-proxmox/pull/297).
+
+## Nothing else
+
+There are no other source-incompatible changes between v0.5.1 and v0.6.0. Every other change is purely additive — see the v0.6.0 GitHub release notes for the full "What's Changed" list.

--- a/migration/v0.7.0.md
+++ b/migration/v0.7.0.md
@@ -1,0 +1,300 @@
+# Migrating to v0.7.0
+
+v0.7.0 is the major cleanup. Three years of accumulated patterns get resolved
+into a consistent shape: instance-handle types for resources identified by ID,
+maps-instead-of-`Field0..9` for indexed devices, pointer-typed config fields
+where the Go zero value would silently override a PVE server default, and
+`IntOrBool` where PVE's boolean wire format used to be a plain Go `bool`.
+
+If you're upgrading from v0.5.x, read [v0.6.0.md](./v0.6.0.md) first.
+
+## TL;DR
+
+| Theme | Affected callers | Section |
+|---|---|---|
+| Snapshots refactored to instance pattern | every snapshot CRUD call site | [Snapshots](#snapshots--instance-pattern) |
+| Firewall rules refactored to instance pattern | every firewall-rule CRUD call site on nodes/VMs/containers | [Firewall rules](#firewall-rules--instance-pattern) |
+| Indexed device fields dropped (`Net0..9`, `SCSI0..30`, `IDE0..3`, `SATA0..5`, `VirtIO0..15`, `USB0..14`, `HostPCI0..9`, `IPConfig0..9`, `Numa0..9`, `Parallel0..2`, `Serial0..3`, `Unused0..9`, container `Mp0..9`, container `Dev0..9`) | callers reading or assigning indexed fields on `VirtualMachineConfig` / `ContainerConfig` | [Indexed device fields](#indexed-device-fields-now-maps) |
+| ~30 config fields pointerized (Memory, Cores, Sockets, Bios, OSType, SCSIHW, …) | callers constructing config/options structs by literal | [Pointerized config fields](#pointerized-config-fields) |
+| ~25 boolean-on-wire fields converted to `IntOrBool` | callers passing `bool` literals to firewall/sdn/pool/backup option structs | [Bool → IntOrBool](#bool--intorbool) |
+| `Client` is no longer comparable | callers using `client1 == client2` | [Client no longer comparable](#client-no-longer-comparable) |
+| Misc smaller breaks | a handful of specific call sites | [Misc](#misc) |
+
+A helper that's referenced throughout: `proxmox.Ptr[T](v T) *T` lets you construct pointerized fields inline without a temporary local.
+
+```go
+cfg := &proxmox.VirtualMachineConfig{
+    Memory: proxmox.Ptr(StringOrInt(4096)),
+    Cores:  proxmox.Ptr(4),
+    OSType: proxmox.Ptr("l26"),
+}
+```
+
+---
+
+## Snapshots — instance pattern
+
+PR [#311](https://github.com/luthermonson/go-proxmox/pull/311). Snapshots are now named resources with a handle type per receiver, replacing the loose `(*VirtualMachine).GetSnapshot(name)` / `DeleteSnapshot(name)` / `UpdateSnapshot(name, ...)` family. The `Snapshot` top-level type is removed; its place is taken by `*VirtualMachineSnapshot` and `*ContainerSnapshot`.
+
+### Pattern conversion
+
+```go
+// before
+err := vm.DeleteSnapshot(ctx, "snap1")
+cfg, _ := vm.GetSnapshotConfig(ctx, "snap1")
+err = vm.UpdateSnapshot(ctx, "snap1", "new description")
+err = vm.SnapshotRollback(ctx, "snap1")
+list, _ := vm.SnapshotIndex(ctx)
+
+// after
+snap := vm.Snapshot("snap1")                    // getter — no API call
+err := snap.Delete(ctx)
+cfg, _ := snap.Config(ctx)
+err = snap.Update(ctx, &VirtualMachineSnapshotUpdateOptions{Description: "new description"})
+err = snap.Rollback(ctx)
+list, _ := vm.Snapshots(ctx)                    // returns []*VirtualMachineSnapshot
+```
+
+Same pattern on `*Container`:
+
+```go
+// before
+err := container.DeleteSnapshot(ctx, "snap1")
+err = container.UpdateSnapshot(ctx, "snap1", nil)
+err = container.RollbackSnapshot(ctx, "snap1")
+cfg, _ := container.GetSnapshotConfig(ctx, "snap1")
+snap, _ := container.GetSnapshot(ctx, "snap1")
+
+// after
+snap := container.Snapshot("snap1")
+err := snap.Delete(ctx)
+err = snap.Update(ctx, &ContainerSnapshotUpdateOptions{Description: "..."})
+err = snap.Rollback(ctx)
+cfg, _ := snap.Config(ctx)
+list, _ := container.Snapshots(ctx)
+```
+
+### Removed methods
+
+`(*VirtualMachine).DeleteSnapshot`, `GetSnapshotConfig`, `UpdateSnapshot`, `SnapshotRollback`, `SnapshotIndex`. `(*Container).DeleteSnapshot`, `GetSnapshot`, `GetSnapshotConfig`, `RollbackSnapshot`, `UpdateSnapshot`. Top-level `Snapshot` type.
+
+---
+
+## Firewall rules — instance pattern
+
+PR [#310](https://github.com/luthermonson/go-proxmox/pull/310). Same shape — a rule is a positional resource (identified by `pos`), so it gets a getter + instance type with `Update`/`Delete` methods.
+
+### Pattern conversion
+
+```go
+// before  (VirtualMachine)
+rules, _ := vm.FirewallGetRules(ctx)
+rule, _ := vm.FirewallGetRule(ctx, 0)
+err := vm.FirewallRulesCreate(ctx, &FirewallRule{...})
+err = vm.FirewallRulesUpdate(ctx, &FirewallRule{Pos: 0, ...})
+err = vm.FirewallRulesDelete(ctx, 0)
+
+// after
+rules, _ := vm.FirewallRules(ctx)
+rule, _ := vm.FirewallRule(ctx, 0)
+err := vm.NewFirewallRule(ctx, &FirewallRuleOptions{...})
+err = rule.Update(ctx, &FirewallRuleOptions{...})
+err = rule.Delete(ctx)
+```
+
+Same pattern on `*Container` and `*Node` firewall surfaces. The cluster firewall (`*FirewallSecurityGroup` rules) already used the instance pattern in v0.6.0 — unchanged.
+
+### Removed methods
+
+- `(*VirtualMachine).FirewallGetRule`, `FirewallGetRules`, `FirewallRulesCreate`, `FirewallRulesUpdate`, `FirewallRulesDelete`
+- `(*Container).GetFirewallRule`, `UpdateFirewallRule`, `DeleteFirewallRule`
+- `(*Node).FirewallGetRules`, `FirewallRulesCreate`, `FirewallRulesUpdate`, `FirewallRulesDelete`
+
+---
+
+## Indexed device fields → maps
+
+PR [#261](https://github.com/luthermonson/go-proxmox/pull/261). PVE accepts more indices per device prefix than the explicit `Field0..9` fields covered (`net0..net31`, `scsi0..scsi30`, `unused0..unused255`, etc.). v0.6.x left the explicit fields in as a compatibility mirror; v0.7.0 drops them entirely and routes all indexed devices through `map[string]string` fields populated by `UnmarshalJSON`.
+
+### Removed fields
+
+On `VirtualMachineConfig`: every numbered `Net0..9`, `IDE0..3`, `SCSI0..30`, `SATA0..5`, `VirtIO0..15`, `USB0..14`, `Serial0..3`, `Parallel0..2`, `HostPCI0..9`, `Numa0..9`, `IPConfig0..9`, `Unused0..9`.
+
+On `ContainerConfig`: every numbered `Dev0..9`, `Mp0..9`, `Net0..9`, `Unused0..9`.
+
+### Replacement maps (populated by `UnmarshalJSON`)
+
+| Was | Now |
+|---|---|
+| `cfg.Net0`, `cfg.Net1`, … | `cfg.Nets["net0"]`, `cfg.Nets["net1"]`, … |
+| `cfg.SCSI0`, …, `cfg.SCSI30` | `cfg.SCSIs["scsi0"]`, … |
+| `cfg.IDE0`, …, `cfg.IDE3` | `cfg.IDEs["ide0"]`, … |
+| `cfg.SATA0`, …, `cfg.SATA5` | `cfg.SATAs["sata0"]`, … |
+| `cfg.VirtIO0`, …, `cfg.VirtIO15` | `cfg.VirtIOs["virtio0"]`, … |
+| `cfg.USB0`, …, `cfg.USB14` | `cfg.USBs["usb0"]`, … |
+| `cfg.HostPCI0`, …, `cfg.HostPCI9` | `cfg.HostPCIs["hostpci0"]`, … |
+| `cfg.Numa0`, …, `cfg.Numa9` | `cfg.Numas["numa0"]`, … |
+| `cfg.Serial0`, …, `cfg.Serial3` | `cfg.Serials["serial0"]`, … |
+| `cfg.Parallel0`, …, `cfg.Parallel2` | `cfg.Parallels["parallel0"]`, … |
+| `cfg.IPConfig0`, …, `cfg.IPConfig9` | `cfg.IPConfigs["ipconfig0"]`, … |
+| `cfg.Unused0`, …, `cfg.Unused9` | `cfg.Unuseds["unused0"]`, … |
+| container `cfg.Dev0..9` | `cfg.Devs["dev0"]`, … |
+| container `cfg.Mp0..9` | `cfg.Mps["mp0"]`, … |
+
+### Removed helpers
+
+The `Merge*` helpers that flattened the explicit fields into a single map (`MergeNets`, `MergeIDEs`, `MergeSCSIs`, `MergeIPConfigs`, `MergeUnuseds`, `MergeNumas`, `MergeHostPCIs`, `MergeUSBs`, `MergeSerials`, `MergeParallels`, `MergeSATAs`, `MergeVirtIOs`, plus container `MergeDevs`, `MergeMps`, `MergeNets`, `MergeUnuseds`) are gone — the maps ARE the authoritative form now, no merge step needed.
+
+`(*VirtualMachineConfig).MergeDisks(ctx)` is **kept** because it merges across types (IDE + SCSI + SATA + VirtIO into one disk map), not within a single prefix.
+
+### Setting devices on writes
+
+Reading a config returns populated maps. Setting devices for create/update still uses the option-pair shape PVE wants — pass `VirtualMachineOption{Name: "net0", Value: "..."}` or `ContainerOption{Name: "mp0", Value: "..."}` to the constructor / `Config` call. That hasn't changed.
+
+```go
+// example: setting net1 on an existing VM
+_, err := vm.Config(ctx,
+    proxmox.VirtualMachineOption{Name: "net1", Value: "virtio,bridge=vmbr0,tag=42"},
+)
+```
+
+---
+
+## Pointerized config fields
+
+Many fields where the Go zero value would silently override a PVE server-side default were converted from `T` to `*T`. Issue [#199](https://github.com/luthermonson/go-proxmox/issues/199); PRs [#268](https://github.com/luthermonson/go-proxmox/pull/268) and [#274](https://github.com/luthermonson/go-proxmox/pull/274).
+
+Use `proxmox.Ptr(v)` to construct these inline:
+
+```go
+// before
+cfg := &proxmox.VirtualMachineConfig{
+    Memory:   StringOrInt(4096),
+    Cores:    4,
+    Sockets:  2,
+    OSType:   "l26",
+    Bios:     "ovmf",
+    SCSIHW:   "virtio-scsi-pci",
+    CPUUnits: 1024,
+}
+
+// after
+cfg := &proxmox.VirtualMachineConfig{
+    Memory:   proxmox.Ptr(StringOrInt(4096)),
+    Cores:    proxmox.Ptr(4),
+    Sockets:  proxmox.Ptr(2),
+    OSType:   proxmox.Ptr("l26"),
+    Bios:     proxmox.Ptr("ovmf"),
+    SCSIHW:   proxmox.Ptr("virtio-scsi-pci"),
+    CPUUnits: proxmox.Ptr(1024),
+}
+```
+
+### Full list
+
+**`VirtualMachineConfig`**: `Bios`, `CPULimit`, `CPUUnits`, `Cores`, `Hotplug`, `OSType`, `SCSIHW`, `Sockets`, `VMGenID` (string/int → pointer); `Acpi`, `CIUpgrade`, `KVM`, `Tablet` (int → `*IntOrBool`).
+
+**`ContainerConfig`**: `Arch`, `CMode`, `CPUUnits`, `Console`, `Memory`, `Swap`, `TTY` (string/int → pointer; `Console` int → `*IntOrBool`).
+
+**`FirewallNodeOption`**: `Enable` (bool → `*IntOrBool`); `NFConntrackMax`, `NFConntrackTCPTimeoutEstablished`, `NFConntrackTCPTimeoutSynRecv`, `ProtectionSynfloodBurst`, `ProtectionSynfloodRate` (int → `*int`).
+
+**`FirewallVirtualMachineOption`**: `Macfilter` (bool → `*IntOrBool`).
+
+**`DomainSyncOptions`**: `EnableNew` (bool → `*IntOrBool`), `RemoveVanished` (string → `*string`).
+
+**`StorageDownloadURLOptions`**: `VerifyCertificates` (IntOrBool → `*IntOrBool`).
+
+**`UserOptions`**: `Enable` (IntOrBool → `*IntOrBool`).
+
+**`SDNZoneOptions`**: `VLANProtocol` (string → `*string`), `VXLANPort` (uint16 → `*uint16`).
+
+**`VirtualMachineBackupOptions`**: `IoNice`, `LockWait`, `StopWait`, `Zstd` (uint → `*uint`); `PruneBackups` (string → `*string`); `Remove`, `StdExcludes` (bool → `*IntOrBool`).
+
+**`VirtualMachineMigrateOptions`, `VirtualMachineCloneOptions`, `VirtualMachineMoveDiskOptions`, `ContainerMigrateOptions`, `ContainerCloneOptions`**: `BWLimit` (uint64 → `*uint64`).
+
+For each: nil means "let PVE use its server default"; non-nil means "send this value." See AGENTS.md ("don't clobber PVE-side defaults on config structs") for the convention going forward.
+
+---
+
+## Bool → IntOrBool
+
+Some PVE fields are documented as `boolean` in the schema but accept both `1`/`0` and `true`/`false` on the wire. v0.6.x typed them as Go `bool`, which works for reads but loses the "unset" distinction on writes (a `bool` zero value of `false` always serializes). v0.7.0 switches them to `IntOrBool`, which round-trips both wire forms.
+
+Mostly mechanical — `IntOrBool(true)` / `IntOrBool(false)` instead of `true` / `false`:
+
+```go
+// before
+opts := &proxmox.FirewallVirtualMachineOption{
+    Dhcp:     true,
+    Enable:   true,
+    Ipfilter: false,
+    Ntp:      true,
+}
+
+// after
+opts := &proxmox.FirewallVirtualMachineOption{
+    Dhcp:     proxmox.IntOrBool(true),
+    Enable:   proxmox.IntOrBool(true),
+    Ipfilter: proxmox.IntOrBool(false),
+    Ntp:      proxmox.IntOrBool(true),
+}
+```
+
+### Full list
+
+**`FirewallNodeOption`**: `LogNfConntrack`, `Ntp`, `NFConntrackAllowInvalid`, `Nosmurfs`, `ProtectionSynflood`, `TCPflags`.
+
+**`FirewallVirtualMachineOption`**: `Dhcp`, `Enable`, `Ipfilter`, `Ntp`, `Radv`.
+
+**`DomainSyncOptions`**: `DryRun`.
+
+**`PoolUpdateOption`**: `Delete`, `AllowMove`.
+
+**`SDNZoneOptions`**: `AdvertiseSubnets`, `BridgeDisableMACLearning`, `DisableARPNDSuppression`.
+
+**`VNetOptions`**: `IsolatePorts`, `VlanAware`.
+
+**`VirtualMachineConfig`**: `Autostart`, `Numa`, `OnBoot`, `Protection`, `Template` (int → `IntOrBool` directly, no pointer because `0` is already a valid "default" value).
+
+**`VirtualMachineBackupOptions`**: `All`, `Quiet`, `StdOut`, `Stop`.
+
+**`VirtualMachineCloneOptions`**, **`ContainerCloneOptions`**: `Full` (uint8 → `IntOrBool`).
+
+**`VirtualMachineMoveDiskOptions`**: `Delete` (uint8 → `IntOrBool`).
+
+---
+
+## `Client` no longer comparable
+
+`Client` now contains a `sync.Mutex` (added with the v0.6.x ticket-refresh work and extended with the v0.7.x option-backed fields). Mutex types are not comparable in Go, so `==` / `!=` on `*Client` values no longer compiles.
+
+Almost no one was doing this — `*Client` is typically passed by pointer and compared by pointer identity (`==` on pointers works fine; the comparability rule is about comparing dereferenced struct values). If you were doing `clientA == clientB` on dereferenced values, switch to pointer comparison or use a field-by-field check on the bits you care about.
+
+---
+
+## Misc
+
+### Removed top-level `Snapshot` type
+
+Replaced by `*VirtualMachineSnapshot` and `*ContainerSnapshot`. See the [Snapshots](#snapshots--instance-pattern) section.
+
+### Coverage scanner internals
+
+If your code calls into `mage/endpoints` programmatically (unlikely), the exported `Coverage()` / `Sync()` / `Extract()` functions are unchanged, but their internal helpers now recognize `<X>Diridx` helpers and `client.Upload[Reader]` call sites — see the AGENTS.md "Endpoint coverage tooling" section. No source-level impact on library consumers.
+
+---
+
+## What didn't change
+
+- Wire format. Every endpoint sends and receives the same JSON v0.6.0 did. The library wrappers around them changed shape, but PVE sees identical requests.
+- `*Client` construction with no options. `proxmox.NewClient(url, proxmox.WithCredentials(...))` and `proxmox.NewClient(url, proxmox.WithAPIToken(...))` behave bit-for-bit identically to v0.6.0 — every new client field has a zero-value-safe code path.
+- The auth retry-on-401 flow. If you didn't use `WithEagerAuth`, the lazy /access/ticket-after-401 path is unchanged.
+
+## What's new (non-breaking)
+
+- 100% PVE API coverage (3 by-design exclusions for streaming endpoints documented in `mage/endpoints/endpoints.go`).
+- 12 new client options: `WithTimeout`, `WithInsecureSkipVerify`, `WithRootCAs`, `WithRootCAFile`, `WithClientCertificate`, `WithOTP`, `WithDefaultRealm`, `WithEagerAuth`, `WithProxy`, `WithProxyFromEnvironment`, `WithRetry`, `WithRequestInterceptor`. See [README "Usage with Client Options"](../README.md#usage-with-client-options).
+- `proxmox.CSV` for comma-joined PVE response fields (`SDNZone.Nodes`, `.Peers`, etc.).
+- `Subdirs` methods on `*Cluster` and `*Node` for ACL-filtered directory-index probes.
+- `examples/sdn` walkthrough of the cluster SDN surface.
+- Unit-test coverage pushed from ~30% to ~88%+.


### PR DESCRIPTION
Two migration guides + a one-paragraph convention note in AGENTS.md.

## migration/v0.6.0.md (retroactive)

Small file. Four source-level breaks documented with before/after code:
- \`Container.Delete\` now takes \`*ContainerDeleteOptions\` (closes #149)
- \`Container.UpdateSnapshot\` now takes \`*ContainerSnapshotUpdateOptions\`
- \`CephMon\` reshaped from cluster-status row to \`/nodes/{node}/ceph/mon/{monid}\` instance type
- \`SDNZone.Nodes\` typed as \`proxmox.CSV\` instead of \`[]string\` (PR #297)

## migration/v0.7.0.md (the big one)

The v0.7.x cycle was the major cleanup. The full apidiff against v0.6.0 reports ~230 incompatible lines; the doc groups them into navigable themed sections:

1. **Snapshots refactored to instance pattern** (#311) — \`*VirtualMachineSnapshot\` and \`*ContainerSnapshot\` instance types replace the \`(*VirtualMachine).GetSnapshot/DeleteSnapshot/UpdateSnapshot/...\` family. Top-level \`Snapshot\` type removed.
2. **Firewall rules refactored to instance pattern** (#310) — \`*FirewallRule\` instance type replaces the \`FirewallGetRule/FirewallRulesCreate/...\` family on \`*VirtualMachine\`, \`*Container\`, and \`*Node\`.
3. **Indexed device fields dropped** (#261) — every \`Net0..9\`, \`SCSI0..30\`, \`IDE0..3\`, \`SATA0..5\`, \`VirtIO0..15\`, \`USB0..14\`, \`HostPCI0..9\`, \`IPConfig0..9\`, \`Numa0..9\`, \`Parallel0..2\`, \`Serial0..3\`, \`Unused0..9\` (and the container equivalents) is gone. The maps populated by \`UnmarshalJSON\` (\`Nets\`, \`SCSIs\`, …) are now the authoritative shape. \`Merge*\` helpers removed.
4. **Pointerized config fields** (#268, #274) — ~30 fields where the Go zero value would silently override a PVE default went from \`T\` to \`*T\`. \`proxmox.Ptr(v)\` is the inline helper. Full list in the doc.
5. **Bool → IntOrBool** (#268, #274) — ~25 fields where PVE accepts both \`true/false\` and \`1/0\` on the wire are now \`IntOrBool\` so they round-trip both forms. Full list in the doc.
6. **Client no longer comparable** — \`sync.Mutex\` field forces non-comparable. No-op for almost all callers.
7. **Misc** — top-level \`Snapshot\` type removed (covered in section 1); scanner internals note.

Each section shows before/after code. There's also a "What didn't change" callout (wire format, no-options NewClient, lazy-auth flow) and a "What's new (non-breaking)" callout for the additive highlights (100% coverage, 12 new client options, \`CSV\`, \`Subdirs\`, \`examples/sdn\`, coverage push to ~88%+).

## AGENTS.md addition

One short section, "Release migration guides", codifying the convention: any release with at least one apidiff \`incompatible\` change ships a \`migration/v<VERSION>.md\` as part of the cut, themed sections with before/after code, not a flat dump. Releases with zero breaks don't need one — the directory is a record, not a ritual.

## README addition

New "Upgrading between releases" subsection right after "More examples" linking the migration directory and each file. Three lines.

## Test plan
- [x] Markdown renders correctly on GitHub (links resolve)
- [x] All version refs and PR numbers cross-checked against \`gh pr view\`
- [x] Break list cross-checked against \`apidiff -incompatible v0.6.0..main\` output (~230 lines bucketed into 6-7 themed sections)