### PR TITLE
docs: add migration/v0.8.0.md

### DIFF
--- a/migration/v0.8.0.md
+++ b/migration/v0.8.0.md
@@ -1,0 +1,54 @@
+# Migrating to v0.8.0
+
+v0.8.0 adds optional delete parameters to `VirtualMachine.Delete`, aligning
+it with the existing `Container.Delete` pattern introduced in v0.6.0.
+
+## TL;DR
+
+One source-level break.
+
+| Change | Affected callers | Fix |
+|---|---|---|
+| `(*VirtualMachine).Delete` gains a second parameter `*VirtualMachineDeleteOptions` | every caller of `vm.Delete(ctx)` | pass `nil` for existing behaviour, or `&VirtualMachineDeleteOptions{...}` to use the new options |
+
+## VirtualMachine.Delete now accepts options
+
+```go
+// before
+task, err := vm.Delete(ctx)
+
+// after — nil preserves the old default behaviour
+task, err := vm.Delete(ctx, nil)
+
+// after — with options
+task, err := vm.Delete(ctx, &proxmox.VirtualMachineDeleteOptions{
+    Purge:                    true, // remove from jobs/replication/HA config
+    SkipLock:                 true, // override a protection lock
+    DestroyUnreferencedDisks: true, // wipe disks not referenced by any config
+})
+```
+
+The new `VirtualMachineDeleteOptions` struct maps directly to the optional
+query parameters accepted by `DELETE /nodes/{node}/qemu/{vmid}`:
+
+```go
+type VirtualMachineDeleteOptions struct {
+    SkipLock                 IntOrBool `json:"skiplock,omitempty"`
+    Purge                    IntOrBool `json:"purge,omitempty"`
+    DestroyUnreferencedDisks IntOrBool `json:"destroy-unreferenced-disks,omitempty"`
+}
+```
+
+Passing `nil` is equivalent to calling the pre-v0.8.0 `Delete(ctx)` — no
+optional parameters are sent and PVE applies its defaults.
+
+## Nothing else
+
+There are no other source-incompatible changes between v0.7.1 and v0.8.0.
+
+Also in this release:
+- `VirtualMachine.Ping` now correctly propagates config-fetch errors instead
+  of silently swallowing them (#339)
+- Golangci-lint config expanded to enforce gofmt and ten additional linters;
+  several minor findings fixed (TLS MinVersion, websocket response body close,
+  `errors.Is` in mock helpers)


### PR DESCRIPTION
Migration guide for v0.8.0. One source-level break: `VirtualMachine.Delete` gains a `*VirtualMachineDeleteOptions` second parameter (pass `nil` for existing behaviour). Follows the same pattern as `Container.Delete` from v0.6.0.

Also documents the Ping fix (#339) and lint infrastructure changes (#341).