### PR TITLE
chore: enable gofmt + linters in golangci config, fix findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,30 @@
 version: "2"
 linters:
+  enable:
+    - bodyclose
+    - errchkjson
+    - errorlint
+    - gocritic
+    - gosec
+    - misspell
+    - nilerr
+    - noctx
+    - unconvert
+    - unparam
+  settings:
+    gosec:
+      excludes:
+        - G115 # integer conversions — VMID/size casts are bounded by PVE
+        - G304 # file inclusion via variable — client library opens caller-supplied paths by design
+  exclusions:
+    rules:
+      - path: (_test\.go|^tests/|^mage/)
+        linters:
+          - gosec
+          - noctx
 formatters:
+  enable:
+    - gofmt
 issues:
 output:
 run:

--- a/access_tfa.go
+++ b/access_tfa.go
@@ -15,13 +15,13 @@ import (
 // TFAUserEntry is one row in GET /access/tfa — a user that has at least one
 // TFA entry configured.
 type TFAUserEntry struct {
-	UserID  string         `json:"userid,omitempty"`
-	Entries []TFAEntryInfo `json:"entries,omitempty"`
-	TOTP    bool           `json:"totp,omitempty"`
-	YubicoOTP bool         `json:"yubico,omitempty"`
-	U2F     bool           `json:"u2f,omitempty"`
-	Webauthn bool          `json:"webauthn,omitempty"`
-	Recovery []int         `json:"recovery,omitempty"`
+	UserID    string         `json:"userid,omitempty"`
+	Entries   []TFAEntryInfo `json:"entries,omitempty"`
+	TOTP      bool           `json:"totp,omitempty"`
+	YubicoOTP bool           `json:"yubico,omitempty"`
+	U2F       bool           `json:"u2f,omitempty"`
+	Webauthn  bool           `json:"webauthn,omitempty"`
+	Recovery  []int          `json:"recovery,omitempty"`
 }
 
 // TFAEntryInfo is the read shape of a single TFA entry.

--- a/cluster.go
+++ b/cluster.go
@@ -149,7 +149,7 @@ func (cl *Cluster) Ceph(ctx context.Context) (*Ceph, error) {
 
 	// TODO?
 	//// requires (/, Sys.Audit), do not error out if no access to still get the ceph
-	//if err := ceph.Status(ctx); !IsNotAuthorized(err) {
+	// if err := ceph.Status(ctx); !IsNotAuthorized(err) {
 	//	return ceph, err
 	//}
 

--- a/cluster_sdn.go
+++ b/cluster_sdn.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 )
 
-func (cl *Cluster) SDNSubnets(ctx context.Context, VNetName string) (subnets []*VNetSubnet, err error) {
-	err = cl.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets", VNetName), &subnets)
+func (cl *Cluster) SDNSubnets(ctx context.Context, vnetName string) (subnets []*VNetSubnet, err error) {
+	err = cl.client.Get(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets", vnetName), &subnets)
 
 	return
 }

--- a/cluster_sdn_vnet_test.go
+++ b/cluster_sdn_vnet_test.go
@@ -162,10 +162,10 @@ func TestVNet_IPs_ErrorBranches(t *testing.T) {
 
 	// nil/empty options → validation errors
 	assert.Error(t, v.UpdateIP(context.Background(), nil))
-	assert.Error(t, v.UpdateIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"}))   // missing zone
+	assert.Error(t, v.UpdateIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"})) // missing zone
 	assert.Error(t, v.DeleteIP(context.Background(), nil))
-	assert.Error(t, v.DeleteIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"}))   // missing zone
-	assert.Error(t, v.CreateIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"}))   // missing zone
+	assert.Error(t, v.DeleteIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"})) // missing zone
+	assert.Error(t, v.CreateIP(context.Background(), &SDNVNetIPOptions{IP: "1.1.1.1"})) // missing zone
 
 	// DeleteIP with MAC populated to exercise the optional path
 	assert.Nil(t, v.DeleteIP(context.Background(), &SDNVNetIPOptions{Zone: "zone1", IP: "10.0.0.10", MAC: "aa:bb:cc:dd:ee:ff"}))

--- a/containers.go
+++ b/containers.go
@@ -583,4 +583,3 @@ func (c *Container) MigrationTunnelWebSocketPath(tunnel *ContainerMigrationTunne
 	}
 	return fmt.Sprintf("/nodes/%s/lxc/%d/mtunnelwebsocket?%s", c.Node, c.VMID, q.Encode())
 }
-

--- a/mage/endpoints/endpoints.go
+++ b/mage/endpoints/endpoints.go
@@ -56,9 +56,9 @@ const (
 // proves the wrapper exists in some non-scannable form. Removing an entry is
 // preferable when we add a real wrapper.
 var intentionallyExcluded = map[string]string{
-	"get /nodes/{}/qemu/{}/mtunnelwebsocket":           "URL-builder helper (MigrationTunnelWebSocketPath); caller drives the websocket dialer",
-	"get /nodes/{}/lxc/{}/mtunnelwebsocket":            "URL-builder helper (MigrationTunnelWebSocketPath); caller drives the websocket dialer",
-	"get /nodes/{}/storage/{}/file-restore/download":   "streaming binary download; needs custom io.Reader plumbing, not the JSON Get helper",
+	"get /nodes/{}/qemu/{}/mtunnelwebsocket":         "URL-builder helper (MigrationTunnelWebSocketPath); caller drives the websocket dialer",
+	"get /nodes/{}/lxc/{}/mtunnelwebsocket":          "URL-builder helper (MigrationTunnelWebSocketPath); caller drives the websocket dialer",
+	"get /nodes/{}/storage/{}/file-restore/download": "streaming binary download; needs custom io.Reader plumbing, not the JSON Get helper",
 }
 
 type methodInfo struct {
@@ -523,7 +523,7 @@ var (
 	// method `(*Storage).Upload(content, filename string)` whose first arg
 	// is a content-type, not a path. The `\w*` suffix catches both variants
 	// (and any future Upload* the library adds) without re-listing each.
-	uploadRE = regexp.MustCompile(`\bclient\.Upload\w*\s*\(\s*(.*?)$`)
+	uploadRE    = regexp.MustCompile(`\bclient\.Upload\w*\s*\(\s*(.*?)$`)
 	sprintfRE   = regexp.MustCompile(`fmt\.Sprintf\(\s*"([^"]+)"`)
 	urlAssignRE = regexp.MustCompile(`\b(\w+)\s*:?=\s*url\.URL\{\s*Path:\s*(.+)\}`)
 	// `<var> := fmt.Sprintf("/…", …)` or `<var> := "/…"` — bindings that later

--- a/nodes.go
+++ b/nodes.go
@@ -231,8 +231,8 @@ func (n *Node) Storage(ctx context.Context, name string) (storage *Storage, err 
 	return
 }
 
-func (n *Node) StorageDownloadURL(ctx context.Context, StorageDownloadURLOptions *StorageDownloadURLOptions) (ret string, err error) {
-	err = n.client.Post(ctx, fmt.Sprintf("/nodes/%s/storage/%s/download-url", n.Name, StorageDownloadURLOptions.Storage), StorageDownloadURLOptions, &ret)
+func (n *Node) StorageDownloadURL(ctx context.Context, options *StorageDownloadURLOptions) (ret string, err error) {
+	err = n.client.Post(ctx, fmt.Sprintf("/nodes/%s/storage/%s/download-url", n.Name, options.Storage), options, &ret)
 	return ret, err
 }
 

--- a/nodes_ceph_pool.go
+++ b/nodes_ceph_pool.go
@@ -145,7 +145,7 @@ func (p *CephPool) Status(ctx context.Context, verbose bool) (status *CephPoolSt
 	}
 	path := fmt.Sprintf("/nodes/%s/ceph/pool/%s/status", p.Node, p.PoolName)
 	if verbose {
-		path = path + "?verbose=1"
+		path += "?verbose=1"
 	}
 	return status, p.client.Get(ctx, path, &status)
 }

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -22,7 +22,7 @@ func TestClient_Nodes(t *testing.T) {
 		assert.Contains(t, n.Node, "node")
 		assert.Equal(t, n.Type, "node")
 	}
-	//assert.Equal(t, 6, len(testData))
+	// assert.Equal(t, 6, len(testData))
 }
 
 func TestClient_Node(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -45,11 +45,11 @@ func WithAPIToken(tokenID, secret string) Option {
 }
 
 // WithSession experimental
-func WithSession(ticket, CSRFPreventionToken string) Option {
+func WithSession(ticket, csrfPreventionToken string) Option {
 	return func(c *Client) {
 		c.session = &Session{
 			Ticket:              ticket,
-			CSRFPreventionToken: CSRFPreventionToken,
+			CSRFPreventionToken: csrfPreventionToken,
 		}
 	}
 }
@@ -275,7 +275,7 @@ func (c *Client) ensureTLSConfig() *tls.Config {
 		return nil
 	}
 	if t.TLSClientConfig == nil {
-		t.TLSClientConfig = &tls.Config{}
+		t.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 	}
 	return t.TLSClientConfig
 }

--- a/options_test.go
+++ b/options_test.go
@@ -439,11 +439,7 @@ func TestWithRequestInterceptor_RegistrationAppends(t *testing.T) {
 func TestWithRequestInterceptor_SingleSeesAuthHeader(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-
-	gock.New(config.C.URI).
-		Get("^/version$").
-		Reply(200).
-		JSON(`{"data":{"version":"9.0"}}`)
+	// Shared pve9x mock set already covers GET ^/version$.
 
 	var (
 		calls   int
@@ -481,11 +477,7 @@ func TestWithRequestInterceptor_SingleSeesAuthHeader(t *testing.T) {
 func TestWithRequestInterceptor_OrderPreserved(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-
-	gock.New(config.C.URI).
-		Get("^/version$").
-		Reply(200).
-		JSON(`{"data":{"version":"9.0"}}`)
+	// Shared pve9x mock set already covers GET ^/version$.
 
 	var order []string
 	first := func(*http.Request) error { order = append(order, "first"); return nil }

--- a/pools.go
+++ b/pools.go
@@ -45,12 +45,13 @@ func (c *Client) Pool(ctx context.Context, poolid string, filters ...string) (po
 		return nil, err
 	}
 
-	if len(pools) == 0 {
+	switch len(pools) {
+	case 0:
 		// This will not hit as the API will return a 500 error if the pool does not exist
 		return nil, fmt.Errorf("pool not found")
-	} else if len(pools) == 1 {
+	case 1:
 		pool = pools[0]
-	} else {
+	default:
 		// Should be impossible to have multiple pools with the same poolid
 		return nil, fmt.Errorf("multiple pools found for poolid: %s", poolid)
 	}

--- a/proxmox.go
+++ b/proxmox.go
@@ -78,7 +78,7 @@ func MakeTag(v string) string {
 //
 // PVE applies its own urlencoded-string validator that rejects '+' as a space
 // encoding and requires every reserved character to be percent-encoded — the
-// Python urllib.parse.quote(s, safe='') style. Go's net/url.QueryEscape emits
+// Python urllib.parse.quote(s, safe="") style. Go's net/url.QueryEscape emits
 // '+' for spaces (HTML form encoding), so its output alone fails validation
 // with "invalid format - invalid urlencoded string". See issue #144.
 //

--- a/proxmox.go
+++ b/proxmox.go
@@ -408,7 +408,9 @@ func (c *Client) UploadReader(path string, fields map[string]string, filename st
 		body,
 		bytes.NewReader(b.Bytes()[header:]))
 
-	req, err := http.NewRequest(http.MethodPost, path, multi)
+	// UploadReader predates context plumbing in the public API; a ctx
+	// parameter is queued for v0.8.0.
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, path, multi)
 	if err != nil {
 		return err
 	}
@@ -527,8 +529,12 @@ func (c *Client) TermWebSocket(path string, term *Term) (chan []byte, chan []byt
 	dialerHeaders := http.Header{}
 	c.authHeaders(&dialerHeaders)
 
-	conn, _, err := dialer.Dial(path, dialerHeaders)
-
+	conn, resp, err := dialer.Dial(path, dialerHeaders)
+	// On a successful upgrade gorilla replaces resp.Body with an empty
+	// NopCloser; on handshake failure the real body must be closed.
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -689,8 +695,12 @@ func (c *Client) VNCWebSocket(path string, vnc *VNC) (chan []byte, chan []byte, 
 	dialerHeaders := http.Header{}
 	c.authHeaders(&dialerHeaders)
 
-	conn, _, err := dialer.Dial(path, dialerHeaders)
-
+	conn, resp, err := dialer.Dial(path, dialerHeaders)
+	// On a successful upgrade gorilla replaces resp.Body with an empty
+	// NopCloser; on handshake failure the real body must be closed.
+	if resp != nil && resp.Body != nil {
+		defer func() { _ = resp.Body.Close() }()
+	}
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/proxmox_test.go
+++ b/proxmox_test.go
@@ -287,11 +287,10 @@ func TestClient_GetWithParams_BadData(t *testing.T) {
 func TestClient_DeleteWithParams(t *testing.T) {
 	mocks.On(mockConfig)
 	defer mocks.Off()
-	gock.New(TestURI).
-		Persist().
-		Delete("^/version$").
-		Reply(200).
-		JSON(`{"data":{"repoid":"r","release":"9.1","version":"9.1-1"}}`)
+	// The shared pve9x mock set already registers DELETE ^/version$ — no
+	// inline mock needed. Wire-param assertions belong in inline-only tests
+	// (no mocks.On), since the shared catch-all answers first regardless of
+	// any MatchParams on a subsequently-registered inline mock.
 
 	client := mockClient()
 	var v Version

--- a/retry.go
+++ b/retry.go
@@ -389,4 +389,3 @@ func contextSleep(ctx context.Context, d time.Duration) error {
 		return nil
 	}
 }
-

--- a/retry.go
+++ b/retry.go
@@ -47,7 +47,7 @@ func defaultRetryPolicy() *retryPolicy {
 		condition:      defaultRetryCondition,
 		now:            time.Now,
 		sleep:          contextSleep,
-		rand:           rand.New(rand.NewSource(time.Now().UnixNano())),
+		rand:           rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec // backoff jitter is not security-sensitive
 	}
 }
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -29,13 +29,12 @@ func fastNoopSleep(ctx context.Context, _ time.Duration) error {
 	return ctx.Err()
 }
 
-// newRetryClient builds a *Client configured with WithRetry plus any extra
-// options. It also installs the fastNoopSleep into the resulting policy so
-// tests don't actually wait the backoff window.
-func newRetryClient(t *testing.T, retryOpts []RetryOption, opts ...Option) *Client {
+// newRetryClient builds a *Client configured with WithRetry. It also installs
+// the fastNoopSleep into the resulting policy so tests don't actually wait the
+// backoff window.
+func newRetryClient(t *testing.T, retryOpts []RetryOption) *Client {
 	t.Helper()
-	allOpts := append([]Option{WithRetry(retryOpts...)}, opts...)
-	c := NewClient(retryTestURI, allOpts...)
+	c := NewClient(retryTestURI, WithRetry(retryOpts...))
 	rt, ok := c.httpClient.Transport.(*retryRoundTripper)
 	require.True(t, ok, "expected retryRoundTripper, got %T", c.httpClient.Transport)
 	rt.policy.sleep = fastNoopSleep

--- a/storage_content.go
+++ b/storage_content.go
@@ -92,11 +92,11 @@ func (s *Storage) OCIRegistryPull(ctx context.Context, reference, filename strin
 
 // StorageFileRestoreEntry is one row from GET /file-restore/list.
 type StorageFileRestoreEntry struct {
-	Filepath string `json:"filepath,omitempty"`
-	Type     string `json:"type,omitempty"` // "f" (file), "d" (directory), "l" (link)
-	Text     string `json:"text,omitempty"`
-	Size     uint64 `json:"size,omitempty"`
-	Mtime    int64  `json:"mtime,omitempty"`
+	Filepath string    `json:"filepath,omitempty"`
+	Type     string    `json:"type,omitempty"` // "f" (file), "d" (directory), "l" (link)
+	Text     string    `json:"text,omitempty"`
+	Size     uint64    `json:"size,omitempty"`
+	Mtime    int64     `json:"mtime,omitempty"`
 	Leaf     IntOrBool `json:"leaf,omitempty"`
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -133,7 +133,7 @@ func tasktail(ctx context.Context, start int, watch chan string, task *Task) err
 		for _, ln := range logs {
 			watch <- ln
 		}
-		start = start + len(logs)
+		start += len(logs)
 		time.Sleep(2 * time.Second)
 	}
 }

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -203,4 +203,3 @@ func TestTask_Watch_NoLogs(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no logs available")
 }
-

--- a/tests/integration/proxmox_test.go
+++ b/tests/integration/proxmox_test.go
@@ -42,10 +42,6 @@ var (
 			},
 		},
 	}
-
-	//tinycoreURL     = "https://github.com/luthermonson/go-proxmox/releases/download/tests/tinycore.iso"
-	//ubuntuURL       = "https://releases.ubuntu.com/20.04.3/ubuntu-20.04.3-desktop-amd64.iso"
-	//alpineAppliance = "http://download.proxmox.com/images/system/alpine-3.17-default_20221129_amd64.tar.xz"
 )
 
 func init() {
@@ -82,62 +78,6 @@ func init() {
 		panic(err)
 	}
 }
-
-//func nameGenerator(length int) string {
-//	rand.Seed(time.Now().UnixNano())
-//	b := make([]byte, length)
-//	rand.Read(b)
-//	rstr := fmt.Sprintf("%x", b)[:length]
-//	return fmt.Sprintf("go-proxmox-%s", rstr)
-//}
-
-//func downloadFile(src, dst string) error {
-//	out, err := os.Create(dst)
-//	if err != nil {
-//		return err
-//	}
-//	defer func() { _ = out.Close() }()
-//
-//	resp, err := http.Get(src)
-//	if err != nil {
-//		return err
-//	}
-//	defer func() { _ = resp.Body.Close() }()
-//
-//	_, err = io.Copy(out, resp.Body)
-//	if err != nil {
-//		return err
-//	}
-//
-//	return nil
-//}
-
-//func createTestISO(file string) error {
-//	//making iso
-//	blocksize := int64(2048)
-//	iso, err := os.OpenFile(file, os.O_CREATE|os.O_RDWR, os.FileMode(0700))
-//	if err != nil {
-//		return err
-//	}
-//	defer func() { _ = iso.Close() }()
-//
-//	// Wrap the *os.File in a backend.Storage
-//	backend := backendfile.New(iso, false)
-//	fs, err := iso9660.Create(backend, 0, 0, blocksize, "")
-//	if err != nil {
-//		return err
-//	}
-//
-//	err = fs.Mkdir("/")
-//	if err != nil {
-//		return err
-//	}
-//
-//	return fs.Finalize(iso9660.FinalizeOptions{
-//		RockRidge:        true,
-//		VolumeIdentifier: "cidata",
-//	})
-//}
 
 func ClientFromEnv() *proxmox.Client {
 	return proxmox.NewClient(os.Getenv("PROXMOX_URL"),

--- a/tests/mocks/capture/capture.go
+++ b/tests/mocks/capture/capture.go
@@ -5,6 +5,7 @@ package capture
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -54,7 +55,7 @@ func UploadMatcher() gock.MatchFunc {
 		mr := multipart.NewReader(bytes.NewReader(raw), params["boundary"])
 		for {
 			part, err := mr.NextPart()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			if err != nil {

--- a/types_test.go
+++ b/types_test.go
@@ -471,4 +471,3 @@ func TestStringOrInt(t *testing.T) {
 		assert.Equal(t, test.expected, unmarshall.Value)
 	}
 }
-


### PR DESCRIPTION
## Why

`.golangci.yaml` was an empty v2 skeleton, so CI's `golangci-lint run` only exercised the five default linters and **never checked formatting**. (gofmt has never been a default golangci linter, and v2 moved formatters into their own section.) That's how the struct-tag misalignment in `types.go` — and the formatting churn seen in #340 — went unnoticed.

## What

**Commit 1 — `chore: gofmt the codebase`**: pure `gofmt`, no behavior change. Bulk is the `types.go` struct-tag realignment plus semicolon-separated test closures. Kept separate so it doesn't drown the real changes.

**Commit 2 — config + fixes**: enable the gofmt formatter plus `bodyclose`, `errchkjson`, `errorlint`, `gocritic`, `gosec`, `misspell`, `nilerr`, `noctx`, `unconvert`, `unparam`, then fix the findings.

### Genuine bugs fixed
- **`proxmox.go`**: the websocket handshake `*http.Response` body was discarded in both `TermWebSocket` and `VNCWebSocket` — leaks on handshake failure. Now closed. Also `UploadReader` uses `NewRequestWithContext`.
- **`options.go`**: `tls.Config` now sets `MinVersion: TLS 1.2` instead of the library default (G402).
- **`capture.go`**: `errors.Is(err, io.EOF)` instead of `==`.

### Linter scope decisions
- `gosec` **G115** (bounded int conversions — VMID/size casts) and **G304** (caller-supplied file paths, expected in a client library) excluded.
- `gosec`/`noctx` exempted in `_test.go`, `tests/`, and `mage/`.

### Cleanup
- Removed dead inline `gock` mocks shadowed by the shared mock set: a matcher registered *after* `mocks.On` never runs, because the shared catch-all answers first. (This is the same trap that made a wire-param assertion in #340 decorative.)
- Removed a long-dead commented-out block in the integration test.
- Misc `gocritic` style fixes (`switch` over if-else chain, `+=`, comment spacing, unexported param names).

## Note on gofmt + `''`
gofmt (stock go1.25 and go1.26) rewrites two adjacent ASCII apostrophes `''` in a comment into a typographic `”`. One comment in `proxmox.go` referencing Python's `quote(s, safe='')` was reworded to `safe=""` (identical valid Python) to stay both correct and gofmt-clean. Worth knowing now that the formatter is enforced.

## Test plan
- [x] `gofmt -l .` clean
- [x] `golangci-lint run` → 0 issues
- [x] `go test .` passes
- [x] `go build ./...` clean