### PR TITLE
fix: improve Ping method to handle VirtualMachineConfig retrieval

### DIFF
--- a/virtual_machine.go
+++ b/virtual_machine.go
@@ -39,9 +39,12 @@ func (v *VirtualMachine) Ping(ctx context.Context) error {
 	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/status/current", v.Node, v.VMID), &v); err != nil {
 		return err
 	}
-	// New, empty config in case something was deleted
-	v.VirtualMachineConfig = &VirtualMachineConfig{}
-	return v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", v.Node, v.VMID), &v.VirtualMachineConfig)
+	cfg := &VirtualMachineConfig{}
+	if err := v.client.Get(ctx, fmt.Sprintf("/nodes/%s/qemu/%d/config", v.Node, v.VMID), cfg); err != nil {
+		return err
+	}
+	v.VirtualMachineConfig = cfg
+	return nil
 }
 
 func (v *VirtualMachine) Config(ctx context.Context, options ...VirtualMachineOption) (*Task, error) {


### PR DESCRIPTION
## Fix empty `VirtualMachineConfig` window during `Ping`
 
 `Ping` refreshes the config by resetting `v.VirtualMachineConfig` to an empty struct and then refilling it with a second GET:
 
 ```go
 v.VirtualMachineConfig = &VirtualMachineConfig{}
 return v.client.Get(ctx, ".../config", &v.VirtualMachineConfig)
 ```
 
 If anything reads `v.VirtualMachineConfig` between those two lines, it gets an empty config. I hit this with a goroutine that calls `Ping` on a timer to keep the VM fresh while another goroutine reads `Nets["net0"]`. Every so often the read came back empty, and the value got passed straight into a config update, which Proxmox rejected:
 
 ```
 400 Parameter verification failed.
 net0.model: property is missing and it is not optional
 ```
 
 The fix is to build the new config into a local and only assign it once it's fully populated, so a reader sees either the previous config or the complete new one:
 
 ```go
 cfg := &VirtualMachineConfig{}
 if err := v.client.Get(ctx, ".../config", cfg); err != nil {
     return err
 }
 v.VirtualMachineConfig = cfg
 ```