### PR TITLE
docs: add migration/v0.7.1.md

### DIFF
--- a/migration/v0.7.1.md
+++ b/migration/v0.7.1.md
@@ -1,0 +1,147 @@
+# Migrating to v0.7.1
+
+v0.7.1 is a correctness patch. The PVE REST API and QEMU Guest Agent schemas
+were audited end-to-end against `apidoc.json` and `qga/qapi-schema.json`, and
+eight long-standing mismatches were fixed — six of them silently no-op'd on
+the wire prior to this release (wrong JSON tag, wrong scalar type, or a
+field name PVE never emitted), so the apparent "breaks" below are functionally
+additive: the new field is the first one that has ever worked.
+
+## TL;DR
+
+Two source-level breaks. Both are on `StorageContent`.
+
+| Change | Affected callers | Fix |
+|---|---|---|
+| `StorageContent.Encryption` (string, tag `encryption`) renamed to `StorageContent.Encrypted` (tag `encrypted`) | anyone reading `.Encryption` on `/nodes/{node}/storage/{storage}/content` entries | rename the field reference; the value was always `""` before because the JSON tag was wrong |
+| `StorageContent.Verification` retyped from `string` to `*StorageContentVerification` (nested `{State, UPID}` object) | anyone reading `.Verification` | dereference the pointer and read `.State` / `.UPID`; the field was always `""` before because PVE returns a nested object, not a string |
+
+Everything else in this release is purely additive or deprecation-with-keep
+(the deprecated field still compiles; only the wire serialization changed).
+
+## StorageContent.Encryption → Encrypted
+
+```go
+// before — silently always empty for PBS-encrypted backups
+for _, entry := range contents {
+    if entry.Encryption != "" {
+        log.Printf("encrypted: %s", entry.Encryption)
+    }
+}
+
+// after
+for _, entry := range contents {
+    if entry.Encrypted != "" {
+        log.Printf("encrypted: %s", entry.Encrypted)
+    }
+}
+```
+
+The wire field is `encrypted` per the upstream apidoc; the v0.7.0 tag
+`json:"encryption"` never matched, so the field was always read as zero.
+
+## StorageContent.Verification (string → *StorageContentVerification)
+
+```go
+// before — silently always empty; PVE actually returns a nested object,
+// which fails to unmarshal into a plain string
+for _, entry := range contents {
+    if entry.Verification != "" {
+        log.Printf("verify: %s", entry.Verification)
+    }
+}
+
+// after
+for _, entry := range contents {
+    if v := entry.Verification; v != nil {
+        log.Printf("verify state=%s upid=%s", v.State, v.UPID)
+    }
+}
+```
+
+The new struct mirrors the upstream shape:
+
+```go
+type StorageContentVerification struct {
+    State string `json:"state,omitempty"`
+    UPID  string `json:"upid,omitempty"`
+}
+```
+
+## Non-breaking but worth noting (deprecate + replacement)
+
+The Go field still exists and the code still compiles, but the wire format
+changed. If you were relying on the old field to do something, it wasn't —
+the field had a non-functional JSON tag. Switch to the replacement to get
+real behavior.
+
+### AgentNetworkIPAddress.MacAddress is deprecated (closes #336)
+
+```go
+// before — always empty: QEMU Guest Agent's GuestIpAddress has no
+// mac-address property in the QGA schema. PVE relays QGA verbatim.
+for _, iface := range ifaces {
+    for _, ip := range iface.IPAddresses {
+        // ip.MacAddress was always ""
+    }
+}
+
+// after — read the MAC from the parent iface
+for _, iface := range ifaces {
+    mac := iface.HardwareAddress // already populated correctly in every version
+    for _, ip := range iface.IPAddresses {
+        _ = mac
+    }
+}
+```
+
+`MacAddress` keeps compiling (kept with `json:"-"`); will be removed in
+v0.8.0.
+
+### FirewallNodeOption.Ntp / FirewallVirtualMachineOption.Ntp deprecated → NDP
+
+PVE's option is `ndp` (Neighbor Discovery Protocol, IPv6); `ntp` was a typo
+that has shipped since v0.1.x and never had an effect — reads never
+populated, writes were ignored by the server.
+
+```go
+// before — silently a no-op on the wire
+opts := &proxmox.FirewallNodeOption{
+    Ntp: proxmox.IntOrBool(true),
+}
+n.FirewallOptionSet(ctx, opts)
+
+// after — actually toggles the NDP filter on PVE
+opts := &proxmox.FirewallNodeOption{
+    NDP: proxmox.IntOrBool(true),
+}
+n.FirewallOptionSet(ctx, opts)
+```
+
+Same change for `FirewallVirtualMachineOption.Ntp` → `.NDP`. Both `Ntp`
+fields keep compiling (kept with `json:"-"`); will be removed in v0.8.0.
+
+## Internal-only tag fixes (no caller impact)
+
+These had buggy JSON tags that prevented the fields from ever populating.
+The Go field names are unchanged; existing code keeps working and now
+actually receives values from PVE.
+
+| Field | What changed |
+|---|---|
+| `CephMonMap.DisallowedLeaders` | tag `"disallowed_leaders: "` (trailing colon+space inside the quoted name) → `"disallowed_leaders"` |
+| `CephMonMap.RemovedRanks` | tag `"removed_ranks: "` → `"removed_ranks"` |
+| `FirewallRule.IcmpType` | tag `"icmp_type"` → `"icmp-type"` — ICMP firewall rules now round-trip correctly |
+
+## How the bugs were found
+
+A full audit of every exported response type in `types.go` against PVE's
+`apidoc.json` and QGA's upstream `qga/qapi-schema.json`. See
+[PR #337](https://github.com/luthermonson/go-proxmox/pull/337) for the
+detailed per-type findings. Additional lower-priority cleanups (phantom
+fields, type tightenings, and a `ContainerMigratePreconditions` rewrite)
+are queued for v0.8.0.
+
+## Nothing else
+
+There are no other source-incompatible changes between v0.7.0 and v0.7.1.


### PR DESCRIPTION
v0.7.1 release prep — adds the migration guide ahead of tagging.

Two source-level breaks (both on `StorageContent`):
- `Encryption` -> `Encrypted` (rename; old tag never matched the upstream `encrypted` key)
- `Verification` retyped from `string` -> `*StorageContentVerification{State, UPID}` (PVE returns a nested object)

Plus deprecate-and-replace where the deprecated field still compiles but no longer serializes:
- `AgentNetworkIPAddress.MacAddress` deprecated -> read `iface.HardwareAddress` instead. Closes #336 (already closed via #337).
- `FirewallNodeOption.Ntp` / `FirewallVirtualMachineOption.Ntp` deprecated -> use `NDP`.

And three internal-only JSON tag fixes that change wire compatibility but not source compat:
- `CephMonMap.DisallowedLeaders`, `CephMonMap.RemovedRanks` (typo: trailing `: ` inside the tag)
- `FirewallRule.IcmpType` (`icmp_type` -> `icmp-type`)

All breaks were verified with apidiff. The "breaks" are functionally additive — the renamed/retyped fields are the first ones that have ever worked.

## Test plan

- [ ] Confirm migration/v0.7.1.md renders cleanly on GitHub
- [ ] After merge, tag v0.7.1 and publish the staged GitHub release